### PR TITLE
Mark the nightly images as `latest`

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -30,13 +30,13 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/docker
       - run: ./crosseval.sh ${{ matrix.eval }}
-      - run: docker image tag $IMAGE $IMAGE:$TAG
+      - run: docker tag $IMAGE $IMAGE:$TAG
       - uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - run: docker push $IMAGE:$TAG
+      - run: docker push --all-tags $IMAGE
 
   tool:
     needs: matrix
@@ -52,10 +52,10 @@ jobs:
       - uses: ./.github/actions/space
       - uses: ./.github/actions/docker
       - run: ./crosstool.sh ${{ matrix.tool }}
-      - run: docker image tag $IMAGE $IMAGE:$TAG
+      - run: docker tag $IMAGE $IMAGE:$TAG
       - uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - run: docker push $IMAGE:$TAG
+      - run: docker push --all-tags $IMAGE

--- a/manual.sh
+++ b/manual.sh
@@ -2,5 +2,5 @@
 set -euo pipefail
 docker build --platform linux/amd64,linux/arm64 "docker/$1" --tag "ghcr.io/gradbench/$1"
 tag=$(docker run --rm "ghcr.io/gradbench/$1")
-docker image tag "ghcr.io/gradbench/$1" "ghcr.io/gradbench/$1:$tag"
+docker tag "ghcr.io/gradbench/$1" "ghcr.io/gradbench/$1:$tag"
 docker push "ghcr.io/gradbench/$1:$tag"


### PR DESCRIPTION
Following up on #38, this PR makes our nightly builds use the [`--all-tags`](https://docs.docker.com/reference/cli/docker/image/push/#all-tags) option so that they push to the `latest` tag instead of just the tag for the current date. That will allow users to automatically build the Docker images via our `run.py` script.