### PR TITLE
Capture validation error messages

### DIFF
--- a/python/gradbench/evals/ba/run.py
+++ b/python/gradbench/evals/ba/run.py
@@ -4,7 +4,7 @@ from typing import Any
 import numpy as np
 
 import gradbench.pytorch.ba as golden
-from gradbench.evaluation import SingleModuleValidatedEvaluation, correctness
+from gradbench.evaluation import SingleModuleValidatedEvaluation, assertion
 from gradbench.wrap_module import Functions
 
 
@@ -32,12 +32,12 @@ def parse(file):
     }
 
 
-def check(name: str, input: Any, b: Any) -> bool:
+def check(name: str, input: Any, b: Any) -> None:
     func: Functions = getattr(golden, name)
     a = func.unwrap(func(func.prepare(input)))
     match name:
         case "calculate_objectiveBA":
-            return (
+            assert (
                 np.all(
                     np.isclose(
                         a["reproj_error"]["elements"], b["reproj_error"]["elements"]
@@ -48,11 +48,11 @@ def check(name: str, input: Any, b: Any) -> bool:
                 and a["w_err"]["repeated"] == b["w_err"]["repeated"]
             )
         case "calculate_jacobianBA":
-            return a == b
+            assert a == b
 
 
 def main():
-    e = SingleModuleValidatedEvaluation(module="ba", validator=correctness(check))
+    e = SingleModuleValidatedEvaluation(module="ba", validator=assertion(check))
     if e.define(source="PLACE HOLDER").success:
         # NOTE: data files are taken directly from ADBench. See README for more information.
         # Currently set to run on the smallest two data files. To run on all 20 set loop range to be: range(1,21)

--- a/python/gradbench/evals/gmm/run.py
+++ b/python/gradbench/evals/gmm/run.py
@@ -5,18 +5,18 @@ import numpy as np
 
 import gradbench.pytorch.gmm as golden
 from gradbench.evals.gmm import data_gen
-from gradbench.evaluation import SingleModuleValidatedEvaluation, correctness
+from gradbench.evaluation import SingleModuleValidatedEvaluation, assertion
 from gradbench.wrap_module import Functions
 
 
-def check(name: str, input: Any, output: Any) -> bool:
+def check(name: str, input: Any, output: Any) -> None:
     func: Functions = getattr(golden, name)
     expected = func.unwrap(func(func.prepare(input)))
-    return np.all(np.isclose(expected, output))
+    assert np.all(np.isclose(expected, output))
 
 
 def main():
-    e = SingleModuleValidatedEvaluation(module="gmm", validator=correctness(check))
+    e = SingleModuleValidatedEvaluation(module="gmm", validator=assertion(check))
     if e.define(source=(Path(__file__).parent / "gmm.adroit").read_text()).success:
         for n in [1000, 10000]:
             for k in [5, 10, 25, 50, 100, 200]:

--- a/python/gradbench/evals/hello/run.py
+++ b/python/gradbench/evals/hello/run.py
@@ -1,19 +1,19 @@
 from pathlib import Path
 from typing import Any
 
-from gradbench.evaluation import SingleModuleValidatedEvaluation, correctness
+from gradbench.evaluation import SingleModuleValidatedEvaluation, assertion
 
 
-def check(name: str, input: Any, output: Any) -> bool:
+def check(name: str, input: Any, output: Any) -> None:
     match name:
         case "double":
-            return output == input * 2
+            assert output == input * 2
         case "square":
-            return output == input * input
+            assert output == input * input
 
 
 def main():
-    e = SingleModuleValidatedEvaluation(module="hello", validator=correctness(check))
+    e = SingleModuleValidatedEvaluation(module="hello", validator=assertion(check))
     if e.define(source=(Path(__file__).parent / "hello.adroit").read_text()).success:
         x = 1.0
         for _ in range(4):


### PR DESCRIPTION
Followup on #101, replacing the boolean-only `correctness(check)` pattern with a richer `assertion(check)` pattern that captures the error message as a string. Hopefully this will help with cases like #103 where the checker itself throws an error due to structure issues before it even begins evaluating its check.