### PR TITLE
Link to CLI doc page for containerd

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,7 @@ If you want to see the JSON output formatted nicely, just pipe it to jq:
 ./run.sh pytorch | jq
 ```
 
-[containerd]: https://docs.docker.com/desktop/containerd/
+[containerd]: https://docs.docker.com/storage/containerd/
 [docker]: https://docs.docker.com/engine/install/
 [git]: https://git-scm.com/downloads
 [jq]: https://jqlang.github.io/jq/download/


### PR DESCRIPTION
Following up on #5, this PR changes the containerd link in `CONTRIBUTING.md` to point to [the page for Docker Engine](https://docs.docker.com/storage/containerd/) instead of [the page for Docker Desktop](https://docs.docker.com/desktop/containerd/), because the former points to the latter but not vice versa.