### PR TITLE
Build nightly Docker images

### DIFF
--- a/.github/actions/space/action.yml
+++ b/.github/actions/space/action.yml
@@ -1,0 +1,10 @@
+name: Space
+runs:
+  using: composite
+  steps:
+    - uses: AdityaGarg8/remove-unwanted-software@v3
+      with:
+        remove-dotnet: "true"
+        remove-android: "true"
+        remove-haskell: "true"
+        remove-codeql: "true"

--- a/.github/matrix.py
+++ b/.github/matrix.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import json
+from datetime import datetime, timezone
 from pathlib import Path
 
 
@@ -14,6 +15,7 @@ def output(name, value):
 
 
 def main():
+    output("date", str(datetime.now(timezone.utc).date()))
     output("eval", ls("evals"))
     output("tool", ls("tools"))
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,13 +76,8 @@ jobs:
         tool: ${{ fromJSON(needs.matrix.outputs.tool) }}
     runs-on: ubuntu-22.04
     steps:
-      - uses: AdityaGarg8/remove-unwanted-software@v3
-        with:
-          remove-dotnet: "true"
-          remove-android: "true"
-          remove-haskell: "true"
-          remove-codeql: "true"
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/space
       - uses: ./.github/actions/docker
       - run: ./crosstool.sh ${{ matrix.tool }}
       - run: docker save --output tool-${{ matrix.tool }}.tar ghcr.io/gradbench/tool-${{ matrix.tool }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,60 @@
+name: Nightly
+on:
+  schedule:
+    # run daily at 1am UTC, just so nobody thinks it's yesterday or tomorrow
+    - cron: "0 1 * * *"
+
+jobs:
+  matrix:
+    runs-on: ubuntu-22.04
+    outputs:
+      date: ${{ steps.matrix.outputs.date }}
+      eval: ${{ steps.matrix.outputs.eval }}
+      tool: ${{ steps.matrix.outputs.tool }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: matrix
+        run: .github/matrix.py | tee -a "$GITHUB_OUTPUT"
+
+  eval:
+    needs: matrix
+    strategy:
+      matrix:
+        eval: ${{ fromJSON(needs.matrix.outputs.eval) }}
+    runs-on: ubuntu-22.04
+    env:
+      IMAGE: ghcr.io/gradbench/eval-${{ matrix.eval }}
+      TAG: ${{ fromJSON(needs.matrix.outputs.date) }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/docker
+      - run: ./crosseval.sh ${{ matrix.eval }}
+      - run: docker image tag $IMAGE $IMAGE:$TAG
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - run: docker push $IMAGE:$TAG
+
+  tool:
+    needs: matrix
+    strategy:
+      matrix:
+        tool: ${{ fromJSON(needs.matrix.outputs.tool) }}
+    runs-on: ubuntu-22.04
+    env:
+      IMAGE: ghcr.io/gradbench/tool-${{ matrix.tool }}
+      TAG: ${{ fromJSON(needs.matrix.outputs.date) }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/space
+      - uses: ./.github/actions/docker
+      - run: ./crosstool.sh ${{ matrix.tool }}
+      - run: docker image tag $IMAGE $IMAGE:$TAG
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - run: docker push $IMAGE:$TAG

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -3,6 +3,7 @@ on:
   schedule:
     # run daily at 1am UTC, just so nobody thinks it's yesterday or tomorrow
     - cron: "0 1 * * *"
+  workflow_dispatch:
 
 jobs:
   matrix:


### PR DESCRIPTION
This PR adds a new "Nightly" workflow in GitHub Actions that builds all our Docker images every day at 1am UTC (9pm Eastern). It's a bit difficult to test CI/CD stuff like this without merging, so I'm gonna merge this and test it via [`workflow_dispatch`](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch).