### PR TITLE
Speed up typechecker by doing less hashing

### DIFF
--- a/packages/gradbench/src/App.tsx
+++ b/packages/gradbench/src/App.tsx
@@ -189,7 +189,7 @@ const App = () => {
               Dex
             </a>
             . The Adroit compiler is <span className="bold">fast</span>: it can
-            lex, parse, and typecheck over 350k lines of code per second using
+            lex, parse, and typecheck over 450k lines of code per second using
             one core on a modern laptop, causing little overhead as an initial
             preprocessing step before passing typed IR as JSON to another tool
             to perform automatic differentiation.


### PR DESCRIPTION
This PR follows up on #58 and #60 by using [`cargo-flamegraph`](https://github.com/flamegraph-rs/flamegraph) to see an `IndexSet<Val>` that should just be a `Vec<Val>`.