### PR TITLE
Add `CONTRIBUTING.md` instructions to install QEMU

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,9 @@ Make sure to have these tools installed:
 - [Docker][]
 
 We build [multi-platform images][] to support both x86 and ARM chips, so to
-build those, you need to enable [containerd][] in Docker.
+build those, you need to enable [containerd][] in Docker. If you're running
+Docker Engine on Linux, without Docker Desktop, you also need to install
+[QEMU][].
 
 Other tools that are optional but useful:
 
@@ -52,3 +54,4 @@ If you want to see the JSON output formatted nicely, just pipe it to jq:
 [git]: https://git-scm.com/downloads
 [jq]: https://jqlang.github.io/jq/download/
 [multi-platform images]: https://docs.docker.com/build/building/multi-platform/
+[qemu]: https://docs.docker.com/build/building/multi-platform/#qemu-without-docker-desktop


### PR DESCRIPTION
This PR follows up on #5 by adding extra instructions necessary for running building multi-platform Docker images in headless Linux.