### PR TITLE
Allow non-Docker commands in `run.py`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,4 +105,4 @@ jobs:
           name: tool-${{ matrix.tool }}
       - run: docker load --input eval-${{ matrix.eval }}.tar
       - run: docker load --input tool-${{ matrix.tool }}.tar
-      - run: ./run.py --eval ${{ matrix.eval }} --tool ${{ matrix.tool }}
+      - run: ./run.py --eval './eval.sh ${{ matrix.eval }}' --tool './run.sh ${{ matrix.tool }}'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,10 +47,12 @@ Use `buildtool.sh` to build the Docker image for any tool:
 ./buildtool.sh pytorch
 ```
 
-Then use `run.py` to run a given evaluation on a given tool:
+Then use `run.py` to run a given evaluation on a given tool. You can use pass
+this script any commands for the evaluation and tool, but to use the Docker
+images, the easiest way is to use the provided `eval.sh` and `tool.sh` scripts:
 
 ```sh
-./run.py --eval hello --tool pytorch
+./run.py --eval './eval.sh hello' --tool './tool.sh pytorch'
 ```
 
 ### Multi-platform images

--- a/eval.sh
+++ b/eval.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -euo pipefail
+docker run --rm --interactive "ghcr.io/gradbench/eval-$1"

--- a/run.py
+++ b/run.py
@@ -1,14 +1,15 @@
 #!/usr/bin/env python3
 
 import argparse
+import shlex
 import subprocess
 import sys
 import time
 
 
-def docker(tag):
+def run(cmd):
     return subprocess.Popen(
-        ["docker", "run", "--rm", "--interactive", tag],
+        shlex.split(cmd),
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
         text=True,
@@ -21,8 +22,8 @@ def main():
     parser.add_argument("--tool", required=True)
     args = parser.parse_args()
 
-    server = docker(f"ghcr.io/gradbench/tool-{args.tool}")
-    client = docker(f"ghcr.io/gradbench/eval-{args.eval}")
+    server = run(args.tool)
+    client = run(args.eval)
 
     print("[")
     first = True

--- a/tool.sh
+++ b/tool.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -euo pipefail
+docker run --rm --interactive "ghcr.io/gradbench/tool-$1"


### PR DESCRIPTION
The `run.py` script added in #25 only supports running the GradBench Docker images. This PR changes it so it can take in arbitrary commands, using [`shlex.split`](https://docs.python.org/3/library/shlex.html#shlex.split) to split them:

```sh
./run.py --eval './eval.sh hello' --tool tools/scilean/.lake/build/bin/gradbench
```