### PR TITLE
Use `Printer::new` outside `#[cfg(test)]`

### DIFF
--- a/crates/adroit/src/compile.rs
+++ b/crates/adroit/src/compile.rs
@@ -326,10 +326,7 @@ pub fn error(modules: &Modules, err: Error) {
         }
         Error::Type { path, full, errs } => {
             let path: &str = &path.display().to_string();
-            let printer = Printer {
-                modules,
-                full: &full,
-            };
+            let printer = Printer::new(modules, &full);
             let mut emitter =
                 AriadneEmitter::new((path, Source::from(&full.source)), "failed to typecheck");
             for err in errs {


### PR DESCRIPTION
Following up on #66, this PR uses `Printer::new` outside tests so that no dead code warnings show up when we do stuff like [this](https://github.com/johnthagen/min-sized-rust/tree/094d314f0c28f7e4bffeb0b0258f71cb303bd91a?tab=readme-ov-file#remove-panic-string-formatting-with-panic_immediate_abort):

```sh
cargo +nightly build -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort --target wasm32-unknown-unknown --release
```