### PR TITLE
Run slow tools separately from fast ones

### DIFF
--- a/.github/matrix.py
+++ b/.github/matrix.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 
 def ls(path):
-    return sorted(p.name for p in Path(path).iterdir())
+    return (p.name for p in Path(path).iterdir())
 
 
 def output(name, value):
@@ -16,8 +16,12 @@ def output(name, value):
 
 def main():
     output("date", str(datetime.now(timezone.utc).date()))
-    output("eval", ls("evals"))
-    output("tool", ls("tools"))
+    output("eval", sorted(ls("evals")))
+    tool = set(ls("tools"))
+    output("tool", sorted(tool))
+    slow = ["scilean", "tensorflow"]
+    output("fast", sorted(tool - set(slow)))
+    output("slow", slow)
 
 
 if __name__ == "__main__":

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,8 @@ jobs:
     runs-on: ubuntu-22.04
     outputs:
       eval: ${{ steps.matrix.outputs.eval }}
-      tool: ${{ steps.matrix.outputs.tool }}
+      fast: ${{ steps.matrix.outputs.fast }}
+      slow: ${{ steps.matrix.outputs.slow }}
     steps:
       - uses: actions/checkout@v4
       - id: matrix
@@ -57,11 +58,11 @@ jobs:
           name: eval-${{ matrix.eval }}
           path: eval-${{ matrix.eval }}.tar
 
-  tool:
+  tool-fast:
     needs: matrix
     strategy:
       matrix:
-        tool: ${{ fromJSON(needs.matrix.outputs.tool) }}
+        tool: ${{ fromJSON(needs.matrix.outputs.fast) }}
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
@@ -74,15 +75,54 @@ jobs:
           name: tool-${{ matrix.tool }}
           path: tool-${{ matrix.tool }}.tar
 
-  run:
+  tool-slow:
+    needs: matrix
+    strategy:
+      matrix:
+        tool: ${{ fromJSON(needs.matrix.outputs.slow) }}
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/space
+      - uses: ./.github/actions/docker
+      - run: ./crosstool.sh ${{ matrix.tool }}
+      - run: docker save --output tool-${{ matrix.tool }}.tar ghcr.io/gradbench/tool-${{ matrix.tool }}
+      - uses: actions/upload-artifact@v4
+        with:
+          name: tool-${{ matrix.tool }}
+          path: tool-${{ matrix.tool }}.tar
+
+  run-fast:
     needs:
       - matrix
       - eval
-      - tool
+      - tool-fast
     strategy:
       matrix:
         eval: ${{ fromJSON(needs.matrix.outputs.eval) }}
-        tool: ${{ fromJSON(needs.matrix.outputs.tool) }}
+        tool: ${{ fromJSON(needs.matrix.outputs.fast) }}
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: eval-${{ matrix.eval }}
+      - uses: actions/download-artifact@v4
+        with:
+          name: tool-${{ matrix.tool }}
+      - run: docker load --input eval-${{ matrix.eval }}.tar
+      - run: docker load --input tool-${{ matrix.tool }}.tar
+      - run: ./run.py --eval './eval.sh ${{ matrix.eval }}' --tool './tool.sh ${{ matrix.tool }}'
+
+  run-slow:
+    needs:
+      - matrix
+      - eval
+      - tool-slow
+    strategy:
+      matrix:
+        eval: ${{ fromJSON(needs.matrix.outputs.eval) }}
+        tool: ${{ fromJSON(needs.matrix.outputs.slow) }}
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This PR splits our `tool` and `run` CI jobs into `tool-fast`/`tool-slow` and `run-fast`/`run-slow` pairs, so that don't have to wait multiple hours for the slow tools to finish building before getting any data from running the evals on the fast tools.