### PR TITLE
SciLean update: run AD benchmark in IO

### DIFF
--- a/tools/scilean/Main.lean
+++ b/tools/scilean/Main.lean
@@ -1,5 +1,6 @@
 import Lean
 import SciLean
+import Mathlib.Lean.CoreM
 
 open Lean
 open Except FromJson ToJson 
@@ -86,9 +87,14 @@ def benchAD : MetaM Unit := do
 
   IO.println s!"differentiating took {1e-6*(done-start).toFloat}ms\n\n{← ppExpr e}\n==>\n{← ppExpr e'}"
 
--- Right now I'm not sure how to run `MetaM Unit` inside `main : IO UInt32`
--- So we just call it in the file with `#eval`
-#eval benchAD
+def ranBenchAD : IO Unit := 
+  let run : CoreM Unit := do
+    let _ ← benchAD.run {} {}
+
+  -- Here you have to specify all the lean files that need to be loaded
+  CoreM.withImportModules #[`SciLean,`Main] run
+    (searchPath:= compile_time_search_path%)
+
 
 def resolve (name : String) : Except String (Float -> Float) :=
   match name with

--- a/tools/scilean/lakefile.lean
+++ b/tools/scilean/lakefile.lean
@@ -6,5 +6,6 @@ package «gradbench»
 @[default_target]
 lean_exe «gradbench» where
   root := `Main
+  supportInterpreter := true
 
 require scilean from git "https://github.com/lecopivo/SciLean.git" @ "22d53b2f4e3db2a172e71da6eb9c916e62655744"


### PR DESCRIPTION
You can now run `benchAD` function but calling `runBenchAD` in `main` function.