### PR TITLE
Allow command line options to be passed to tools and evals.

### DIFF
--- a/eval.sh
+++ b/eval.sh
@@ -1,3 +1,5 @@
 #!/usr/bin/env bash
 set -euo pipefail
-docker run --rm --interactive "ghcr.io/gradbench/eval-$1"
+eval=$1
+shift
+docker run --rm --interactive "ghcr.io/gradbench/eval-${eval}" "$@"

--- a/python/gradbench/evals/ba/run.py
+++ b/python/gradbench/evals/ba/run.py
@@ -1,3 +1,4 @@
+import argparse
 from pathlib import Path
 from typing import Any
 
@@ -52,11 +53,16 @@ def check(name: str, input: Any, b: Any) -> None:
 
 
 def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--min", type=int, default=1)
+    parser.add_argument("--max", type=int, default=3)
+    args = parser.parse_args()
+
     e = SingleModuleValidatedEvaluation(module="ba", validator=assertion(check))
     if e.define().success:
         # NOTE: data files are taken directly from ADBench. See README for more information.
         # Currently set to run on the smallest two data files. To run on all 20 set loop range to be: range(1,21)
-        for i in range(1, 3):
+        for i in range(args.min, args.max + 1):
             datafile = next((Path(__file__).parent / "data").glob(f"ba{i}_*.txt"), None)
             if datafile:
                 input = parse(datafile)

--- a/python/gradbench/evals/ba/run.py
+++ b/python/gradbench/evals/ba/run.py
@@ -55,7 +55,7 @@ def check(name: str, input: Any, b: Any) -> None:
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--min", type=int, default=1)
-    parser.add_argument("--max", type=int, default=3)
+    parser.add_argument("--max", type=int, default=2)
     args = parser.parse_args()
 
     e = SingleModuleValidatedEvaluation(module="ba", validator=assertion(check))

--- a/python/gradbench/evals/gmm/run.py
+++ b/python/gradbench/evals/gmm/run.py
@@ -1,3 +1,4 @@
+import argparse
 from pathlib import Path
 from typing import Any
 
@@ -16,10 +17,15 @@ def check(name: str, input: Any, output: Any) -> None:
 
 
 def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-n", nargs="+", type=int, default=[1000, 10000])
+    parser.add_argument("-k", nargs="+", type=int, default=[5, 10, 25, 50, 100, 200])
+    args = parser.parse_args()
+
     e = SingleModuleValidatedEvaluation(module="gmm", validator=assertion(check))
     if e.define().success:
-        for n in [1000, 10000]:
-            for k in [5, 10, 25, 50, 100, 200]:
+        for n in args.n:
+            for k in args.k:
                 input = data_gen.main(2, k, n)  # d k n
                 e.evaluate(name="calculate_objectiveGMM", input=input)
                 e.evaluate(name="calculate_jacobianGMM", input=input)

--- a/python/gradbench/evals/ht/run.py
+++ b/python/gradbench/evals/ht/run.py
@@ -1,3 +1,4 @@
+import argparse
 from pathlib import Path
 from typing import Any
 
@@ -16,6 +17,11 @@ def check(name: str, input: Any, output: Any) -> None:
 
 
 def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--min", type=int, default=1)
+    parser.add_argument("--max", type=int, default=2)
+    args = parser.parse_args()
+
     e = SingleModuleValidatedEvaluation(module="ht", validator=assertion(check))
     if e.define().success:
         data_root = Path("evals/ht/data")  # assumes cwd is set correctly
@@ -28,7 +34,7 @@ def main():
         def evals(data_dir, complicated):
             # Shrink the range because some of the larger datasets take an
             # excessive amount of time with PyTorch.
-            for i in range(1, 13)[:2]:
+            for i in range(args.min, args.max + 1):
                 fn = next(data_dir.glob(f"hand{i}_*.txt"), None)
                 model_dir = data_dir / "model"
                 input = io.read_hand_instance(model_dir, fn, complicated).to_dict()

--- a/tool.sh
+++ b/tool.sh
@@ -1,3 +1,5 @@
 #!/usr/bin/env bash
 set -euo pipefail
-docker run --rm --interactive "ghcr.io/gradbench/tool-$1"
+tool=$1
+shift
+docker run --rm --interactive "ghcr.io/gradbench/tool-${tool}" "$@"


### PR DESCRIPTION
Also augments the ba/gmm/ht evals to accept command line options indicating which workloads to run. This is probably the most useful usage of command line options.

By default, when no options are provided, the current selection of workloads is preserved.