### PR TITLE
Add `perf` subcommand to benchmark Adroit compiler

### DIFF
--- a/crates/adroit/src/main.rs
+++ b/crates/adroit/src/main.rs
@@ -6,7 +6,7 @@ mod range;
 mod typecheck;
 mod util;
 
-use std::{fs, io, path::PathBuf, process::ExitCode};
+use std::{fs, io, path::PathBuf, process::ExitCode, time::Instant};
 
 use clap::{Parser, Subcommand};
 use serde::Serialize;
@@ -43,6 +43,124 @@ fn entrypoint(path: PathBuf) -> Result<Graph, (compile::Modules, Box<compile::Er
     Ok(Graph { modules, module })
 }
 
+fn perf(n: usize, path: PathBuf) -> Result<(), (compile::Modules, Box<compile::Error>)> {
+    let mut modules = compile::Modules::new();
+    let (path, source) = match read(path) {
+        Ok(ok) => ok,
+        Err(err) => return Err((modules, err)),
+    };
+
+    let mut i = 1;
+    let lexing = Instant::now();
+    let tokens = loop {
+        match lex::lex(&source) {
+            Ok(tokens) => {
+                if i < n {
+                    i += 1;
+                } else {
+                    break tokens;
+                }
+            }
+            Err(err) => return Err((modules, Box::new(compile::Error::Lex { path, source, err }))),
+        }
+    };
+    let lexed = lexing.elapsed().as_secs_f64();
+
+    let mut i = 1;
+    let parsing = Instant::now();
+    let tree = loop {
+        match parse::parse(&tokens) {
+            Ok(tree) => {
+                if i < n {
+                    i += 1;
+                } else {
+                    break tree;
+                }
+            }
+            Err(err) => {
+                return Err((
+                    modules,
+                    Box::new(compile::Error::Parse {
+                        path,
+                        source,
+                        tokens,
+                        err,
+                    }),
+                ))
+            }
+        }
+    };
+    let parsed = parsing.elapsed().as_secs_f64();
+
+    let mut imports = vec![];
+    for node in tree.imports().iter() {
+        let token = node.module;
+        match compile::import(&mut modules, &path, &tokens.get(token).string(&source)) {
+            Ok(id) => imports.push(id),
+            Err(err) => {
+                return Err((
+                    modules,
+                    Box::new(compile::Error::Import {
+                        path,
+                        source,
+                        tokens,
+                        token,
+                        err,
+                    }),
+                ))
+            }
+        }
+    }
+
+    let typing = Instant::now();
+    for _ in 1..=n {
+        let (module, errs) = typecheck::typecheck(
+            &source,
+            &tokens,
+            &tree,
+            imports.iter().map(|&id| &modules.get(id).module).collect(),
+        );
+        if !errs.is_empty() {
+            let full = compile::FullModule {
+                source,
+                tokens,
+                tree,
+                imports,
+                module,
+            };
+            return Err((
+                modules,
+                Box::new(compile::Error::Type {
+                    path,
+                    full: Box::new(full),
+                    errs,
+                }),
+            ));
+        }
+    }
+    let typed = typing.elapsed().as_secs_f64();
+
+    let lines = source.lines().count();
+    let total = lexed + parsed + typed;
+    let integer = [lexed, parsed, typed, total]
+        .iter()
+        .map(|&x| x.floor().to_string().len())
+        .max()
+        .unwrap();
+    let fractional = 3;
+    let width = integer + 1 + fractional;
+    let loc_per_sec = (n * lines) as f64 / total;
+    println!("{n} × lex       = {lexed:>width$.fractional$} seconds",);
+    println!("{n} × parse     = {parsed:>width$.fractional$} seconds",);
+    println!("{n} × typecheck = {typed:>width$.fractional$} seconds",);
+    println!("{n} × total     = {total:>width$.fractional$} seconds");
+    println!();
+    println!("{} is {lines} lines", path.display());
+    println!("lines of code per second: {}", loc_per_sec.floor());
+
+    Ok(())
+}
+
 #[derive(Debug, Parser)]
 struct Cli {
     #[command(subcommand)]
@@ -56,6 +174,15 @@ enum Commands {
 
     /// Print the typed IR of a module as JSON
     Json { file: PathBuf },
+
+    /// Print compiler performance info for a module
+    Perf {
+        /// Number of times to process the module
+        #[arg(short)]
+        n: usize,
+
+        file: PathBuf,
+    },
 }
 
 fn cli() -> Result<(), ()> {
@@ -83,6 +210,9 @@ fn cli() -> Result<(), ()> {
                 Err(())
             }
         },
+        Commands::Perf { n, file } => {
+            perf(n, file).map_err(|(modules, err)| compile::error(&modules, *err))
+        }
     }
 }
 


### PR DESCRIPTION
Previously e.g. in #60 and #61 I would manually insert some code into `crates/adroit/src/compile.rs` to measure and print timing data, then manually gather the data and plug all the numbers into a calculator. This PR gets rid of the need for all that by adding an `adroit perf` subcommand that you can use like this:

```sh
cargo run --release perf -n100000 evals/gmm/gmm.adroit
```

```
100000 × lex       =  0.869 seconds
100000 × parse     =  2.675 seconds
100000 × typecheck = 25.281 seconds
100000 × total     = 28.825 seconds

evals/gmm/gmm.adroit is 139 lines
lines of code per second: 482218
```