### PR TITLE
Adding Wrapper to Python Tools

### DIFF
--- a/tools/autograd/Dockerfile
+++ b/tools/autograd/Dockerfile
@@ -1,9 +1,11 @@
 FROM python:3.11-slim
 WORKDIR /home/gradbench
+
 RUN pip install numpy==1.26.0
 RUN pip install autograd
 
 COPY tools/autograd/ .
+COPY shared/wrap_module.py .
 
 ENTRYPOINT ["python", "/home/gradbench/run.py"]
 LABEL org.opencontainers.image.source https://github.com/gradbench/gradbench

--- a/tools/autograd/gradbench.py
+++ b/tools/autograd/gradbench.py
@@ -1,10 +1,13 @@
 from autograd import grad
+from wrap_module import wrap
 
 
+@wrap(lambda x: x * 1.0, lambda x: x)
 def square(x):
     return x * x
 
 
+@wrap(lambda x: x * 1.0, lambda x: x)
 def double(x):
     y = grad(square)
     return y(x)

--- a/tools/autograd/run.py
+++ b/tools/autograd/run.py
@@ -11,7 +11,7 @@ def resolve(module, name):
 
 def run(params):
     func = resolve(params["module"], params["name"])
-    arg = params["input"] * 1.0
+    arg = params["input"]
     start = time.perf_counter_ns()
     ret = func(arg)
     end = time.perf_counter_ns()

--- a/tools/autograd/run.py
+++ b/tools/autograd/run.py
@@ -11,11 +11,11 @@ def resolve(module, name):
 
 def run(params):
     func = resolve(params["module"], params["name"])
-    arg = params["input"]
+    input = func.prepare(params["input"])
     start = time.perf_counter_ns()
-    ret = func(arg)
+    ret = func(input)
     end = time.perf_counter_ns()
-    return {"output": ret, "nanoseconds": {"evaluate": end - start}}
+    return {"output": func.unwrap(ret), "nanoseconds": {"evaluate": end - start}}
 
 
 def main():

--- a/tools/jax/Dockerfile
+++ b/tools/jax/Dockerfile
@@ -1,6 +1,11 @@
 FROM python:3.11-slim
+
 RUN pip install jax jaxlib
+
 WORKDIR /home/gradbench
+
 COPY tools/jax/ .
+COPY shared/wrap_module.py .
+
 ENTRYPOINT ["python", "/home/gradbench/run.py"]
 LABEL org.opencontainers.image.source https://github.com/gradbench/gradbench

--- a/tools/jax/gradbench.py
+++ b/tools/jax/gradbench.py
@@ -1,10 +1,16 @@
 from jax import grad
+import jax.numpy as jnp
+from wrap_module import wrap
+
+def to_tensor(x):
+    return jnp.array(x, dtype=jnp.float32)
 
 
+@wrap(to_tensor, lambda x: x.item())
 def square(x):
     return x * x
 
-
+@wrap(to_tensor, lambda x: x.item())
 def double(x):
     gradient = grad(square)
     return gradient(x)

--- a/tools/jax/run.py
+++ b/tools/jax/run.py
@@ -3,31 +3,19 @@ import sys
 import time
 from importlib import import_module
 
-import jax.numpy as jnp
-
-# from jax import grad, jit
-
 
 def resolve(module, name):
     functions = import_module(module)
     return getattr(functions, name)
 
 
-def tensor(x):
-    return jnp.array(x, dtype=jnp.float32)
-
-
 def run(params):
     func = resolve(params["module"], params["name"])
-    arg = tensor(params["input"])
-
-    # jfunc = jit(func)
-
+    input = func.prepare(params["input"])
     start = time.perf_counter_ns()
-    ret = func(arg)
+    ret = func(input)
     end = time.perf_counter_ns()
-
-    return {"output": ret.item(), "nanoseconds": {"evaluate": end - start}}
+    return {"output": func.unwrap(ret), "nanoseconds": {"evaluate": end - start}}
 
 
 def main():

--- a/tools/mygrad/Dockerfile
+++ b/tools/mygrad/Dockerfile
@@ -4,6 +4,7 @@ RUN pip install mygrad
 WORKDIR /home/gradbench
 
 COPY tools/mygrad/ .
+COPY shared/wrap_module.py .
 
 ENTRYPOINT ["python", "/home/gradbench/run.py"]
 LABEL org.opencontainers.image.source https://github.com/gradbench/gradbench

--- a/tools/mygrad/gradbench.py
+++ b/tools/mygrad/gradbench.py
@@ -1,10 +1,15 @@
 import numpy as np
+from mygrad import tensor as mg_tensor
+from wrap_module import wrap
 
+def to_tensor(x):
+    return mg_tensor(x, dtype=np.float64)
 
+@wrap(to_tensor, lambda x: x.item())
 def square(x):
     return x * x
 
-
+@wrap(to_tensor, lambda x: x.item())
 def double(x):
     y = square(x)
     y.backward()

--- a/tools/mygrad/run.py
+++ b/tools/mygrad/run.py
@@ -3,26 +3,19 @@ import sys
 import time
 from importlib import import_module
 
-import numpy as np
-from mygrad import tensor as mg_tensor
-
 
 def resolve(module, name):
     functions = import_module(module)
     return getattr(functions, name)
 
 
-def tensor(x):
-    return mg_tensor(x, dtype=np.float64)
-
-
 def run(params):
     func = resolve(params["module"], params["name"])
-    vals = tensor(params["input"])
+    input = func.prepare(params["input"])
     start = time.perf_counter_ns()
-    ret = func(vals)
+    ret = func(input)
     end = time.perf_counter_ns()
-    return {"output": ret.item(), "nanoseconds": {"evaluate": end - start}}
+    return {"output": func.unwrap(ret), "nanoseconds": {"evaluate": end - start}}
 
 
 def main():

--- a/tools/tapenade/run.py
+++ b/tools/tapenade/run.py
@@ -3,6 +3,8 @@ import sys
 import time
 from importlib import import_module
 
+# NOTE: The current implementation for Tapenade only supports passing in individual scalar inputs.
+
 
 def resolve(module, name):
     functions = import_module(module)

--- a/tools/tensorflow/Dockerfile
+++ b/tools/tensorflow/Dockerfile
@@ -9,6 +9,7 @@ RUN pip install tensorflow
 WORKDIR /home/gradbench
 
 COPY tools/tensorflow/ .
+COPY shared/wrap_module.py .
 
 ENTRYPOINT ["python", "/home/gradbench/run.py"]
 LABEL org.opencontainers.image.source https://github.com/gradbench/gradbench

--- a/tools/tensorflow/gradbench.py
+++ b/tools/tensorflow/gradbench.py
@@ -1,10 +1,14 @@
 import tensorflow as tf
+from wrap_module import wrap
 
+def to_tensor(x):
+    return tf.Variable(x, dtype=tf.float64)
 
+@wrap(to_tensor, lambda x: x.numpy())
 def square(x):
     return x * x
 
-
+@wrap(to_tensor, lambda x: x.numpy())
 def double(x):
     with tf.GradientTape() as tape:
         tape.watch(x)

--- a/tools/tensorflow/run.py
+++ b/tools/tensorflow/run.py
@@ -3,26 +3,19 @@ import sys
 import time
 from importlib import import_module
 
-import tensorflow as tf
-
 
 def resolve(module, name):
     functions = import_module(module)
     return getattr(functions, name)
 
 
-def tensor(x):
-    return tf.Variable(x, dtype=tf.float64)
-
-
 def run(params):
     func = resolve(params["module"], params["name"])
-    arg = tensor(params["input"])
+    input = func.prepare(params["input"])
     start = time.perf_counter_ns()
-    ret = func(arg)
+    ret = func(input)
     end = time.perf_counter_ns()
-
-    return {"output": ret.numpy(), "nanoseconds": {"evaluate": end - start}}
+    return {"output": func.unwrap(ret), "nanoseconds": {"evaluate": end - start}}
 
 
 def main():


### PR DESCRIPTION
Updating Autograd, Jax, MyGrad, and TensorFlow with the wrapper function originally written for PyTorch. This wrapper is a [decorator](https://stackoverflow.com/questions/739654/how-do-i-make-function-decorators-and-chain-them-together) that has similar functionality to those for SciLean and DiffSharp.

Autograd inputs and outputs do not really require adjustment. Currently I have a lambda function multiplying by 1.0 to ensure floats. This is not strictly necessary.

Tapenade is written in a combination of Python and C but inputs don't need to be changed. Inputs are simply converted to strings (and multiplied by 1.0 to ensure they are floats) when sent to C files and converted back to floats to be returned in JSON. A wrapper could be implemented here but it is not needed.

Similarly Zygote appears to not need a wrapper.