### PR TITLE
Give nightly workflow package permissions again

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  packages: write
 
 jobs:
   matrix:


### PR DESCRIPTION
Followup on #114 because [the nightly is failing earlier now](https://github.com/gradbench/gradbench/actions/runs/11734858253), this time with the message

> ```
> unexpected status from POST request to https://ghcr.io/v2/gradbench/.../blobs/uploads/: 403 Forbidden
> ```

which I'm guessing is because previously there was implicit permissions and I accidentally disabled those by adding `contents: write`. But it's GitHub Actions, who even knows really. Time to wait and see when the next nightly runs in fifteen minutes.