### PR TITLE
Choose PyTorch as a "gold" tool to run first

### DIFF
--- a/.github/matrix.py
+++ b/.github/matrix.py
@@ -22,6 +22,7 @@ def main():
     slow = ["scilean"]
     output("fast", sorted(tool - set(slow)))
     output("slow", slow)
+    output("gold", "pytorch")
 
 
 if __name__ == "__main__":

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,6 +53,7 @@ jobs:
       eval: ${{ steps.matrix.outputs.eval }}
       fast: ${{ steps.matrix.outputs.fast }}
       slow: ${{ steps.matrix.outputs.slow }}
+      gold: ${{ steps.matrix.outputs.gold }}
     steps:
       - uses: actions/checkout@v4
       - id: matrix
@@ -108,11 +109,39 @@ jobs:
           name: tool-${{ matrix.tool }}
           path: tool-${{ matrix.tool }}.tar
 
+  gold:
+    needs:
+      - matrix
+      - eval
+      - tool-fast
+    strategy:
+      matrix:
+        eval: ${{ fromJSON(needs.matrix.outputs.eval) }}
+        tool:
+          - ${{ fromJSON(needs.matrix.outputs.gold) }}
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: eval-${{ matrix.eval }}
+      - uses: actions/download-artifact@v4
+        with:
+          name: tool-${{ matrix.tool }}
+      - run: docker load --input eval-${{ matrix.eval }}.tar
+      - run: docker load --input tool-${{ matrix.tool }}.tar
+      - run: ./run.py --eval './eval.sh ${{ matrix.eval }}' --tool './tool.sh ${{ matrix.tool }}' | tee log.json
+      - uses: actions/upload-artifact@v4
+        with:
+          name: log-${{ matrix.eval }}-gold
+          path: log.json
+
   run-fast:
     needs:
       - matrix
       - eval
       - tool-fast
+      - gold
     strategy:
       matrix:
         eval: ${{ fromJSON(needs.matrix.outputs.eval) }}
@@ -139,6 +168,7 @@ jobs:
       - matrix
       - eval
       - tool-slow
+      - gold
     strategy:
       matrix:
         eval: ${{ fromJSON(needs.matrix.outputs.eval) }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -133,7 +133,7 @@ jobs:
       - run: ./run.py --eval './eval.sh ${{ matrix.eval }}' --tool './tool.sh ${{ matrix.tool }}' | tee log.json
       - uses: actions/upload-artifact@v4
         with:
-          name: log-${{ matrix.eval }}-gold
+          name: gold-${{ matrix.eval }}
           path: log.json
 
   run-fast:
@@ -160,7 +160,7 @@ jobs:
       - run: ./run.py --eval './eval.sh ${{ matrix.eval }}' --tool './tool.sh ${{ matrix.tool }}' | tee log.json
       - uses: actions/upload-artifact@v4
         with:
-          name: log-${{ matrix.eval }}-${{ matrix.tool }}
+          name: run-${{ matrix.eval }}-${{ matrix.tool }}
           path: log.json
 
   run-slow:
@@ -187,5 +187,5 @@ jobs:
       - run: ./run.py --eval './eval.sh ${{ matrix.eval }}' --tool './tool.sh ${{ matrix.tool }}' | tee log.json
       - uses: actions/upload-artifact@v4
         with:
-          name: log-${{ matrix.eval }}-${{ matrix.tool }}
+          name: run-${{ matrix.eval }}-${{ matrix.tool }}
           path: log.json

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -12,6 +12,7 @@ jobs:
       date: ${{ steps.matrix.outputs.date }}
       eval: ${{ steps.matrix.outputs.eval }}
       tool: ${{ steps.matrix.outputs.tool }}
+      gold: ${{ steps.matrix.outputs.gold }}
     steps:
       - uses: actions/checkout@v4
       - id: matrix
@@ -60,11 +61,39 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - run: docker push --all-tags $IMAGE
 
+  gold:
+    needs:
+      - matrix
+      - eval
+      - tool
+    strategy:
+      matrix:
+        eval: ${{ fromJSON(needs.matrix.outputs.eval) }}
+        tool:
+          - ${{ fromJSON(needs.matrix.outputs.gold) }}
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: eval-${{ matrix.eval }}
+      - uses: actions/download-artifact@v4
+        with:
+          name: tool-${{ matrix.tool }}
+      - run: docker load --input eval-${{ matrix.eval }}.tar
+      - run: docker load --input tool-${{ matrix.tool }}.tar
+      - run: ./run.py --eval './eval.sh ${{ matrix.eval }}' --tool './tool.sh ${{ matrix.tool }}' | tee log.json
+      - uses: actions/upload-artifact@v4
+        with:
+          name: log-${{ matrix.eval }}-gold
+          path: log.json
+
   run:
     needs:
       - matrix
       - eval
       - tool
+      - gold
     strategy:
       matrix:
         eval: ${{ fromJSON(needs.matrix.outputs.eval) }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -85,7 +85,7 @@ jobs:
       - run: ./run.py --eval './eval.sh ${{ matrix.eval }}' --tool './tool.sh ${{ matrix.tool }}' | tee log.json
       - uses: actions/upload-artifact@v4
         with:
-          name: log-${{ matrix.eval }}-gold
+          name: gold-${{ matrix.eval }}
           path: log.json
 
   run:
@@ -112,5 +112,5 @@ jobs:
       - run: ./run.py --eval './eval.sh ${{ matrix.eval }}' --tool './tool.sh ${{ matrix.tool }}' | tee log.json
       - uses: actions/upload-artifact@v4
         with:
-          name: log-${{ matrix.eval }}-${{ matrix.tool }}
+          name: run-${{ matrix.eval }}-${{ matrix.tool }}
           path: log.json


### PR DESCRIPTION
As a first step for #98, this PR adds a `gold` job to our Build and Nightly workflows, which runs a single tool on all the evals first before running any of the other tools, so that tool's results will be available to validate all the others' against it. In `.github/matrix.py` we specify that our particular choice for this "gold" tool is PyTorch; quoting @athas [on Discord](https://discord.com/channels/1242864568850579487/1267596255886970952/1298393783033139402):

> I would probably use PyTorch as the golden implementations, because it's so popular, so there's a pretty good chance people will be familiar with it. Could also be autograd.

Note that currently, this CI setup runs PyTorch _twice_ on every eval, since it's also a part of the "tool" and "fast" sets that get run after the "gold" tool. This is intentional: even though it's a bit redundant, it'll serve as a nice easy determinism smoke check, since while for other tools there might be some numerical differences, we'd expect that running PyTorch twice should be exactly the same.