### PR TITLE
Save Build and Nightly results as artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -116,7 +116,11 @@ jobs:
           name: tool-${{ matrix.tool }}
       - run: docker load --input eval-${{ matrix.eval }}.tar
       - run: docker load --input tool-${{ matrix.tool }}.tar
-      - run: ./run.py --eval './eval.sh ${{ matrix.eval }}' --tool './tool.sh ${{ matrix.tool }}'
+      - run: ./run.py --eval './eval.sh ${{ matrix.eval }}' --tool './tool.sh ${{ matrix.tool }}' | tee log.json
+      - uses: actions/upload-artifact@v4
+        with:
+          name: log-${{ matrix.eval }}-${{ matrix.tool }}
+          path: log.json
 
   run-slow:
     needs:
@@ -138,4 +142,8 @@ jobs:
           name: tool-${{ matrix.tool }}
       - run: docker load --input eval-${{ matrix.eval }}.tar
       - run: docker load --input tool-${{ matrix.tool }}.tar
-      - run: ./run.py --eval './eval.sh ${{ matrix.eval }}' --tool './tool.sh ${{ matrix.tool }}'
+      - run: ./run.py --eval './eval.sh ${{ matrix.eval }}' --tool './tool.sh ${{ matrix.tool }}' | tee log.json
+      - uses: actions/upload-artifact@v4
+        with:
+          name: log-${{ matrix.eval }}-${{ matrix.tool }}
+          path: log.json

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -59,3 +59,29 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - run: docker push --all-tags $IMAGE
+
+  run:
+    needs:
+      - matrix
+      - eval
+      - tool
+    strategy:
+      matrix:
+        eval: ${{ fromJSON(needs.matrix.outputs.eval) }}
+        tool: ${{ fromJSON(needs.matrix.outputs.tool) }}
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: eval-${{ matrix.eval }}
+      - uses: actions/download-artifact@v4
+        with:
+          name: tool-${{ matrix.tool }}
+      - run: docker load --input eval-${{ matrix.eval }}.tar
+      - run: docker load --input tool-${{ matrix.tool }}.tar
+      - run: ./run.py --eval './eval.sh ${{ matrix.eval }}' --tool './tool.sh ${{ matrix.tool }}' | tee log.json
+      - uses: actions/upload-artifact@v4
+        with:
+          name: log-${{ matrix.eval }}-${{ matrix.tool }}
+          path: log.json

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ __pycache__/
 .lake/
 *.vsix
 /.config/dotnet-tools.json
+/log.json
 /packages/vscode/bin/
 /target/
 dist/


### PR DESCRIPTION
This PR adds to our Nightly GitHub Actions workflow a `run` job that uses [`actions/upload-artifact`](https://github.com/actions/upload-artifact) to save the JSON log, then also modifies the `run-fast` and `run-slow` jobs in our Build workflow to save their logs as well.

As a followup, we should add a job to collect all these artifacts and commit and push them to a branch, since GitHub Actions artifacts are ephemeral.