### PR TITLE
Flush stdout after processing a message.

### DIFF
--- a/run.py
+++ b/run.py
@@ -54,6 +54,7 @@ def main():
         client.stdin.write(response)
         client.stdin.flush()
         print("  }", end="")
+        sys.stdout.flush()
     print()
     print("]")
     sys.exit((server.poll() or 0) | (client.poll() or 0))


### PR DESCRIPTION
This is useful when piping the result of run.py into 'tee' (or other tools), as Python switches stdout from line to block buffering when stdout is not a tty.