### PR TITLE
Cancel existing CI runs on PR push

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
 
 concurrency:
   group: ${{ github.event.pull_request.number }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   site:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.event.pull_request.number }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   site:
     runs-on: ubuntu-22.04

--- a/.github/workflows/close-pr.yml
+++ b/.github/workflows/close-pr.yml
@@ -1,0 +1,15 @@
+name: Close PR
+on:
+  pull_request:
+    types:
+      - closed
+
+concurrency:
+  group: ${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  cancel-ci:
+    runs-on: ubuntu-22.04
+    steps:
+      - run: echo 'PR closed; cancelling in-progress CI workflow runs.'


### PR DESCRIPTION
Our main build workflow spawns quite a few jobs, some of which are long-running. The free version of GitHub Actions has a [limit](https://docs.github.com/en/actions/administering-github-actions/usage-limits-billing-and-administration#usage-limits) of 20 concurrent jobs, so this can cause jobs to have to wait a while if, e.g., we push several commits to a pull request within the space of a couple hours. This PR uses the [`concurrency`](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/control-the-concurrency-of-workflows-and-jobs) feature to automatically cancel running CI workflows on further pushes to a PR, and also adds a new "Close PR" workflow which uses the same concurrency group, effectively cancelling any CI workflow runs when the PR gets closed.