### PR TITLE
Fix `concurrency` usage for `push` events

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ on:
       - main
 
 concurrency:
-  group: ${{ github.event.pull_request.number }}
+  group: ${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:


### PR DESCRIPTION
Followup on #82 to fix [this error](https://github.com/gradbench/gradbench/actions/runs/11021882294):

> **Invalid workflow file:** .github/workflows/build.yml#L9
> `The workflow is not valid. .github/workflows/build.yml (Line: 9, Col: 10): Unexpected value ''`