### PR TITLE
Give nightly workflow permissions to create a release

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -5,6 +5,9 @@ on:
     - cron: "0 1 * * *"
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   matrix:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
The [most recent nightly](https://github.com/gradbench/gradbench/actions/runs/11715372548/job/32669554843) failed with this error message:

> HTTP 403: Resource not accessible by integration (https://api.github.com/repos/gradbench/gradbench/releases)

According to [the GitHub docs](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token) for the `contents` permission:

> Work with the contents of the repository. For example, `contents: read` permits an action to list the commits, and `contents: write` allows the action to create a release. For more information, see "[Permissions required for GitHub Apps](https://docs.github.com/en/rest/overview/permissions-required-for-github-apps?apiVersion=2022-11-28#repository-permissions-for-contents)."