### PR TITLE
Serialize the entire Adroit module graph again

### DIFF
--- a/crates/adroit/Cargo.toml
+++ b/crates/adroit/Cargo.toml
@@ -17,7 +17,7 @@ line-index = "0.1"
 logos = "0.14"
 lsp-server = "0.7"
 lsp-types = "0.97"
-serde = { version = "1", features = ["derive"] }
+serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1"
 url = "2"
 

--- a/crates/adroit/src/graph.rs
+++ b/crates/adroit/src/graph.rs
@@ -8,6 +8,7 @@ use std::{
 };
 
 use line_index::{LineCol, LineIndex};
+use serde::{Serialize, Serializer};
 use url::Url;
 
 use crate::{
@@ -54,6 +55,12 @@ impl Uri {
         let base = if relative { self } else { stdlib };
         let url = base.0.join(&format!("{name}.adroit")).map_err(|_| ())?;
         Ok(Self::new(url))
+    }
+}
+
+impl Serialize for Uri {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(self.as_str())
     }
 }
 
@@ -207,8 +214,12 @@ impl Graph {
         &self.nodes[uri]
     }
 
+    pub fn nodes(&self) -> impl Iterator<Item = (&Uri, &Node)> {
+        self.nodes.iter()
+    }
+
     pub fn roots(&self) -> impl Iterator<Item = (&Uri, &Node)> {
-        self.nodes.iter().filter(|(_, node)| node.root)
+        self.nodes().filter(|(_, node)| node.root)
     }
 
     pub fn pending(&mut self) -> Vec<Uri> {


### PR DESCRIPTION
#69 changed the `adroit json` command to only print the typed IR for a single module, in contrast to its previous behavior which printed the entire module graph. This PR changes it back, but now uses URIs instead of indices into a flat topologically-sorted list.