### PR TITLE
Write more documentation

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
+  "[markdown]": { "editor.formatOnSave": false },
   "[python]": {
     "editor.codeActionsOnSave": { "source.organizeImports": "always" },
     "editor.defaultFormatter": "ms-python.black-formatter"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,7 @@
 - [Docker](#docker)
   - [Multi-platform images](#multi-platform-images)
   - [Manual images](#manual-images)
+- [Tools](#tools)
 - [Node](#node)
   - [Markdown](#markdown)
   - [Website](#website)
@@ -77,11 +78,23 @@ These typically take much longer than `buildeval.sh` and `buildtool.sh`, so they
 
 ### Manual images
 
-All the Docker images for individual autodiff tools are in the `tools` directory and built automatically in GitHub Actions. However, some of those `Dockerfile`s are built `FROM` base images that we are unable to build in GitHub Actions. All such base images are in the `docker` directory. Each must have an `ENTRYPOINT` that simply prints the tag of the image. To build, tag, and push one of these images, first [log in to GHCR][], then use `manual.sh`:
+All the Docker images for individual autodiff tools are in the `tools` directory and built automatically in GitHub Actions. However, some of those `Dockerfile`s are built `FROM` base images that we are unable to build in GitHub Actions. All such base images are in the `docker` directory. Each must have an `ENTRYPOINT` that simply prints the tag of the image. _If you have write access to the GradBench organization on GitHub_, you can build, tag, and push one of these images by first [log in to GHCR][] and then running `manual.sh`:
 
 ```sh
 ./manual.sh mathlib4
 ```
+
+## Tools
+
+If you'd like to contribute a new tool: awesome! We're always excited to expand the set of automatic differentiation tools in GradBench. All you need to do is create a subdirectory under the `tools` directory in this repo, and create a `Dockerfile` in that new subdirectory. Other than having an `ENTRYPOINT`, you can pretty much do whatever you want; take a look at the already-supported tools to see some examples! You must include the following as the last line in your `Dockerfile`, though:
+
+```Dockerfile
+LABEL org.opencontainers.image.source=https://github.com/gradbench/gradbench
+```
+
+We'd really appreciate it if you also write a short `README.md` file next to your `Dockerfile`; this can be as minimal as just a link to the tool's website, but can also include more information, e.g. anything specific about this setup of that tool for GradBench.
+
+Before taking a look at any of the other evals, you should implement the [`hello` eval](evals/hello) for the tool you're adding! This will help you get all the structure for the GradBench protocol working correctly first, after which you can implement other evals for that tool over time.
 
 ## Node
 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,17 @@
 <h1 align="center">GradBench</h1>
 <p align="center"><a href="LICENSE"><img src="https://img.shields.io/github/license/rose-lang/rose" alt="license" /></a> <a href="https://github.com/gradbench/gradbench/actions/workflows/nightly.yml"><img src="https://github.com/gradbench/gradbench/actions/workflows/nightly.yml/badge.svg" alt="Nightly" /></a> <a href="https://discord.gg/nPXmPzeykS"><img src="https://dcbadge.vercel.app/api/server/nPXmPzeykS?style=flat" alt="Discord" /></a></p>
 
-**GradBench** is a benchmark for differentiable programming across languages and domains.
+**GradBench** is a benchmark suite for differentiable programming across languages and domains.
+
+See https://gradben.ch for a daily overview of all the tools (columns) and benchmarks (rows). The website is a work in progress and currently pretty bare-bones, but soon it will provide more detailed information, such as charts of tools' relative performance for each individual benchmark.
 
 <!-- toc -->
 
 - [Usage](#usage)
+- [Protocol](#protocol)
+  - [Example](#example)
+  - [Specification](#specification)
+  - [Types](#types)
 - [Contributing](#contributing)
 - [License](#license)
 
@@ -29,6 +35,158 @@ Then if you have [Python][] and [Docker][] installed, you can run any of our [ev
 
 This will first automatically download our latest nightly Docker images for the given eval and tool, and then run the eval against the tool while printing the entire communication log to the terminal.
 
+## Protocol
+
+GradBench decouples benchmarks from tools via a [JSON][]-based protocol. In this protocol, there is an _intermediary_ (our `run.py` script), an _eval_, and a _tool_. The eval and the tool communicate with each other by sending and receiving messages over stdout and stdin, which are intercepted by the intermediary and forwarded as appropriate.
+
+### Example
+
+To illustrate, here is a hypothetical example of a complete session of the protocol, as captured and reported by the intermediary:
+
+```json
+[
+  {
+    "message": { "id": 0, "kind": "define", "module": "foo" },
+    "nanoseconds": 12345,
+    "response": { "id": 0, "success": true }
+  },
+  {
+    "message": { "id": 1, "kind": "evaluate", "module": "foo", "name": "bar", "input": 3.14159 },
+    "nanoseconds": 56789,
+    "response": { "id": 1, "output": 2.71828, "nanoseconds": { "evaluate": 45678 } },
+    "analysis": { "id": 1, "kind": "analysis", "correct": true, "error": "Expected tau, got e." }
+  },
+  {
+    "message": { "id": 2, "kind": "evaluate", "module": "foo", "name": "baz", "input": { "mynumber": 121 } },
+    "nanoseconds": 34567,
+    "response": { "id": 2, "output": { "yournumber": 342 }, "nanoseconds": { "evaluate": 23456 } },
+    "analysis": { "id": 2, "kind": "analysis", "correct": true }
+  },
+  {
+    "message": { "id": 3, "kind": "end", "validations": [ { "id": 1, "correct": false, "error": "Expected tau, got e." }, { "id": 2, "correct": true } ] }
+  }
+]
+```
+
+Here is that example from the perspective of the eval. (Output is listed first here, because the eval drives the protocol.)
+
+- Output:
+  ```json
+  { "id": 0, "kind": "define", "module": "foo" }
+  { "id": 1, "kind": "evaluate", "module": "foo", "name": "bar", "input": 3.14159 }
+  { "id": 1, "kind": "analysis", "correct": true, "error": "Expected tau, got e." }
+  { "id": 2, "kind": "evaluate", "module": "foo", "name": "baz", "input": { "mynumber": 121 } }
+  { "id": 2, "kind": "analysis", "correct": true }
+  { "id": 3, "kind": "end", "validations": [ { "id": 1, "correct": false, "error": "Expected tau, got e." }, { "id": 2, "correct": true } ] }
+  ```
+- Input:
+  ```json
+  { "id": 0, "success": true }
+  { "id": 1, "output": 2.71828, "nanoseconds": { "evaluate": 45678 } }
+  { "id": 2, "output": { "yournumber": 342 }, "nanoseconds": { "evaluate": 23456 } }
+  ```
+
+And here is that example from the perspective of the tool. (Input is listed first here, because the tool does not drive the protocol.)
+
+- Input:
+  ```json
+  { "id": 0, "kind": "define", "module": "foo" }
+  { "id": 1, "kind": "evaluate", "module": "foo", "name": "bar", "input": 3.14159 }
+  { "id": 2, "kind": "evaluate", "module": "foo", "name": "baz", "input": { "mynumber": 121 } }
+  ```
+- Output:
+  ```json
+  { "id": 0, "success": true }
+  { "id": 1, "output": 2.71828, "nanoseconds": { "evaluate": 45678 } }
+  { "id": 2, "output": { "yournumber": 342 }, "nanoseconds": { "evaluate": 23456 } }
+  ```
+
+As shown by this example, the intermediary forwards every message from the tool back to the eval, but it only forwards `"define"` and `"evaluate"` messages from the eval to the tool.
+
+### Specification
+
+The session proceeds over a series of _rounds_, driven by the eval. At the beginning of each round, the eval sends a message, which always includes an `"id"` and a `"kind"`, the latter of which has three possibilities:
+
+1. `"kind": "define"` - The eval provides the name of a `"module"` which the tool will need in order to proceed further with this particular benchmark. This will allow the tool to respond saying whether or not it knows of and has an implementation for the module of that name.
+
+   - The intermediary forwards this message to the tool, which must respond with the same `"id"` as the original message, and either `"success": true` or `"success": false`. In the former case, the benchmark proceeds normally. In the latter case, the tool is indicating that it does not have an implementation for the requested module, and the eval should stop and not send any further messages.
+
+2. `"kind": "evaluate"` - the eval again provides a `"module"` name, as well as the `"name"` of a function in that module. Currently there is no formal process for registering module names or specifying the functions available in those modules; those are specified informally via documentation in the evals themselves. An `"input"` to that function is also provided; the tool will be expected to evaluate that function at that input, and return the result.
+
+   - The intermediary forwards this message to the tool, which must again respond with the same `"id"` as the original message, along with the `"output"` of evaluating the requested function with the given input. The intermediary can time this entire interaction, but that measurement is very coarse; the tool can provide more fine-grained timing data for sub-tasks in the `"nanoseconds"` field. Currently, most tools only provide one entry in `"nanoseconds"`: the `"evaluate"` entry, which by convention means the amount of time that tool spent evaluating the function itself, not including other time such as JSON encoding/decoding.
+
+   - The intermediary forwards that response back to the eval, which can then respond back to the intermediary with a `"kind": "analysis"` message, only valid in this specific context. The `"id"` must again match that of the original message. The `"correct"` field is a boolean saying whether the tool's output was acceptable; if `"correct": false`, the eval can also provide an `"error"` field with a string message explaining why the tool's output was not acceptable.
+
+3. `"kind": "end"`, which must be the last message of the session and is not forwarded to the tool. The eval provides a list of `"validations"`; currently these are just a reiteration of the data already provided by the eval's `"kind": "analysis"` messages.
+
+### Types
+
+Here is a somewhat more formal definition of the protocol using [TypeScript][] types.
+
+```typescript
+interface Message {
+  id: string;
+}
+
+interface DefineMessage extends Message {
+  kind: "define";
+  module: string;
+}
+
+interface DefineResponse extends Message {
+  success: boolean;
+}
+
+interface EvaluateMessage extends Message {
+  kind: "evaluate";
+  module: string;
+  name: string;
+  input: any;
+}
+
+interface EvaluateResponse extends Message {
+  output: any;
+  nanoseconds: Record<string, number>;
+}
+
+interface EvaluateAnalysis extends Message {
+  correct: boolean;
+  error?: string;
+}
+
+interface Validation extends Message {
+  correct: boolean;
+  error?: string;
+}
+
+interface EndMessage extends Message {
+  kind: "end";
+  validations: Validation[];
+}
+
+interface Define {
+  message: DefineMessage;
+  nanoseconds: number;
+  response: DefineResponse;
+}
+
+interface Evaluate {
+  message: EvaluateMessage;
+  nanoseconds: number;
+  response: EvaluateResponse;
+  analysis?: EvaluateAnalysis;
+}
+
+interface End {
+  message: EndMessage;
+}
+
+type Round = Define | Evaluate | End;
+
+type Session = Round[];
+```
+
+
 ## Contributing
 
 See [`CONTRIBUTING.md`](CONTRIBUTING.md).
@@ -40,4 +198,6 @@ GradBench is licensed under the [MIT License](LICENSE).
 [docker]: https://docs.docker.com/engine/install/
 [git]: https://git-scm.com/downloads
 [github cli]: https://github.com/cli/cli#installation
+[json]: https://json.org/
 [python]: https://www.python.org/downloads/
+[typescript]: https://www.typescriptlang.org/

--- a/evals/hello/README.md
+++ b/evals/hello/README.md
@@ -1,0 +1,7 @@
+# Hello, world!
+
+The `hello` eval is the simplest one; it first defines a module named `"hello"` and then alternates between asking the tool to evaluate one of the two functions in that module:
+
+- The `"square"` function implements $f : \mathbb{R} \to \mathbb{R}$ given by $f(x) = x^2$, taking a single number as output and returning the square of that value as output.
+
+- The `"double"` function is the gradient of the `"square"` function! It implements $\nabla f : \mathbb{R} \to \mathbb{R}$ given by $\nabla f(x) = 2x$, taking a single number as input, and returns twice that value as output.

--- a/tools/autograd/README.md
+++ b/tools/autograd/README.md
@@ -1,0 +1,6 @@
+# Autograd
+
+[Autograd][] is an automatic differentiation library for the [Python][] programming language.
+
+[autograd]: https://github.com/HIPS/autograd
+[python]: https://www.python.org/

--- a/tools/diffsharp/README.md
+++ b/tools/diffsharp/README.md
@@ -1,0 +1,6 @@
+# DiffSharp
+
+[DiffSharp][] is a differentiable programming library for the [F#][] programming language.
+
+[diffsharp]: https://diffsharp.github.io/
+[f#]: https://fsharp.org/

--- a/tools/futhark/README.md
+++ b/tools/futhark/README.md
@@ -1,0 +1,5 @@
+# Futhark
+
+[Futhark][] is a purely functional array language with automatic differentiation built in.
+
+[futhark]: https://futhark-lang.org/

--- a/tools/jax/README.md
+++ b/tools/jax/README.md
@@ -1,0 +1,6 @@
+# JAX
+
+[JAX][] is an automatic differentiation library for the [Python][] programming language.
+
+[jax]: http://jax.readthedocs.io/
+[python]: https://www.python.org/

--- a/tools/mygrad/README.md
+++ b/tools/mygrad/README.md
@@ -1,0 +1,6 @@
+# MyGrad
+
+[MyGrad][] is an automatic differentiation library for the [Python][] programming language.
+
+[mygrad]: https://rsokl.github.io/MyGrad/
+[python]: https://www.python.org/

--- a/tools/pytorch/README.md
+++ b/tools/pytorch/README.md
@@ -1,0 +1,6 @@
+# PyTorch
+
+[PyTorch][] is a machine learning library for the [Python][] programming language.
+
+[python]: https://www.python.org/
+[pytorch]: https://pytorch.org/

--- a/tools/scilean/README.md
+++ b/tools/scilean/README.md
@@ -1,0 +1,6 @@
+# SciLean
+
+[SciLean][] is a scientific computing library for the [Lean 4][] programming language.
+
+[lean 4]: https://lean-lang.org/
+[scilean]: https://github.com/lecopivo/SciLean

--- a/tools/tapenade/README.md
+++ b/tools/tapenade/README.md
@@ -1,0 +1,7 @@
+# Tapenade
+
+[Tapenade][] is an automatic differentiation tool for the [C][] and [Fortran][] programming languages.
+
+[c]: https://en.wikipedia.org/wiki/C_(programming_language)
+[fortran]: https://fortran-lang.org/
+[tapenade]: https://tapenade.gitlabpages.inria.fr/userdoc/build/html/index.html

--- a/tools/tensorflow/README.md
+++ b/tools/tensorflow/README.md
@@ -1,0 +1,6 @@
+# TensorFlow
+
+[TensorFlow][] is a machine learning library for the [Python][] programming language.
+
+[python]: https://www.python.org/
+[tensorflow]: https://www.tensorflow.org/

--- a/tools/zygote/README.md
+++ b/tools/zygote/README.md
@@ -1,0 +1,6 @@
+# Zygote
+
+[Zygote][] is a differentiable programming library for the [Julia][] programming language.
+
+[julia]: https://julialang.org/
+[zygote]: https://fluxml.ai/Zygote.jl/


### PR DESCRIPTION
Resolves #95 and then some. The only actual code change here is in the log output for validation: previously the `"analysis"` messages said `"valid"` which was inconsistent with the `"end"` messages that said `"correct"`, so I made them consistent with each other (in this case I just chose the one that we were already using in the `.github/summarize.py` script). I also made it so that, if no `"error"` is provided, it's omitted from the JSON instead of being serialized as `null`.

I disabled Markdown autoformatting because Prettier was introducing too many linebreaks in the JSON examples in `README.md`.