### PR TITLE
Check for and print validation errors in CI

### DIFF
--- a/.github/errors.py
+++ b/.github/errors.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+
+import json
+import sys
+from pathlib import Path
+
+
+def eprint(s):
+    print(s, file=sys.stderr)
+
+
+def main():
+    any_errors = False
+    log = json.loads(Path("log.json").read_text())
+    for validation in log[-1]["message"]["validations"]:
+        if not validation["correct"]:
+            any_errors = True
+            eprint(f"- id: {validation['id']}")
+            eprint("  error: |")
+            for line in validation["error"].splitlines():
+                eprint(f"    {line}")
+    sys.exit(any_errors)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -144,6 +144,7 @@ jobs:
         with:
           name: run-${{ matrix.eval }}-${{ matrix.tool }}
           path: log.json
+      - run: .github/errors.py
 
   run-slow:
     needs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,6 +66,7 @@ jobs:
   eval:
     needs: matrix
     strategy:
+      fail-fast: false
       matrix:
         eval: ${{ fromJSON(needs.matrix.outputs.eval) }}
     runs-on: ubuntu-22.04
@@ -82,6 +83,7 @@ jobs:
   tool-fast:
     needs: matrix
     strategy:
+      fail-fast: false
       matrix:
         tool: ${{ fromJSON(needs.matrix.outputs.fast) }}
     runs-on: ubuntu-22.04
@@ -99,6 +101,7 @@ jobs:
   tool-slow:
     needs: matrix
     strategy:
+      fail-fast: false
       matrix:
         tool: ${{ fromJSON(needs.matrix.outputs.slow) }}
     runs-on: ubuntu-22.04
@@ -119,6 +122,7 @@ jobs:
       - eval
       - tool-fast
     strategy:
+      fail-fast: false
       matrix:
         eval: ${{ fromJSON(needs.matrix.outputs.eval) }}
         tool: ${{ fromJSON(needs.matrix.outputs.fast) }}
@@ -147,6 +151,7 @@ jobs:
       - eval
       - tool-slow
     strategy:
+      fail-fast: false
       matrix:
         eval: ${{ fromJSON(needs.matrix.outputs.eval) }}
         tool: ${{ fromJSON(needs.matrix.outputs.slow) }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -168,3 +168,4 @@ jobs:
         with:
           name: run-${{ matrix.eval }}-${{ matrix.tool }}
           path: log.json
+      - run: .github/errors.py

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -23,6 +23,7 @@ jobs:
   eval:
     needs: matrix
     strategy:
+      fail-fast: false
       matrix:
         eval: ${{ fromJSON(needs.matrix.outputs.eval) }}
     runs-on: ubuntu-22.04
@@ -49,6 +50,7 @@ jobs:
   tool:
     needs: matrix
     strategy:
+      fail-fast: false
       matrix:
         tool: ${{ fromJSON(needs.matrix.outputs.tool) }}
     runs-on: ubuntu-22.04
@@ -79,6 +81,7 @@ jobs:
       - eval
       - tool
     strategy:
+      fail-fast: false
       matrix:
         eval: ${{ fromJSON(needs.matrix.outputs.eval) }}
         tool: ${{ fromJSON(needs.matrix.outputs.tool) }}


### PR DESCRIPTION
#113 made it possible to capture all kinds of errors from validation, but also made it so that CI no longer fails when a validation error occurs. This PR adds a `.github/errors.py` script that prints any validation errors from a log, and also yields a nonzero exit code if there were any errors.

This script only gets run in the Build workflow, because there, the `run-*` jobs are terminal. It does not run in the Nightly workflow, which feeds the logs into a final `release` job that is meant to produce a bundle of assets that can then be displayed on the website.