### PR TITLE
Tapenade Compilation Fix

### DIFF
--- a/tools/tapenade/hello.py
+++ b/tools/tapenade/hello.py
@@ -1,40 +1,59 @@
 import subprocess
+import sys
 import time
 
 
-def double(vals):
-    subprocess.run(
-        [
-            "tapenade",
-            "-reverse",
-            "-head",
-            "square(x)\\y",
-            "-output",
-            "double",
-            "functions.c",
-        ],
-        text=True,
-        capture_output=True,
-    )
-    subprocess.run(
-        [
-            "gcc",
-            "-I/home/gradbench/tapenade_3.16/ADFirstAidKit/",
-            "run_deriv.c",
-            "functions.c",
-            "double_b.c",
-            "-o",
-            "derivative",
-        ]
-    )
-    ret = subprocess.run(["./derivative", str(vals)], text=True, capture_output=True)
+def compile():
+    try:
+        # generate AD code
+        result = subprocess.run(
+            [
+                "tapenade",
+                "-reverse",
+                "-head",
+                "square(x)\\y",
+                "-output",
+                "double",
+                "functions.c",
+            ],
+            text=True,
+            capture_output=True,
+        )
+        if result.returncode != 0:
+            return False
 
+        # compile AD code
+        result = subprocess.run(
+            [
+                "gcc",
+                "-I/home/gradbench/tapenade_3.16/ADFirstAidKit/",
+                "run_deriv.c",
+                "functions.c",
+                "double_b.c",
+                "-o",
+                "derivative",
+            ]
+        )
+        if result.returncode != 0:
+            return False
+
+        # compile original code
+        result = subprocess.run(["gcc", "run_origin.c", "functions.c", "-o", "normal"])
+        if result.returncode != 0:
+            return False
+
+        return True
+
+    except Exception as e:
+        # print(f"Compilation failed with error {e}", file=sys.stderr)
+        return False
+
+
+def double(vals):
+    ret = subprocess.run(["./derivative", str(vals)], text=True, capture_output=True)
     return ret
 
 
 def square(vals):
-
-    subprocess.run(["gcc", "run_origin.c", "functions.c", "-o", "normal"])
     ret = subprocess.run(["./normal", str(vals)], text=True, capture_output=True)
-
     return ret

--- a/tools/tapenade/run.py
+++ b/tools/tapenade/run.py
@@ -30,8 +30,10 @@ def main():
             response = run(message)
         elif message["kind"] == "define":
             try:
-                import_module(message["module"])
-                response["success"] = True
+                functions = import_module(message["module"])
+                func = getattr(functions, "compile")
+                success = func()  # compiles C code
+                response["success"] = success
             except:
                 response["success"] = False
         print(json.dumps({"id": message["id"]} | response), flush=True)


### PR DESCRIPTION
Ensures Tapenade only compiles once during the `define` message and then runs that compiled code for `evaluate` calls.