### PR TITLE
Enable more Rust optimizations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,7 @@
 [workspace]
 members = ["crates/*"]
 resolver = "2"
+
+[profile.release]
+codegen-units = 1
+lto = true

--- a/crates/adroit/src/typecheck/mod.rs
+++ b/crates/adroit/src/typecheck/mod.rs
@@ -172,7 +172,7 @@ pub enum Type {
     },
 }
 
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Serialize)]
+#[derive(Clone, Copy, Debug, Serialize)]
 #[serde(tag = "kind")]
 pub enum Src {
     Import { src: ImportId, id: parse::DefId },
@@ -182,7 +182,7 @@ pub enum Src {
     Inst { val: ValId, ty: TypeId },
 }
 
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Serialize)]
+#[derive(Clone, Copy, Debug, Serialize)]
 pub struct Val {
     pub ty: TypeId,
     pub src: Src,

--- a/packages/gradbench/src/App.tsx
+++ b/packages/gradbench/src/App.tsx
@@ -189,10 +189,13 @@ const App = () => {
               Dex
             </a>
             . The Adroit compiler is <span className="bold">fast</span>: it can
-            lex, parse, and typecheck over 450k lines of code per second using
-            one core on a modern laptop, causing little overhead as an initial
-            preprocessing step before passing typed IR as JSON to another tool
-            to perform automatic differentiation.
+            lex, parse, and typecheck{" "}
+            <span className="bold">
+              half a million lines of code per second
+            </span>{" "}
+            using one core on a modern laptop, causing little overhead as an
+            initial preprocessing step before passing typed IR as JSON to
+            another tool to perform automatic differentiation.
           </div>
         </div>
       </div>


### PR DESCRIPTION
This PR follows up on the performance improvements in #61 by cleaning a couple things up (removing now-unnecessary `#[derive(Eq, Hash, PartialEq)]` from a couple types) and enabling a couple [Rust build configuration options](https://nnethercote.github.io/perf-book/build-configuration.html) to improve performance. Example:

```sh
cargo flamegraph --root -- perf -n10000 evals/gmm/gmm.adroit
```

```
10000 × lex       = 0.084 seconds
10000 × parse     = 0.148 seconds
10000 × typecheck = 2.403 seconds
10000 × total     = 2.636 seconds

evals/gmm/gmm.adroit is 139 lines
lines of code per second: 527400
```

I was curious how much these build config options actually matter, so I ran the above command 100 times with each possible combination of them:

- "unit" means `codegen-units = 1`
- "thin" means `lto = "thin"`
- "fat" means `lto = "fat"` (or, equivalently, `lto = true`)

Here's the result:

![violin](https://github.com/user-attachments/assets/bb186c5a-50c1-4b7b-a65f-03d98c85a15f)

Honestly, kinda hard to tell from just looking at it.

Strangely, using [`cargo-flamegraph`](https://github.com/flamegraph-rs/flamegraph) _increases_ performance? When I don't use it, it's actually slower for some reason:

```sh
cargo run --release perf -n10000 evals/gmm/gmm.adroit
```

```
10000 × lex       = 0.089 seconds
10000 × parse     = 0.259 seconds
10000 × typecheck = 2.496 seconds
10000 × total     = 2.844 seconds

evals/gmm/gmm.adroit is 139 lines
lines of code per second: 488717
```

I should figure out what causes this. I asked @titzer and he suggested using [Linux `perf`](https://perf.wiki.kernel.org/index.php/Main_Page) to investigate further, so I should try that.