### PR TITLE
Use `disjoint_sets::ElementType` for index types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,7 @@ dependencies = [
  "ariadne",
  "clap",
  "dirs",
+ "disjoint-sets",
  "enumset",
  "goldenfile",
  "indexmap",
@@ -218,6 +219,12 @@ dependencies = [
  "redox_users",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "disjoint-sets"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ccbbca7d6a247007ca2535c616d4bb4a5fcad176ef0218671f96b88c52c3d34"
 
 [[package]]
 name = "either"

--- a/crates/adroit/Cargo.toml
+++ b/crates/adroit/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 ariadne = "0.4"
 clap = { version = "4", features = ["cargo", "derive"] }
 dirs = "5"
+disjoint-sets = "0.4"
 enumset = "1"
 indexmap = "2"
 itertools = "0.13"

--- a/crates/adroit/src/parse.rs
+++ b/crates/adroit/src/parse.rs
@@ -1,3 +1,4 @@
+use disjoint_sets::ElementType;
 use enumset::EnumSet;
 use serde::Serialize;
 
@@ -16,9 +17,16 @@ pub struct TypeId {
     pub index: u32,
 }
 
-impl From<TypeId> for usize {
-    fn from(id: TypeId) -> Self {
-        u32_to_usize(id.index)
+impl ElementType for TypeId {
+    fn from_usize(n: usize) -> Option<Self> {
+        match n.try_into() {
+            Ok(index) => Some(Self { index }),
+            Err(_) => None,
+        }
+    }
+
+    fn to_usize(self) -> usize {
+        u32_to_usize(self.index)
     }
 }
 
@@ -28,9 +36,16 @@ pub struct ParamId {
     pub index: u32,
 }
 
-impl From<ParamId> for usize {
-    fn from(id: ParamId) -> Self {
-        u32_to_usize(id.index)
+impl ElementType for ParamId {
+    fn from_usize(n: usize) -> Option<Self> {
+        match n.try_into() {
+            Ok(index) => Some(Self { index }),
+            Err(_) => None,
+        }
+    }
+
+    fn to_usize(self) -> usize {
+        u32_to_usize(self.index)
     }
 }
 
@@ -40,9 +55,16 @@ pub struct ExprId {
     pub index: u32,
 }
 
-impl From<ExprId> for usize {
-    fn from(id: ExprId) -> Self {
-        u32_to_usize(id.index)
+impl ElementType for ExprId {
+    fn from_usize(n: usize) -> Option<Self> {
+        match n.try_into() {
+            Ok(index) => Some(Self { index }),
+            Err(_) => None,
+        }
+    }
+
+    fn to_usize(self) -> usize {
+        u32_to_usize(self.index)
     }
 }
 
@@ -52,9 +74,16 @@ pub struct DefId {
     pub index: u32,
 }
 
-impl From<DefId> for usize {
-    fn from(id: DefId) -> Self {
-        u32_to_usize(id.index)
+impl ElementType for DefId {
+    fn from_usize(n: usize) -> Option<Self> {
+        match n.try_into() {
+            Ok(index) => Some(Self { index }),
+            Err(_) => None,
+        }
+    }
+
+    fn to_usize(self) -> usize {
+        u32_to_usize(self.index)
     }
 }
 
@@ -218,51 +247,34 @@ pub struct Module {
 
 impl Module {
     fn make_ty(&mut self, ty: Type) -> TypeId {
-        let id = TypeId {
-            index: self
-                .types
-                .len()
-                .try_into()
-                .expect("tokens should outnumber types"),
-        };
+        let id = TypeId::from_usize(self.types.len()).expect("tokens should outnumber types");
         self.types.push(ty);
         id
     }
 
     fn make_param(&mut self, param: Param) -> ParamId {
-        let id = ParamId {
-            index: self
-                .params
-                .len()
-                .try_into()
-                .expect("tokens should outnumber parameters"),
-        };
+        let id =
+            ParamId::from_usize(self.params.len()).expect("tokens should outnumber parameters");
         self.params.push(param);
         id
     }
 
     fn make_expr(&mut self, expr: Expr) -> ExprId {
-        let id = ExprId {
-            index: self
-                .exprs
-                .len()
-                .try_into()
-                .expect("tokens should outnumber expressions"),
-        };
+        let id = ExprId::from_usize(self.exprs.len()).expect("tokens should outnumber expressions");
         self.exprs.push(expr);
         id
     }
 
     pub fn ty(&self, id: TypeId) -> Type {
-        self.types[usize::from(id)]
+        self.types[id.to_usize()]
     }
 
     pub fn param(&self, id: ParamId) -> Param {
-        self.params[usize::from(id)]
+        self.params[id.to_usize()]
     }
 
     pub fn expr(&self, id: ExprId) -> Expr {
-        self.exprs[usize::from(id)]
+        self.exprs[id.to_usize()]
     }
 
     pub fn imports(&self) -> &[Import] {
@@ -349,7 +361,7 @@ impl<'a> Parser<'a> {
     }
 
     fn after_close(&self) -> TokenId {
-        let mut after = self.brackets[usize::from(self.id)];
+        let mut after = self.brackets[self.id.to_usize()];
         assert!(after.index > self.id.index);
         after.index += 1; // this function does not automatically ignore whitespace
         after
@@ -887,8 +899,8 @@ fn brackets(tokens: &Tokens) -> Result<Vec<TokenId>, ParseError> {
                         kinds: EnumSet::only(expected),
                     });
                 }
-                brackets[usize::from(open)] = id;
-                brackets[usize::from(id)] = open;
+                brackets[open.to_usize()] = id;
+                brackets[id.to_usize()] = open;
             }
             _ => {}
         }

--- a/crates/adroit/src/util.rs
+++ b/crates/adroit/src/util.rs
@@ -4,6 +4,7 @@ use std::{
 };
 
 use ariadne::{Color, Label, Report, ReportKind, Source};
+use disjoint_sets::ElementType;
 use indexmap::IndexMap;
 use serde::{ser::SerializeSeq, Serialize, Serializer};
 
@@ -55,9 +56,13 @@ pub struct ModuleId {
     pub index: usize, // just for convenience for now; can definitely choose a smaller type
 }
 
-impl From<ModuleId> for usize {
-    fn from(id: ModuleId) -> Self {
-        id.index
+impl ElementType for ModuleId {
+    fn from_usize(n: usize) -> Option<Self> {
+        Some(Self { index: n })
+    }
+
+    fn to_usize(self) -> usize {
+        self.index
     }
 }
 
@@ -83,7 +88,7 @@ impl Modules {
     }
 
     pub fn get(&self, id: ModuleId) -> &FullModule {
-        &self.modules[usize::from(id)]
+        &self.modules[id.to_usize()]
     }
 }
 
@@ -419,7 +424,7 @@ impl Printer<'_> {
             Untyped => write!(w, "?")?,
             Var { src, def } => {
                 let full = match src {
-                    Some(id) => self.modules.get(self.full.imports[usize::from(id)]),
+                    Some(id) => self.modules.get(self.full.imports[id.to_usize()]),
                     None => self.full,
                 };
                 write!(w, "{}", &full.source[full.tokens.get(def).byte_range()])?;


### PR DESCRIPTION
Currently we do `impl From<T> for usize` on every index type, call that via `usize::from`, and use `try_into()` along with direct construction syntax to convert from `usize` to an index type. This PR replaces all that with [`disjoint_sets::ElementType`](https://docs.rs/disjoint-sets/0.4.2/disjoint_sets/trait.ElementType.html), since we're about to start using the disjoint-sets crate anyway for type inference. Specifically, we need a Rust implementation of [union-find](https://en.wikipedia.org/wiki/Disjoint-set_data_structure) so we can do [unification](https://en.wikipedia.org/wiki/Unification_(computer_science)), and disjoint-sets is the best I could find out of the several existing crates:

- [aph_disjoint_set](https://crates.io/crates/aph_disjoint_set)
	- 0 GitLab stars
	- lots of different structs for different element sizes
	- implementation uses lots of macros, hard to understand data layout at a glance
- [cozad-union-find](https://crates.io/crates/cozad-union-find)
	- 2 GitHub stars
	- uses a `HashMap`
- [disjoint](https://crates.io/crates/disjoint)
	- 2 GitHub stars
	- has a `DisjointSetVec` type to track associated data
	- has an `add_singleton` method to grow the collection
	- uses `Cell` for non-thread-safe interior mutability for `root_of`
	- stores each parent as `usize`
	- stores each rank as a `u8`
	- does path splitting
- [disjoint-hash-set](https://crates.io/crates/disjoint-hash-set)
	- 0 GitHub stars
	- uses a `HashMap`
- [disjoint-set](https://crates.io/crates/disjoint-set)
	- 1 GitHub star
	- uses a `HashMap`
- [disjoint-sets](https://crates.io/crates/disjoint-sets)
	- 15 GitHub stars (well, 16 now that I've starred it)
	- three different implementations
	- `UnionFind` is the non-concurrent one that doesn't store other data
	- has an `alloc` method to grow the collection
	- stores each parent as any type implementing `ElementType`
	- stores each rank as a `u8`
	- does path splitting I think, but the docs say "rank-balanced path halving"
- [dsu-tree](https://crates.io/crates/dsu-tree)
	- 9 GitHub stars
	- uses `Rc`
- [palau-rs](https://crates.io/crates/pulau-rs)
	- 8 GitHub stars
	- says it's allocation-free for bare metal environments
	- seems complicated
- [partitions](https://crates.io/crates/partitions)
	- 9 GitHub stars
	- supports iteration over elements within a partition
	- everything is a `Cell`
	- stores each parent as a `usize`
	- stores each rank also as a `usize`
	- and stores a `link` to another index for iteration, also as a `usize`
	- does recursive path compression
- [petgraph](https://crates.io/crates/petgraph)
	- 2.8k GitHub stars
	- non-concurrent but also no interior mutability
	- doesn't support growing the collection
- [range_union_find](https://crates.io/crates/range_union_find)
	- 2 GitHub stars
	- seems focused on contiguous integer ranges
- [reunion](https://crates.io/crates/reunion)
	- 3 GitHub stars
	- uses a `HashMap`
- [unifier_set](https://crates.io/crates/unifier_set)
	- 0 GitHub stars
	- uses [rpds](https://crates.io/crates/rpds)
- [union-find](https://crates.io/crates/union-find)
	- 17 GitHub stars
	- has several different structs
	-  seems to store parent as a `usize`

If we later decide that this is too tight of a coupling, we can just write our own trait that looks identical to `ElementType`, and make a generic implementation of `disjoint_sets::ElementType` that covers all instances of our own trait.