### PR TITLE
Update Adroit performance claim on website

### DIFF
--- a/packages/gradbench/src/App.tsx
+++ b/packages/gradbench/src/App.tsx
@@ -189,10 +189,10 @@ const App = () => {
               Dex
             </a>
             . The Adroit compiler is <span className="bold">fast</span>: it can
-            lex, parse, and typecheck over a million lines of code per second,
-            causing little overhead as an initial preprocessing step before
-            passing typed IR as JSON to another tool to perform automatic
-            differentiation.
+            lex, parse, and typecheck over 350k lines of code per second using
+            one core on a modern laptop, causing little overhead as an initial
+            preprocessing step before passing typed IR as JSON to another tool
+            to perform automatic differentiation.
           </div>
         </div>
       </div>


### PR DESCRIPTION
Unfortunately #58 made the typechecker slower, so this PR accordingly updates the claim we originally made in #47.