### PR TITLE
Create nightly release with benchmark data/summary

### DIFF
--- a/.github/release.py
+++ b/.github/release.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+
+import json
+import shutil
+from pathlib import Path
+
+
+def ls(path):
+    return (p.name for p in Path(path).iterdir())
+
+
+def summarize(run):
+    implemented = run[0]["response"]["success"]
+    return {"status": "implemented" if implemented else "unimplemented"}
+
+
+def main():
+    folder = Path("release")
+    folder.mkdir()
+    table = []
+    for e in sorted(ls("evals")):
+        row = []
+        for t in sorted(ls("tools")):
+            source = Path("run") / f"run-{e}-{t}/log.json"
+            run = json.loads(source.read_text())
+            cell = {"tool": t} | summarize(run)
+            row.append(cell)
+            shutil.copy(source, folder / f"run-{e}-{t}.json")
+        table.append({"eval": e, "tools": row})
+    summary = {"table": table}
+    (folder / "summary.json").write_text(json.dumps(summary))
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -128,3 +128,16 @@ jobs:
         with:
           name: run-${{ matrix.eval }}-${{ matrix.tool }}
           path: log.json
+
+  release:
+    needs:
+      - matrix
+      - run
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - run: gh run download ${{ github.run_id }} --pattern 'run-*'
+      - run: .github/release.py
+      - env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release create nightly-${{ fromJSON(needs.matrix.outputs.date) }} release/*

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ __pycache__/
 /.config/dotnet-tools.json
 /log.json
 /packages/vscode/bin/
+/release/
+/run/
 /target/
 dist/
 node_modules/


### PR DESCRIPTION
For #97, while we could possibly just have the website look up the workflow run for a nightly release and download the artifacts, that introduces a lot of steps and also [the artifacts expire eventually](https://docs.github.com/en/organizations/managing-organization-settings/configuring-the-retention-period-for-github-actions-artifacts-and-logs-in-your-organization). This PR puts the data in an easier place by having the nightly workflow create a GitHub release with all the JSON logs. It also runs a new `.github/release.py` script that collects a summary of all the runs into a single much smaller file, which the website will be able to download to create a table of all evals and tools on the homepage. In the future we could also expand this to add summary files for the rows and columns in the table.