### PR TITLE
Add `.DS_Store` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 __pycache__/
+.DS_Store
 .lake/
 *.vsix
 /target/


### PR DESCRIPTION
This PR adds `.DS_Store` to our `.gitignore` to make it easier to avoid accidentally committing it, e.g. in #23.