### PR TITLE
Remove TensorFlow from the "slow" list

### DIFF
--- a/.github/matrix.py
+++ b/.github/matrix.py
@@ -19,7 +19,7 @@ def main():
     output("eval", sorted(ls("evals")))
     tool = set(ls("tools"))
     output("tool", sorted(tool))
-    slow = ["scilean", "tensorflow"]
+    slow = ["scilean"]
     output("fast", sorted(tool - set(slow)))
     output("slow", slow)
 


### PR DESCRIPTION
On 2024-09-24 in #81 we created a "slow" list of tools that take a long time to build. For example, on 2024-09-25 in [Nightly build #76](https://github.com/gradbench/gradbench/actions/runs/11044363484/job/30680182588) it took over half an hour. However, the next day on 2024-09-26 in [Nightly build #77](https://github.com/gradbench/gradbench/actions/runs/11063377546/job/30739410907) it only took about seven minutes, and this has continued to be the case ever since. So, this PR removes TensorFlow from the "slow" list.