### PR TITLE
Obviate custom `goldenfile` differ

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,6 @@ dependencies = [
  "lsp-types",
  "serde",
  "serde_json",
- "similar-asserts",
  "url",
 ]
 
@@ -345,9 +344,9 @@ dependencies = [
 
 [[package]]
 name = "goldenfile"
-version = "1.7.1"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0d5c44265baec620ea19c97b4ce9f068e28f8c3d7faccc483f02968b5e3c587"
+checksum = "672ff1c2f0537cf3f92065ce8aa77e2fc3f2abae2c805eb67f40ceecfbdee428"
 dependencies = [
  "scopeguard",
  "similar-asserts",

--- a/crates/adroit/Cargo.toml
+++ b/crates/adroit/Cargo.toml
@@ -22,5 +22,4 @@ serde_json = "1"
 url = "2"
 
 [dev-dependencies]
-goldenfile = "1"
-similar-asserts = "1"
+goldenfile = "1.7.2"

--- a/crates/adroit/src/pprint/mod.rs
+++ b/crates/adroit/src/pprint/mod.rs
@@ -360,22 +360,11 @@ pub fn pprint(
 mod tests {
     use std::{fs, path::Path};
 
-    use goldenfile::{differs::Differ, Mint};
+    use goldenfile::Mint;
 
     use crate::{lex::lex, parse::parse};
 
     use super::*;
-
-    fn differ() -> Differ {
-        Box::new(|old, new| {
-            similar_asserts::assert_eq!(
-                &fs::read_to_string(old).unwrap_or("".to_string()),
-                &fs::read_to_string(new).unwrap_or("".to_string()),
-                "{}",
-                old.display(),
-            );
-        })
-    }
 
     #[test]
     fn test_examples() {
@@ -388,9 +377,7 @@ mod tests {
             let source = fs::read_to_string(&path).expect(stripped);
             let tokens = lex(&source).expect(stripped);
             let tree = parse(&tokens).expect(stripped);
-            let mut file = mint
-                .new_goldenfile_with_differ(stripped, differ())
-                .expect(stripped);
+            let mut file = mint.new_goldenfile(stripped).expect(stripped);
             pprint(&mut file, &source, &tokens, &tree).expect(stripped);
         }
     }

--- a/crates/adroit/src/typecheck/mod.rs
+++ b/crates/adroit/src/typecheck/mod.rs
@@ -1390,7 +1390,7 @@ pub fn typecheck(
 mod tests {
     use std::{fs, io::Write, ops::Range, path::Path, sync::Arc};
 
-    use goldenfile::{differs::Differ, Mint};
+    use goldenfile::Mint;
     use line_index::{LineCol, LineIndex, TextSize};
 
     use crate::{
@@ -1467,17 +1467,6 @@ mod tests {
         fn finish(self) {}
     }
 
-    fn differ() -> Differ {
-        Box::new(|old, new| {
-            similar_asserts::assert_eq!(
-                &fs::read_to_string(old).unwrap_or("".to_string()),
-                &fs::read_to_string(new).unwrap_or("".to_string()),
-                "{}",
-                old.display(),
-            );
-        })
-    }
-
     #[test]
     fn test_errors() {
         let prefix = Path::new("src/typecheck/errors");
@@ -1513,9 +1502,7 @@ mod tests {
                 printer.emit_type_error(&mut emitter, path_str, error);
             }
 
-            let mut file = mint
-                .new_goldenfile_with_differ(stripped, differ())
-                .expect(stripped);
+            let mut file = mint.new_goldenfile(stripped).expect(stripped);
             for (i, line) in source.lines().enumerate() {
                 writeln!(file, "{}", line).expect(stripped);
                 for (start, end, message) in emitter.errors.remove(&i).unwrap_or_default() {


### PR DESCRIPTION
See calder/rust-goldenfile#10.