### PR TITLE
Try using `windows-2019` instead of `windows-2022`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         include:
           - vscode-platform: win32-x64
-            github-os: windows-2022
+            github-os: windows-2019
             rust-target: x86_64-pc-windows-msvc
             ext: ".exe"
           - vscode-platform: linux-x64


### PR DESCRIPTION
Followup on #69, trying to figure out why the Windows VS Code extension built in GitHub Actions just gives `_` on hover but otherwise seems to work correctly; in contrast, when I build locally, everything works perfectly.