### PR TITLE
Run CI on `main` in parallel again

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ on:
       - main
 
 concurrency:
-  group: ${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:


### PR DESCRIPTION
Followup on #83 which accidentally forced all CI on `main` to run serialized. This PR lets it run in parallel again.