### PR TITLE
Delete `release` job from Nightly workflow

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -104,19 +104,3 @@ jobs:
         with:
           name: run-${{ matrix.eval }}-${{ matrix.tool }}
           path: log.json
-
-  release:
-    needs:
-      - matrix
-      - run
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v4
-      - env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh run download ${{ github.run_id }} --dir run --pattern 'run-*'
-      - run: .github/release.py
-      - env:
-          DATE: ${{ fromJSON(needs.matrix.outputs.date) }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release create --target "$GITHUB_SHA" "nightly-$DATE" release/*


### PR DESCRIPTION
After the most recent nightly finished, I tried to download the data in #109, but it failed due to CORS.