### PR TITLE
Try building for MinGW instead of MSVC

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
         include:
           - vscode-platform: win32-x64
             github-os: windows-2022
-            rust-target: x86_64-pc-windows-msvc
+            rust-target: x86_64-pc-windows-gnu
             ext: ".exe"
           - vscode-platform: linux-x64
             github-os: ubuntu-22.04


### PR DESCRIPTION
Followup on #69, trying to figure out why the Windows VS Code extension built in GitHub Actions just gives `_` on hover but otherwise seems to work correctly; in contrast, when I build locally, everything works perfectly.