### PR TITLE
Make the VS Code extension more flexible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "adroit"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "ariadne",

--- a/crates/adroit/Cargo.toml
+++ b/crates/adroit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adroit"
-version = "0.2.1"
+version = "0.2.2"
 publish = false
 edition = "2021"
 

--- a/crates/adroit/src/graph.rs
+++ b/crates/adroit/src/graph.rs
@@ -50,7 +50,8 @@ impl Uri {
     }
 
     fn resolve(&self, stdlib: &Self, name: &str) -> Result<Self, ()> {
-        let base = if name.starts_with('.') { self } else { stdlib };
+        let relative = name.starts_with("./") || name.starts_with("../");
+        let base = if relative { self } else { stdlib };
         let url = base.0.join(&format!("{name}.adroit")).map_err(|_| ())?;
         Ok(Self::new(url))
     }

--- a/crates/adroit/src/lsp.rs
+++ b/crates/adroit/src/lsp.rs
@@ -2,6 +2,7 @@ use std::{collections::HashMap, mem::take, ops::Range, sync::Arc};
 
 use anyhow::anyhow;
 use crossbeam_channel::Sender;
+use itertools::Itertools;
 use line_index::{LineCol, LineIndex};
 use lsp_server::{Connection, Message, RequestId, ResponseError};
 use lsp_types::{
@@ -277,7 +278,9 @@ impl State {
         let doc = params.text_document;
         let uri = Uri::from_lsp_uri(&doc.uri).unwrap();
         self.graph.make_root(uri.clone());
-        self.graph.set_text(&uri, doc.text);
+        let (pending,) = self.graph.pending().into_iter().collect_tuple().unwrap();
+        assert_eq!(pending, uri);
+        self.graph.set_text(&pending, doc.text);
         self.exhaust();
         self.diagnose_all()
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5242,7 +5242,7 @@
     },
     "packages/vscode": {
       "name": "adroit-vscode",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "MIT",
       "engines": {
         "vscode": "^1.75.0"

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adroit-vscode",
   "displayName": "Adroit",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "publisher": "samestep",
   "description": "Language services for Adroit.",
   "license": "MIT",
@@ -40,6 +40,14 @@
       "type": "object",
       "title": "Adroit configuration",
       "properties": {
+        "adroit.exe": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "default": null,
+          "description": "Path to Adroit executable."
+        },
         "adroit.trace.server": {
           "scope": "window",
           "type": "string",

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -2,21 +2,27 @@ import * as process from "process";
 import * as vscode from "vscode";
 import * as lsp from "vscode-languageclient/node";
 
-let client: lsp.LanguageClient;
-
-export const activate = (context: vscode.ExtensionContext) => {
+const exeDefault = (context: vscode.ExtensionContext): string => {
   const uri = context.extensionUri;
   const ext = process.platform === "win32" ? ".exe" : "";
-  const command = vscode.Uri.joinPath(uri, "bin", `adroit${ext}`).fsPath;
+  return vscode.Uri.joinPath(uri, "bin", `adroit${ext}`).fsPath;
+};
+
+let client: lsp.LanguageClient;
+
+export const activate = (context: vscode.ExtensionContext): void => {
+  const command =
+    vscode.workspace.getConfiguration("adroit").get<string>("exe") ??
+    exeDefault(context);
   client = new lsp.LanguageClient(
     "adroit",
     "Adroit",
     { command, args: ["lsp"] },
-    { documentSelector: [{ scheme: "file", language: "adroit" }] },
+    { documentSelector: ["adroit"] },
   );
   client.start();
 };
 
-export const deactivate = () => {
-  if (client) return client.stop();
+export const deactivate = (): void => {
+  if (client) client.stop();
 };


### PR DESCRIPTION
This PR expands on #69 by
- tweaking the behavior for identifying relative `import`s
- removing the redundant call to `fetch` for `textDocument/didOpen`
- adding an `adroit.exe` configuration option (mostly useful for local development)
- removing the `file:` restriction so now e.g. `untitled:` works too