### PR TITLE
Set `GH_TOKEN` when using `gh` in nightly workflow

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -136,8 +136,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
-      - run: gh run download ${{ github.run_id }} --pattern 'run-*'
+      - env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh run download ${{ github.run_id }} --pattern 'run-*'
       - run: .github/release.py
       - env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh release create nightly-${{ fromJSON(needs.matrix.outputs.date) }} release/*


### PR DESCRIPTION
Log from [nightly failures](https://github.com/gradbench/gradbench/actions/runs/11656984084/job/32486384749) since #108:

> ```
> gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable. Example:
>   env:
>     GH_TOKEN: ${{ github.token }}
> ```

And [the docs](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/using-github-cli-in-workflows) say to set `GH_TOKEN` instead of `GITHUB_TOKEN` so I'm doing that here.