### PR TITLE
Fix Adroit for Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,8 +24,8 @@ jobs:
       matrix:
         include:
           - vscode-platform: win32-x64
-            github-os: windows-2022
-            rust-target: x86_64-pc-windows-msvc
+            github-os: ubuntu-22.04
+            rust-target: x86_64-pc-windows-gnu
             ext: ".exe"
           - vscode-platform: linux-x64
             github-os: ubuntu-22.04

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,24 +24,29 @@ jobs:
       matrix:
         include:
           - vscode-platform: win32-x64
-            github-os: ubuntu-22.04
             rust-target: x86_64-pc-windows-gnu
-            ext: ".exe"
-          - vscode-platform: linux-x64
             github-os: ubuntu-22.04
+            ext: ".exe"
+            install-script: sudo apt-get install -y mingw-w64
+          - vscode-platform: linux-x64
             rust-target: x86_64-unknown-linux-musl
+            github-os: ubuntu-22.04
             ext: ""
+            install-script: ""
           - vscode-platform: darwin-x64
-            github-os: macos-13
             rust-target: x86_64-apple-darwin
+            github-os: macos-13
             ext: ""
+            install-script: ""
           - vscode-platform: darwin-arm64
-            github-os: macos-14
             rust-target: aarch64-apple-darwin
+            github-os: macos-14
             ext: ""
+            install-script: ""
     runs-on: ${{ matrix.github-os }}
     steps:
       - uses: actions/checkout@v4
+      - run: ${{ matrix.install-script }}
       - run: rustup target add ${{ matrix.rust-target }}
       - run: npm ci
       - run: cargo build --release --target ${{ matrix.rust-target }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "adroit"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "ariadne",

--- a/crates/adroit/Cargo.toml
+++ b/crates/adroit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adroit"
-version = "0.2.0"
+version = "0.2.1"
 publish = false
 edition = "2021"
 

--- a/crates/adroit/src/lex.rs
+++ b/crates/adroit/src/lex.rs
@@ -49,7 +49,7 @@ impl Id for ByteLen {
 pub enum TokenKind {
     Eof,
 
-    #[token("\n")]
+    #[regex("\r?\n")]
     Newline,
 
     #[regex("#[^\n]*")]
@@ -299,4 +299,26 @@ pub fn lex(source: &str) -> Result<Tokens, LexError> {
     }
     tokens.push(eof);
     Ok(Tokens { tokens })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_crlf() {
+        let actual: Vec<TokenKind> = lex("a\r\nb")
+            .unwrap()
+            .tokens
+            .into_iter()
+            .map(|tok| tok.kind)
+            .collect();
+        let expected = vec![
+            TokenKind::Ident,
+            TokenKind::Newline,
+            TokenKind::Ident,
+            TokenKind::Eof,
+        ];
+        assert_eq!(actual, expected);
+    }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5242,7 +5242,7 @@
     },
     "packages/vscode": {
       "name": "adroit-vscode",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "engines": {
         "vscode": "^1.75.0"

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adroit-vscode",
   "displayName": "Adroit",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "publisher": "samestep",
   "description": "Language services for Adroit.",
   "license": "MIT",


### PR DESCRIPTION
Followup on #69: the Windows VS Code extension built in GitHub Actions just gives `_` on hover but otherwise seems to work correctly; in contrast, when I build locally, everything works perfectly. This PR fixes the issue by cross-compiling from Linux. It also modifies the lexer so it can recognize Windows-style line endings.