### PR TITLE
Extend protocol with an "analysis" message kind.

### DIFF
--- a/python/gradbench/evaluation.py
+++ b/python/gradbench/evaluation.py
@@ -60,6 +60,11 @@ class SingleModuleValidatedEvaluation:
         self.id += 1
         return response
 
+    # Do not increment ID, do not ask for response.
+    def analysis(self, message: Any) -> Any:
+        json.dump(message, sys.stdout)
+        print(flush=True)
+
     def define(self) -> DefineResponse:
         message = {"kind": "define", "module": self.module}
         response = DefineResponse.model_validate(self.send(message))
@@ -74,7 +79,11 @@ class SingleModuleValidatedEvaluation:
         }
         id = self.id
         response = EvaluateResponse.model_validate(self.send(message))
-        self.validations[id] = self.validator(name, input, response.output)
+        valid = self.validator(name, input, response.output)
+        self.analysis(
+            {"id": id, "kind": "analysis", "valid": valid.correct, "error": valid.error}
+        )
+        self.validations[id] = valid
         return response
 
     def end(self) -> None:

--- a/run.py
+++ b/run.py
@@ -50,7 +50,7 @@ def main():
             print("  }", end="")
             break
         print(",")
-        print(f'    "response": {response.strip()}')
+        print(f'    "response": {response.strip()}', end="")
         client.stdin.write(response)
         client.stdin.flush()
         if json.loads(message)["kind"] == "evaluate":

--- a/run.py
+++ b/run.py
@@ -53,7 +53,11 @@ def main():
         print(f'    "response": {response.strip()}')
         client.stdin.write(response)
         client.stdin.flush()
-        print("  }", end="")
+        if json.loads(message)["kind"] == "evaluate":
+            analysis = client.stdout.readline()
+            print(",")
+            print(f'    "analysis": {analysis.strip()}')
+            print("  }", end="")
         sys.stdout.flush()
     print()
     print("]")

--- a/run.py
+++ b/run.py
@@ -57,7 +57,7 @@ def main():
             analysis = client.stdout.readline()
             print(",")
             print(f'    "analysis": {analysis.strip()}')
-            print("  }", end="")
+        print("  }", end="")
         sys.stdout.flush()
     print()
     print("]")


### PR DESCRIPTION
This message is sent by the eval after it receives a response to an evaluation message, and contains validation information. The idea is that this is used by the run.py script (or equivalent). The eval does not expect a response to the analysis message. The ID of the analysis message is the same as the ID of the evaluation message.

This PR does not change the contents of the "end" message, so validation information is now reported twice (but still only computed once, so there is little risk of inconsistency).