### PR TITLE
Add workload labels.

### DIFF
--- a/python/gradbench/evals/ba/run.py
+++ b/python/gradbench/evals/ba/run.py
@@ -66,8 +66,8 @@ def main():
             datafile = next((Path(__file__).parent / "data").glob(f"ba{i}_*.txt"), None)
             if datafile:
                 input = parse(datafile)
-                e.evaluate(name="calculate_objectiveBA", input=input)
-                e.evaluate(name="calculate_jacobianBA", input=input)
+                e.evaluate(name="calculate_objectiveBA", workload=datafile.stem, input=input)
+                e.evaluate(name="calculate_jacobianBA", workload=datafile.stem, input=input)
     e.end()
 
 

--- a/python/gradbench/evals/ba/run.py
+++ b/python/gradbench/evals/ba/run.py
@@ -66,8 +66,12 @@ def main():
             datafile = next((Path(__file__).parent / "data").glob(f"ba{i}_*.txt"), None)
             if datafile:
                 input = parse(datafile)
-                e.evaluate(name="calculate_objectiveBA", workload=datafile.stem, input=input)
-                e.evaluate(name="calculate_jacobianBA", workload=datafile.stem, input=input)
+                e.evaluate(
+                    name="calculate_objectiveBA", workload=datafile.stem, input=input
+                )
+                e.evaluate(
+                    name="calculate_jacobianBA", workload=datafile.stem, input=input
+                )
     e.end()
 
 

--- a/python/gradbench/evals/gmm/run.py
+++ b/python/gradbench/evals/gmm/run.py
@@ -26,9 +26,10 @@ def main():
     if e.define().success:
         for n in args.n:
             for k in args.k:
-                input = data_gen.main(2, k, n)  # d k n
-                e.evaluate(name="calculate_objectiveGMM", input=input)
-                e.evaluate(name="calculate_jacobianGMM", input=input)
+                d = 2
+                input = data_gen.main(d, k, n)
+                e.evaluate(name="calculate_objectiveGMM", workload="{d}_{k}_{n}", input=input)
+                e.evaluate(name="calculate_jacobianGMM", workload="{d}_{k}_{n}", input=input)
     e.end()
 
 

--- a/python/gradbench/evals/gmm/run.py
+++ b/python/gradbench/evals/gmm/run.py
@@ -28,8 +28,12 @@ def main():
             for k in args.k:
                 d = 2
                 input = data_gen.main(d, k, n)
-                e.evaluate(name="calculate_objectiveGMM", workload="{d}_{k}_{n}", input=input)
-                e.evaluate(name="calculate_jacobianGMM", workload="{d}_{k}_{n}", input=input)
+                e.evaluate(
+                    name="calculate_objectiveGMM", workload="{d}_{k}_{n}", input=input
+                )
+                e.evaluate(
+                    name="calculate_jacobianGMM", workload="{d}_{k}_{n}", input=input
+                )
     e.end()
 
 

--- a/python/gradbench/evals/hello/run.py
+++ b/python/gradbench/evals/hello/run.py
@@ -17,8 +17,8 @@ def main():
     if e.define().success:
         x = 1.0
         for _ in range(4):
-            y = e.evaluate(name="square", input=x).output
-            x = e.evaluate(name="double", input=y).output
+            y = e.evaluate(name="square", workload=str(x), input=x).output
+            x = e.evaluate(name="double", workload=str(x), input=y).output
     e.end()
 
 

--- a/python/gradbench/evals/ht/run.py
+++ b/python/gradbench/evals/ht/run.py
@@ -38,8 +38,8 @@ def main():
                 fn = next(data_dir.glob(f"hand{i}_*.txt"), None)
                 model_dir = data_dir / "model"
                 input = io.read_hand_instance(model_dir, fn, complicated).to_dict()
-                e.evaluate(name="calculate_objectiveHT", input=input)
-                e.evaluate(name="calculate_jacobianHT", input=input)
+                e.evaluate(name="calculate_objectiveHT", workload=fn.stem, input=input)
+                e.evaluate(name="calculate_jacobianHT", workload=fn.stem, input=input)
 
         evals(simple_small, False)
         evals(simple_big, False)

--- a/python/gradbench/evaluation.py
+++ b/python/gradbench/evaluation.py
@@ -65,14 +65,17 @@ class SingleModuleValidatedEvaluation:
         response = DefineResponse.model_validate(self.send(message))
         return response
 
-    def evaluate(self, *, name: str, workload: str, input: Any) -> EvaluateResponse:
+    def evaluate(
+        self, *, name: str, input: Any, workload: Optional[str] = None
+    ) -> EvaluateResponse:
         message = {
             "kind": "evaluate",
             "module": self.module,
             "name": name,
-            "workload": workload,
             "input": input,
         }
+        if workload is not None:
+            message["workload"] = (workload,)
         id = self.id
         response = EvaluateResponse.model_validate(self.send(message))
         self.validations[id] = self.validator(name, input, response.output)

--- a/python/gradbench/evaluation.py
+++ b/python/gradbench/evaluation.py
@@ -65,11 +65,12 @@ class SingleModuleValidatedEvaluation:
         response = DefineResponse.model_validate(self.send(message))
         return response
 
-    def evaluate(self, *, name: str, input: Any) -> EvaluateResponse:
+    def evaluate(self, *, name: str, workload: str, input: Any) -> EvaluateResponse:
         message = {
             "kind": "evaluate",
             "module": self.module,
             "name": name,
+            "workload": workload,
             "input": input,
         }
         id = self.id


### PR DESCRIPTION
This extends the eval protocol such that "evaluate" messages must now also have a "workload" field. This field must contain a human-readable string. It is intended for use by analysis tools and carries no semantic meaning. It is intended that every distinct "input" also has a distinct "workload" label.