### PR TITLE
Give nightly usage in the `README`

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,27 @@
 
 Benchmark for differentiable programming across languages and domains.
 
+## Usage
+
+If you have [Git][] installed, you can clone this repository; for instance, via
+the [GitHub CLI][]:
+
+```sh
+gh repo clone gradbench/gradbench
+cd gradbench
+```
+
+Then if you have [Python][] and [Docker][] installed, you can run any of our
+[evals](evals) against any of our [tools](tools) via our `run.py` script:
+
+```sh
+./run.py --eval './eval.sh hello' --tool './tool.sh pytorch'
+```
+
+This will first automatically download our latest nightly Docker images for the
+given eval and tool, and then run the eval against the tool while printing the
+entire communication log to the terminal.
+
 ## Contributing
 
 See [`CONTRIBUTING.md`](CONTRIBUTING.md).
@@ -9,3 +30,8 @@ See [`CONTRIBUTING.md`](CONTRIBUTING.md).
 ## License
 
 GradBench is licensed under the [MIT License](LICENSE).
+
+[docker]: https://docs.docker.com/engine/install/
+[git]: https://git-scm.com/downloads
+[github cli]: https://github.com/cli/cli#installation
+[python]: https://www.python.org/downloads/


### PR DESCRIPTION
Following up on #39, this PR adds instructions in `README.md` for people to run our nightly Docker images without building them.

In future, we should make it possible to run GradBench without cloning this repo at all.