### PR TITLE
Label every Docker image with this repository URL

### DIFF
--- a/docker/mathlib4/Dockerfile
+++ b/docker/mathlib4/Dockerfile
@@ -8,3 +8,4 @@ COPY lake-manifest.json .
 COPY lean-toolchain .
 RUN lake exe cache get
 ENTRYPOINT ["jq", "-r", ".packages[] | select(.name == \"mathlib\") | .rev", "/home/gradbench/lake-manifest.json"]
+LABEL org.opencontainers.image.source https://github.com/gradbench/gradbench

--- a/tools/jax/Dockerfile
+++ b/tools/jax/Dockerfile
@@ -4,3 +4,4 @@ WORKDIR /home/gradbench
 COPY jax_functions.py .
 COPY jax_run.py .
 ENTRYPOINT ["python", "/home/gradbench/jax_run.py"]
+LABEL org.opencontainers.image.source https://github.com/gradbench/gradbench

--- a/tools/mygrad/Dockerfile
+++ b/tools/mygrad/Dockerfile
@@ -5,3 +5,4 @@ WORKDIR /home/gradbench
 COPY mg_functions.py .
 COPY mg_run.py .
 ENTRYPOINT ["python", "/home/gradbench/mg_run.py"]
+LABEL org.opencontainers.image.source https://github.com/gradbench/gradbench

--- a/tools/pytorch/Dockerfile
+++ b/tools/pytorch/Dockerfile
@@ -5,3 +5,4 @@ WORKDIR /home/gradbench
 COPY functions.py .
 COPY run.py .
 ENTRYPOINT ["python", "/home/gradbench/run.py"]
+LABEL org.opencontainers.image.source https://github.com/gradbench/gradbench

--- a/tools/scilean/Dockerfile
+++ b/tools/scilean/Dockerfile
@@ -4,3 +4,4 @@ COPY lake-manifest.json .
 COPY Main.lean .
 RUN lake build
 ENTRYPOINT ["/home/gradbench/.lake/build/bin/gradbench"]
+LABEL org.opencontainers.image.source https://github.com/gradbench/gradbench

--- a/tools/tapenade/Dockerfile
+++ b/tools/tapenade/Dockerfile
@@ -13,7 +13,7 @@ RUN wget https://tapenade.gitlabpages.inria.fr/tapenade/distrib/tapenade_3.16.ta
 RUN tar -xvzf tapenade_3.16.tar
 
 
-# ensure Tapenade is accessible 
+# ensure Tapenade is accessible
 RUN ln -s /home/gradbench/tapenade_3.16/bin/tapenade /usr/local/bin/tapenade
 
 COPY functions.c .
@@ -23,3 +23,4 @@ COPY run_shells.py .
 COPY tapenade_run.py .
 
 ENTRYPOINT ["python3", "/home/gradbench/tapenade_run.py"]
+LABEL org.opencontainers.image.source https://github.com/gradbench/gradbench

--- a/tools/tensorflow/Dockerfile
+++ b/tools/tensorflow/Dockerfile
@@ -1,8 +1,8 @@
 FROM python:3.11
 
 RUN apt-get update && apt-get install -y \
-build-essential \
-libhdf5-dev
+    build-essential \
+    libhdf5-dev
 RUN pip install h5py
 RUN pip install tensorflow
 
@@ -10,3 +10,4 @@ WORKDIR /home/gradbench
 COPY tensor_functions.py .
 COPY tensor_run.py .
 ENTRYPOINT ["python", "/home/gradbench/tensor_run.py"]
+LABEL org.opencontainers.image.source https://github.com/gradbench/gradbench

--- a/tools/zygote/Dockerfile
+++ b/tools/zygote/Dockerfile
@@ -5,3 +5,4 @@ COPY Manifest.toml .
 RUN julia --project=. -e 'import Pkg; Pkg.instantiate()'
 COPY run.jl .
 ENTRYPOINT ["julia", "--project=/home/gradbench", "/home/gradbench/run.jl"]
+LABEL org.opencontainers.image.source https://github.com/gradbench/gradbench


### PR DESCRIPTION
This PR adds a [`LABEL org.opencontainers.image.source`](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#labelling-container-images) line to each of our `Dockerfile`s, allowing GitHub to automatically detect that the resulting Docker images come from this repo. I believe that this should mean that the resulting GHCR packages should [automatically give access](https://docs.github.com/en/packages/learn-github-packages/about-permissions-for-github-packages#permissions-for-repository-scoped-packages) to @gradbench/team, which has maintain access to this repository.