### PR TITLE
Port Manual and Finite implementations from ADBench

### DIFF
--- a/cpp/adbench/io.cpp
+++ b/cpp/adbench/io.cpp
@@ -3,6 +3,23 @@
 #include "adbench/shared/GMMData.h"
 #include "adbench/shared/BAData.h"
 
+void read_HelloInput_json(const char* fname, HelloInput &input) {
+  using json = nlohmann::json;
+  std::ifstream f(fname);
+  json data = json::parse(f);
+  input.x = data.get<double>();
+}
+
+void write_HelloOutput_objective_json(std::ostream& f, HelloOutput &output) {
+  using json = nlohmann::json;
+  f << json(output.objective);
+}
+
+void write_HelloOutput_jacobian_json(std::ostream& f, HelloOutput &output) {
+  using json = nlohmann::json;
+  f << json(output.gradient);
+}
+
 void read_GMMInput_json(const char* fname, GMMInput &input) {
   // Based on read_lstm_instance from ADBench.
   using json = nlohmann::json;

--- a/cpp/adbench/io.h
+++ b/cpp/adbench/io.h
@@ -1,10 +1,15 @@
 // Functions for converting between ADBench objects and the JSON
 // format used by the Gradbench protocol.
 
+#include "adbench/shared/HelloData.h"
 #include "adbench/shared/GMMData.h"
 #include "adbench/shared/BAData.h"
 #include "adbench/shared/LSTMData.h"
 #include "adbench/shared/HTData.h"
+
+void read_HelloInput_json(const char* fname, HelloInput &input);
+void write_HelloOutput_objective_json(std::ostream& f, HelloOutput &output);
+void write_HelloOutput_jacobian_json(std::ostream& f, HelloOutput &output);
 
 void read_GMMInput_json(const char* fname, GMMInput &input);
 void write_GMMOutput_objective_json(std::ostream& f, GMMOutput &output);

--- a/cpp/adbench/shared/HelloData.h
+++ b/cpp/adbench/shared/HelloData.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <vector>
+
+#include "defs.h"
+#include "utils.h"
+
+struct HelloInput {
+  double x;
+};
+
+struct HelloOutput {
+  double objective;
+  double gradient;
+};

--- a/cpp/adbench/shared/ba.h
+++ b/cpp/adbench/shared/ba.h
@@ -1,0 +1,220 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+// https://github.com/microsoft/ADBench/blob/38cb7931303a830c3700ca36ba9520868327ac87/src/cpp/shared/ba.h
+
+#pragma once
+
+#include <stdlib.h>
+#include <math.h>
+#include <float.h>
+
+#include "defs.h"
+#include "matrix.h"
+
+////////////////////////////////////////////////////////////
+//////////////////// Declarations //////////////////////////
+////////////////////////////////////////////////////////////
+
+// cam: 11 camera in format [r1 r2 r3 C1 C2 C3 f u0 v0 k1 k2]
+//            r1, r2, r3 are angle - axis rotation parameters(Rodrigues)
+//            [C1 C2 C3]' is the camera center
+//            f is the focal length in pixels
+//            [u0 v0]' is the principal point
+//            k1, k2 are radial distortion parameters
+// X: 3 point
+// feats: 2 feature (x,y coordinates)
+// reproj_err: 2
+// projection function: 
+// Xcam = R * (X - C)
+// distorted = radial_distort(projective2euclidean(Xcam), radial_parameters)
+// proj = distorted * f + principal_point
+// err = sqsum(proj - measurement)
+template<typename T>
+void computeReprojError(
+    const T* const cam,
+    const T* const X,
+    const T* const w,
+    const double* const feat,
+    T *err);
+
+// w: 1
+// w_err: 1
+template<typename T>
+void computeZachWeightError(const T* const w, T* err);
+
+// n number of cameras
+// m number of points
+// p number of observations
+// cams: 11*n cameras in format [r1 r2 r3 C1 C2 C3 f u0 v0 k1 k2]
+//            r1, r2, r3 are angle - axis rotation parameters(Rodrigues)
+//            [C1 C2 C3]' is the camera center
+//            f is the focal length in pixels
+//            [u0 v0]' is the principal point
+//            k1, k2 are radial distortion parameters
+// X: 3*m points
+// obs: 2*p observations (pairs cameraIdx, pointIdx)
+// feats: 2*p features (x,y coordinates corresponding to observations)
+// reproj_err: 2*p errors of observations
+// w_err: p weight "error" terms
+// projection function: 
+// Xcam = R * (X - C)
+// distorted = radial_distort(projective2euclidean(Xcam), radial_parameters)
+// proj = distorted * f + principal_point
+// err = sqsum(proj - measurement)
+template<typename T>
+void ba_objective(int n, int m, int p,
+    const T* const cams,
+    const T* const X,
+    const T* const w,
+    const int* const obs,
+    const double* const feats,
+    T* reproj_err,
+    T* w_err);
+
+// rot: 3 rotation parameters
+// pt: 3 point to be rotated
+// rotatedPt: 3 rotated point
+// this is an efficient evaluation (part of
+// the Ceres implementation)
+// easy to understand calculation in matlab:
+//  theta = sqrt(sum(w. ^ 2));
+//  n = w / theta;
+//  n_x = au_cross_matrix(n);
+//  R = eye(3) + n_x*sin(theta) + n_x*n_x*(1 - cos(theta));
+template<typename T>
+void rodrigues_rotate_point(
+    const T* const rot,
+    const T* const pt,
+    T *rotatedPt);
+
+////////////////////////////////////////////////////////////
+//////////////////// Definitions ///////////////////////////
+////////////////////////////////////////////////////////////
+
+template<typename T>
+T sqsum(int n, const T* const x)
+{
+    T res = 0;
+    for (int i = 0; i < n; i++)
+        res = res + x[i] * x[i];
+    return res;
+}
+
+template<typename T>
+void rodrigues_rotate_point(
+    const T* const rot,
+    const T* const pt,
+    T *rotatedPt)
+{
+    T sqtheta = sqsum(3, rot);
+    if (sqtheta != 0)
+    {
+        T theta, costheta, sintheta, theta_inverse,
+            w[3], w_cross_pt[3], tmp;
+
+        theta = sqrt(sqtheta);
+        costheta = cos(theta);
+        sintheta = sin(theta);
+        theta_inverse = 1.0 / theta;
+
+        for (int i = 0; i < 3; i++)
+            w[i] = rot[i] * theta_inverse;
+
+        cross(w, pt, w_cross_pt);
+
+        tmp = (w[0] * pt[0] + w[1] * pt[1] + w[2] * pt[2]) *
+            (1. - costheta);
+
+        for (int i = 0; i < 3; i++)
+            rotatedPt[i] = pt[i] * costheta + w_cross_pt[i] * sintheta + w[i] * tmp;
+    }
+    else
+    {
+        T rot_cross_pt[3];
+        cross(rot, pt, rot_cross_pt);
+
+        for (int i = 0; i < 3; i++)
+            rotatedPt[i] = pt[i] + rot_cross_pt[i];
+    }
+}
+
+template<typename T>
+void radial_distort(
+    const T* const rad_params,
+    T *proj)
+{
+    T rsq, L;
+    rsq = sqsum(2, proj);
+    L = 1. + rad_params[0] * rsq + rad_params[1] * rsq * rsq;
+    proj[0] = proj[0] * L;
+    proj[1] = proj[1] * L;
+}
+
+template<typename T>
+void project(const T* const cam,
+    const T* const X,
+    T* proj)
+{
+    const T* const C = &cam[3];
+    T Xo[3], Xcam[3];
+
+    Xo[0] = X[0] - C[0];
+    Xo[1] = X[1] - C[1];
+    Xo[2] = X[2] - C[2];
+
+    rodrigues_rotate_point(&cam[0], Xo, Xcam);
+
+    proj[0] = Xcam[0] / Xcam[2];
+    proj[1] = Xcam[1] / Xcam[2];
+
+    radial_distort(&cam[9], proj);
+
+    proj[0] = proj[0] * cam[6] + cam[7];
+    proj[1] = proj[1] * cam[6] + cam[8];
+}
+
+template<typename T>
+void computeReprojError(
+    const T* const cam,
+    const T* const X,
+    const T* const w,
+    const double* const feat,
+    T *err)
+{
+    T proj[2];
+    project(cam, X, proj);
+
+    err[0] = (*w)*(proj[0] - feat[0]);
+    err[1] = (*w)*(proj[1] - feat[1]);
+}
+
+template<typename T>
+void computeZachWeightError(const T* const w, T* err)
+{
+    *err = 1 - (*w)*(*w);
+}
+
+template<typename T>
+void ba_objective(int n, int m, int p,
+    const T* const cams,
+    const T* const X,
+    const T* const w,
+    const int* const obs,
+    const double* const feats,
+    T* reproj_err,
+    T* w_err)
+{
+    for (int i = 0; i < p; i++)
+    {
+        int camIdx = obs[i * 2 + 0];
+        int ptIdx = obs[i * 2 + 1];
+        computeReprojError(&cams[camIdx * BA_NCAMPARAMS], &X[ptIdx * 3],
+            &w[i], &feats[i * 2], &reproj_err[2 * i]);
+    }
+
+    for (int i = 0; i < p; i++)
+    {
+        computeZachWeightError(&w[i], &w_err[i]);
+    }
+}

--- a/cpp/adbench/shared/gmm.h
+++ b/cpp/adbench/shared/gmm.h
@@ -1,0 +1,278 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+// https://github.com/microsoft/ADBench/blob/38cb7931303a830c3700ca36ba9520868327ac87/src/cpp/shared/gmm.h
+
+#pragma once
+
+#include <cmath>
+#include <vector>
+using std::vector;
+#include "defs.h"
+#include "matrix.h"
+
+////////////////////////////////////////////////////////////
+//////////////////// Declarations //////////////////////////
+////////////////////////////////////////////////////////////
+
+// d: dim
+// k: number of gaussians
+// n: number of points
+// alphas: k logs of mixture weights (unnormalized), so
+//          weights = exp(log_alphas) / sum(exp(log_alphas))
+// means: d*k component means
+// icf: (d*(d+1)/2)*k inverse covariance factors 
+//                  every icf entry stores firstly log of diagonal and then 
+//          columnwise other entris
+//          To generate icf in MATLAB given covariance C :
+//              L = inv(chol(C, 'lower'));
+//              inv_cov_factor = [log(diag(L)); L(au_tril_indices(d, -1))]
+// wishart: wishart distribution parameters
+// x: d*n points
+// err: 1 output
+template<typename T>
+void gmm_objective(int d, int k, int n, const T* const alphas, const T* const means,
+    const T* const icf, const double* const x, Wishart wishart, T* err);
+
+// split of the outer loop over points
+template<typename T>
+void gmm_objective_split_inner(int d, int k,
+    const T* const alphas,
+    const T* const means,
+    const T* const icf,
+    const double* const x,
+    Wishart wishart,
+    T* err);
+// other terms which are outside the loop
+template<typename T>
+void gmm_objective_split_other(int d, int k, int n,
+    const T* const alphas,
+    const T* const means,
+    const T* const icf,
+    Wishart wishart,
+    T* err);
+
+template<typename T>
+T logsumexp(int n, const T* const x);
+
+// p: dim
+// k: number of components
+// wishart parameters
+// sum_qs: k sums of log diags of Qs
+// Qdiags: d*k
+// icf: (p*(p+1)/2)*k inverse covariance factors
+template<typename T>
+T log_wishart_prior(int p, int k,
+    Wishart wishart,
+    const T* const sum_qs,
+    const T* const Qdiags,
+    const T* const icf);
+
+template<typename T>
+void preprocess_qs(int d, int k,
+    const T* const icf,
+    T* sum_qs,
+    T* Qdiags);
+
+template<typename T>
+void Qtimesx(int d,
+    const T* const Qdiag,
+    const T* const ltri, // strictly lower triangular part
+    const T* const x,
+    T* out);
+
+////////////////////////////////////////////////////////////
+//////////////////// Definitions ///////////////////////////
+////////////////////////////////////////////////////////////
+
+template<typename T>
+T logsumexp(int n, const T* const x)
+{
+    T mx = arr_max(n, x);
+    T semx = 0.;
+    for (int i = 0; i < n; i++)
+    {
+        semx = semx + exp(x[i] - mx);
+    }
+    return log(semx) + mx;
+}
+
+template<typename T>
+T log_wishart_prior(int p, int k,
+    Wishart wishart,
+    const T* const sum_qs,
+    const T* const Qdiags,
+    const T* const icf)
+{
+    int n = p + wishart.m + 1;
+    int icf_sz = p * (p + 1) / 2;
+
+    double C = n * p * (log(wishart.gamma) - 0.5 * log(2)) - log_gamma_distrib(0.5 * n, p);
+
+    T out = 0;
+    for (int ik = 0; ik < k; ik++)
+    {
+        T frobenius = sqnorm(p, &Qdiags[ik * p]) + sqnorm(icf_sz - p, &icf[ik * icf_sz + p]);
+        out = out + 0.5 * wishart.gamma * wishart.gamma * (frobenius)
+            -wishart.m * sum_qs[ik];
+    }
+
+    return out - k * C;
+}
+
+template<typename T>
+void preprocess_qs(int d, int k,
+    const T* const icf,
+    T* sum_qs,
+    T* Qdiags)
+{
+    int icf_sz = d * (d + 1) / 2;
+    for (int ik = 0; ik < k; ik++)
+    {
+        sum_qs[ik] = 0.;
+        for (int id = 0; id < d; id++)
+        {
+            T q = icf[ik * icf_sz + id];
+            sum_qs[ik] = sum_qs[ik] + q;
+            Qdiags[ik * d + id] = exp(q);
+        }
+    }
+}
+
+template<typename T>
+void Qtimesx(int d,
+    const T* const Qdiag,
+    const T* const ltri, // strictly lower triangular part
+    const T* const x,
+    T* out)
+{
+    for (int id = 0; id < d; id++)
+        out[id] = Qdiag[id] * x[id];
+
+    int Lparamsidx = 0;
+    for (int i = 0; i < d; i++)
+    {
+        for (int j = i + 1; j < d; j++)
+        {
+            out[j] = out[j] + ltri[Lparamsidx] * x[i];
+            Lparamsidx++;
+        }
+    }
+}
+
+template<typename T>
+void gmm_objective(int d, int k, int n,
+    const T* const alphas,
+    const T* const means,
+    const T* const icf,
+    const double* const x,
+    Wishart wishart,
+    T* err)
+{
+    const double CONSTANT = -n * d * 0.5 * log(2 * PI);
+    int icf_sz = d * (d + 1) / 2;
+
+    vector<T> Qdiags(d * k);
+    vector<T> sum_qs(k);
+    vector<T> xcentered(d);
+    vector<T> Qxcentered(d);
+    vector<T> main_term(k);
+
+    preprocess_qs(d, k, icf, &sum_qs[0], &Qdiags[0]);
+
+    T slse = 0.;
+    for (int ix = 0; ix < n; ix++)
+    {
+        for (int ik = 0; ik < k; ik++)
+        {
+            subtract(d, &x[ix * d], &means[ik * d], &xcentered[0]);
+            Qtimesx(d, &Qdiags[ik * d], &icf[ik * icf_sz + d], &xcentered[0], &Qxcentered[0]);
+
+            main_term[ik] = alphas[ik] + sum_qs[ik] - 0.5 * sqnorm(d, &Qxcentered[0]);
+        }
+        slse = slse + logsumexp(k, &main_term[0]);
+    }
+
+    T lse_alphas = logsumexp(k, alphas);
+
+    *err = CONSTANT + slse - n * lse_alphas;
+
+    *err = *err + log_wishart_prior(d, k, wishart, &sum_qs[0], &Qdiags[0], icf);
+}
+
+template<typename T>
+void gmm_objective_split_inner(int d, int k,
+    const T* const alphas,
+    const T* const means,
+    const T* const icf,
+    const double* const x,
+    Wishart wishart,
+    T* err)
+{
+    int icf_sz = d * (d + 1) / 2;
+
+    T* Ldiag = new T[d];
+    T* xcentered = new T[d];
+    T* mahal = new T[d];
+    T* lse = new T[k];
+
+    for (int ik = 0; ik < k; ik++)
+    {
+        int icf_off = ik * icf_sz;
+        T sumlog_Ldiag(0.);
+        for (int id = 0; id < d; id++)
+        {
+            sumlog_Ldiag = sumlog_Ldiag + icf[icf_off + id];
+            Ldiag[id] = exp(icf[icf_off + id]);
+        }
+
+        for (int id = 0; id < d; id++)
+        {
+            xcentered[id] = x[id] - means[ik * d + id];
+            mahal[id] = Ldiag[id] * xcentered[id];
+        }
+        int Lparamsidx = d;
+        for (int i = 0; i < d; i++)
+        {
+            for (int j = i + 1; j < d; j++)
+            {
+                mahal[j] = mahal[j] + icf[icf_off + Lparamsidx] * xcentered[i];
+                Lparamsidx++;
+            }
+        }
+        T sqsum_mahal(0.);
+        for (int id = 0; id < d; id++)
+        {
+            sqsum_mahal = sqsum_mahal + mahal[id] * mahal[id];
+        }
+
+        lse[ik] = alphas[ik] + sumlog_Ldiag - 0.5 * sqsum_mahal;
+    }
+
+    *err = logsumexp(k, lse);
+
+    delete[] mahal;
+    delete[] xcentered;
+    delete[] Ldiag;
+    delete[] lse;
+}
+
+template<typename T>
+void gmm_objective_split_other(int d, int k, int n,
+    const T* const alphas,
+    const T* const means,
+    const T* const icf,
+    Wishart wishart,
+    T* err)
+{
+    const double CONSTANT = -n * d * 0.5 * log(2 * PI);
+
+    T lse_alphas = logsumexp(k, alphas);
+
+    T* sum_qs = new T[k];
+    T* Qdiags = new T[d * k];
+    preprocess_qs(d, k, icf, sum_qs, Qdiags);
+    *err = CONSTANT - n * lse_alphas + log_wishart_prior(d, k, wishart, sum_qs, Qdiags, icf);
+    delete[] sum_qs;
+    delete[] Qdiags;
+}

--- a/cpp/adbench/shared/hello.h
+++ b/cpp/adbench/shared/hello.h
@@ -1,0 +1,5 @@
+#pragma once
+
+double hello_objective(double x) {
+  return x * x;
+}

--- a/cpp/adbench/shared/ht_light_matrix.h
+++ b/cpp/adbench/shared/ht_light_matrix.h
@@ -1,0 +1,276 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+// https://github.com/microsoft/ADBench/blob/38cb7931303a830c3700ca36ba9520868327ac87/src/cpp/shared/hand_light_matrix.h
+
+#pragma once
+
+#include <vector>
+#include <string>
+
+#include "matrix.h"
+#include "defs.h"
+
+using std::vector;
+using std::string;
+
+////////////////////////////////////////////////////////////
+//////////////////// Declarations //////////////////////////
+////////////////////////////////////////////////////////////
+
+// theta: 26 [global rotation, global translation, finger parameters (4*5)]
+// data: data measurements and hand model
+// err: 3*number_of_correspondences
+template<typename T>
+void hand_objective(
+  const T* const theta,
+  const HandDataLightMatrix& data,
+  T *err);
+
+// theta: 26 [global rotation, global translation, finger parameters (4*5)]
+// us: 2*number_of_correspondences
+// data: data measurements and hand model
+// err: 3*number_of_correspondences
+template<typename T>
+void hand_objective(
+  const T* const theta,
+  const T* const us,
+  const HandDataLightMatrix& data,
+  T *err);
+
+////////////////////////////////////////////////////////////
+//////////////////// Definitions ///////////////////////////
+////////////////////////////////////////////////////////////
+
+
+template<typename T>
+void angle_axis_to_rotation_matrix(
+  const T* const angle_axis,
+  LightMatrix<T> *pR)
+{
+  T norm = sqrt(sqnorm(3, angle_axis));
+  if (norm < .0001)
+  {
+    pR->set_identity();
+    return;
+  }
+
+  T x = angle_axis[0] / norm;
+  T y = angle_axis[1] / norm;
+  T z = angle_axis[2] / norm;
+
+  T s = sin(norm);
+  T c = cos(norm);
+
+  auto& R = *pR;
+  R(0, 0) = x*x + (1 - x*x)*c; R(0, 1) = x*y*(1 - c) - z*s; R(0, 2) = x*z*(1 - c) + y*s;
+  R(1, 0) = x*y*(1 - c) + z*s; R(1, 1) = y*y + (1 - y*y)*c; R(1, 2) = y*z*(1 - c) - x*s;
+  R(2, 0) = x*z*(1 - c) - y*s; R(2, 1) = z*y*(1 - c) + x*s; R(2, 2) = z*z + (1 - z*z)*c;
+}
+
+template<typename T>
+void apply_global_transform(
+  const LightMatrix<T>& pose_params,
+  LightMatrix<T>* positions)
+{
+  LightMatrix<T> R(3, 3);
+  angle_axis_to_rotation_matrix(pose_params.get_col(0), &R);
+
+  for (int i = 0; i < 3; i++)
+    R.scale_col(i, pose_params(i, 1));
+
+  LightMatrix<T> tmp;
+  mat_mult(R, *positions, &tmp);
+  for (int j = 0; j < positions->ncols_; j++)
+    for (int i = 0; i < positions->nrows_; i++)
+      (*positions)(i, j) = tmp(i, j) + pose_params(i, 2);
+}
+
+template<typename T>
+void relatives_to_absolutes(
+  const vector<LightMatrix<T>>& relatives,
+  const vector<int>& parents,
+  vector<LightMatrix<T>>* pabsolutes)
+{
+  auto& absolutes = *pabsolutes;
+  absolutes.resize(parents.size());
+  for (size_t i = 0; i < parents.size(); i++)
+  {
+    if (parents[i] == -1)
+      absolutes[i] = relatives[i];
+    else
+      mat_mult(absolutes[parents[i]], relatives[i], &absolutes[i]);
+  }
+}
+
+template<typename T>
+void euler_angles_to_rotation_matrix(
+  const T* const xzy,
+  LightMatrix<T> *pR)
+{
+  T tx = xzy[0], ty = xzy[2], tz = xzy[1];
+  LightMatrix<T> Rx(3, 3), Ry(3, 3), Rz(3, 3);
+  Rx.set_identity();
+  Rx(1, 1) = cos(tx);
+  Rx(2, 1) = sin(tx);
+  Rx(1, 2) = -Rx(2, 1);
+  Rx(2, 2) = Rx(1, 1);
+
+  Ry.set_identity();
+  Ry(0, 0) = cos(ty);
+  Ry(0, 2) = sin(ty);
+  Ry(2, 0) = -Ry(0, 2);
+  Ry(2, 2) = Ry(0, 0);
+
+  Rz.set_identity();
+  Rz(0, 0) = cos(tz);
+  Rz(1, 0) = sin(tz);
+  Rz(0, 1) = -Rz(1, 0);
+  Rz(1, 1) = Rz(0, 0);
+
+  LightMatrix<T> tmp;
+  mat_mult(Rz, Ry, &tmp);
+  mat_mult(tmp, Rx, pR);
+}
+
+template<typename T>
+void get_posed_relatives(
+  const HandModelLightMatrix& model,
+  const LightMatrix<T>& pose_params,
+  vector<LightMatrix<T>>* prelatives)
+{
+  auto& relatives = *prelatives;
+  relatives.resize(model.base_relatives.size());
+
+  int offset = 3;
+  for (size_t i = 0; i < model.bone_names.size(); i++)
+  {
+    LightMatrix<T> tr(4, 4);
+    tr.set_identity();
+
+    LightMatrix<T> R(3, 3);
+    euler_angles_to_rotation_matrix(pose_params.get_col((int)i + offset), &R);
+    tr.set_block(0, 0, R);
+
+    mat_mult(model.base_relatives[i], tr, &relatives[i]);
+  }
+}
+
+template<typename T>
+void get_skinned_vertex_positions(
+  const HandModelLightMatrix& model,
+  const LightMatrix<T>& pose_params,
+  LightMatrix<T>* ppositions,
+  bool apply_global)
+{
+  vector<LightMatrix<T>> relatives, absolutes, transforms;
+  get_posed_relatives(model, pose_params, &relatives);
+  relatives_to_absolutes(relatives, model.parents, &absolutes);
+
+  // Get bone transforms.
+  transforms.resize(absolutes.size());
+  for (size_t i = 0; i < absolutes.size(); i++)
+  {
+    mat_mult(absolutes[i], model.inverse_base_absolutes[i], &transforms[i]);
+  }
+
+  // Transform vertices by necessary transforms. + apply skinning
+  auto& positions = *ppositions;
+  positions.resize(3, model.base_positions.ncols_);
+  positions.fill(0.);
+  LightMatrix<T> curr_positions(4, model.base_positions.ncols_);
+  for (size_t i_bone = 0; i_bone < transforms.size(); i_bone++)
+  {
+    mat_mult(transforms[i_bone], model.base_positions, &curr_positions);
+    for (int i_vert = 0; i_vert < positions.ncols_; i_vert++)
+      for (int i = 0; i < 3; i++)
+        positions(i, i_vert) += curr_positions(i, i_vert) * model.weights((int)i_bone, i_vert);
+  }
+
+  if (model.is_mirrored)
+    positions.scale_row(0, -1);
+
+  if (apply_global)
+    apply_global_transform(pose_params, &positions);
+}
+
+//% !!!!!!! fixed order pose_params !!!!!
+//% 1) global_rotation 2) scale 3) global_translation
+//% 4) wrist
+//% 5) thumb1, 6)thumb2, 7) thumb3, 8) thumb4
+//%       similarly: index, middle, ring, pinky
+//%       end) forearm
+template<typename T>
+void to_pose_params(const T* const theta,
+  const vector<string>& bone_names,
+  LightMatrix<T> *ppose_params)
+{
+  auto& pose_params = *ppose_params;
+  pose_params.resize(3, (int)bone_names.size() + 3);
+  pose_params.fill(0.);
+
+  pose_params.set_col(0, &theta[0]);
+  pose_params.set_col(1, 1.);
+  pose_params.set_col(2, &theta[3]);
+
+  int i_theta = 6;
+  int i_pose_params = 5;
+  int n_fingers = 5;
+  for (int i_finger = 0; i_finger < n_fingers; i_finger++)
+  {
+    for (int i = 2; i <= 4; i++)
+    {
+      pose_params(0, i_pose_params) = theta[i_theta++];
+      if (i == 2)
+      {
+        pose_params(1, i_pose_params) = theta[i_theta++];
+      }
+      i_pose_params++;
+    }
+    i_pose_params++;
+  }
+}
+
+template<typename T>
+void hand_objective(
+  const T* const theta,
+  const HandDataLightMatrix& data,
+  T *err)
+{
+  LightMatrix<T> pose_params;
+  to_pose_params(theta, data.model.bone_names, &pose_params);
+
+  LightMatrix<T> vertex_positions;
+  get_skinned_vertex_positions(data.model, pose_params, &vertex_positions, true);
+
+  for (size_t i = 0; i < data.correspondences.size(); i++)
+    for (int j = 0; j < 3; j++)
+      err[i * 3 + j] = data.points(j, i) - vertex_positions(j, data.correspondences[i]);  
+}
+
+template<typename T>
+void hand_objective(
+  const T* const theta,
+  const T* const us,
+  const HandDataLightMatrix& data,
+  T *err)
+{
+  LightMatrix<T> pose_params;
+  to_pose_params(theta, data.model.bone_names, &pose_params);
+
+  LightMatrix<T> vertex_positions;
+  get_skinned_vertex_positions(data.model, pose_params, &vertex_positions, true);
+
+  for (size_t i = 0; i < data.correspondences.size(); i++)
+  {
+    const auto& verts = data.model.triangles[data.correspondences[i]].verts;
+    const T* const u = &us[2 * i];
+    for (int j = 0; j < 3; j++)
+    {
+      T hand_point_coord = u[0] * vertex_positions(j, verts[0]) + u[1] * vertex_positions(j, verts[1])
+        + (1. - u[0] - u[1])*vertex_positions(j, verts[2]);
+
+      err[i * 3 + j] = data.points(j, i) - hand_point_coord;
+    }
+  }
+}

--- a/cpp/adbench/shared/lstm.h
+++ b/cpp/adbench/shared/lstm.h
@@ -1,0 +1,219 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+// https://github.com/microsoft/ADBench/blob/38cb7931303a830c3700ca36ba9520868327ac87/src/cpp/shared/lstm.h
+
+#pragma once
+#pragma warning (disable : 4996) // fopen
+
+#include <vector>
+#include <cmath>
+#include <string>
+
+// UTILS
+
+// Sigmoid on scalar
+template<typename T>
+T sigmoid(T x) {
+    return 1 / (1 + std::exp(-x));
+}
+
+// log(sum(exp(x), 2))
+template<typename T>
+T logsumexp(const T* vect, int sz) {
+    T sum = 0.0;
+    for (int i = 0; i < sz; ++i)
+        sum += std::exp(vect[i]);
+    sum += 2;
+    return log(sum);
+}
+
+// log(sum(exp(x), 2))
+template<typename T>
+T logsumexp_store_temps(const T* vect, int sz) {
+    std::vector<T> vect2(sz);
+    for (int i = 0; i < sz; ++i)
+        vect2[i] = exp(vect[i]);
+    T sum = 0.0;
+    for (int i = 0; i < sz; ++i)
+        sum += vect2[i];
+    sum += 2;
+    return log(sum);
+}
+
+// Helper structures
+
+template<typename T>
+struct WeightOrBias
+{
+    const T* forget;
+    const T* ingate;
+    const T* outgate;
+    const T* change;
+
+    WeightOrBias(const T* params, int hsize) :
+        forget(params),
+        ingate(&params[hsize]),
+        outgate(&params[2 * hsize]),
+        change(&params[3 * hsize])
+    {}
+};
+
+template<typename T>
+struct LayerParams
+{
+    const WeightOrBias<T> weight;
+    const WeightOrBias<T> bias;
+
+    LayerParams(const T* layer_params, int hsize) :
+        weight(layer_params, hsize),
+        bias(&layer_params[hsize * 4], hsize)
+    {}
+};
+
+template<typename T>
+struct MainParams
+{
+    std::vector<LayerParams<T>> layer_params;
+
+    MainParams(const T* main_params, int hsize, int n_layers)
+    {
+        layer_params.reserve(n_layers);
+        for (int i = 0; i < n_layers; ++i)
+        {
+            layer_params.emplace_back(&main_params[8 * hsize * i], hsize);
+        }
+    }
+};
+
+template<typename T>
+struct ExtraParams
+{
+    const T* in_weight;
+    const T* out_weight;
+    const T* out_bias;
+
+    ExtraParams(const T* params, int hsize) :
+        in_weight(params),
+        out_weight(&params[hsize]),
+        out_bias(&params[2 * hsize])
+    {}
+};
+
+template<typename T>
+struct InputSequence
+{
+    std::vector<const T*> sequence;
+
+    InputSequence(const T* input_sequence, int char_bits, int char_count)
+    {
+        sequence.reserve(char_count);
+        for (int i = 0; i < char_count; ++i)
+        {
+            sequence.push_back(&input_sequence[char_bits * i]);
+        }
+    }
+};
+
+template<typename T>
+struct LayerState
+{
+    T* hidden;
+    T* cell;
+
+    LayerState(T* layer_state, int hsize) :
+        hidden(layer_state),
+        cell(&layer_state[hsize])
+    {}
+};
+
+template<typename T>
+struct State
+{
+    std::vector<LayerState<T>> layer_state;
+
+    State(T* state, int hsize, int n_layers)
+    {
+        layer_state.reserve(n_layers);
+        for (int i = 0; i < n_layers; ++i)
+        {
+            layer_state.emplace_back(&state[2 * hsize * i], hsize);
+        }
+    }
+};
+
+// LSTM OBJECTIVE
+
+// The LSTM model
+template<typename T>
+void lstm_model(int hsize,
+    const LayerParams<T>& params,
+    LayerState<T>& state,
+    const T* input)
+{
+    for (int i = 0; i < hsize; ++i) {
+        // gates for i-th cell/hidden
+        T forget = sigmoid(input[i] * params.weight.forget[i] + params.bias.forget[i]);
+        T ingate = sigmoid(state.hidden[i] * params.weight.ingate[i] + params.bias.ingate[i]);
+        T outgate = sigmoid(input[i] * params.weight.outgate[i] + params.bias.outgate[i]);
+        T change = tanh(state.hidden[i] * params.weight.change[i] + params.bias.change[i]);
+
+        state.cell[i] = state.cell[i] * forget + ingate * change;
+        state.hidden[i] = outgate * tanh(state.cell[i]);
+    }
+}
+    
+// Predict LSTM output given an input
+template<typename T>
+void lstm_predict(int l, int b,
+    const MainParams<T>& main_params, const ExtraParams<T>& extra_params,
+    State<T>& state,
+    const T* input, T* output)
+{
+    for (int i = 0; i < b; ++i)
+        output[i] = input[i] * extra_params.in_weight[i];
+
+    T* layer_output = output;
+
+    for (int i = 0; i < l; ++i)
+    {
+        lstm_model(b, main_params.layer_params[i], state.layer_state[i], layer_output);
+        layer_output = state.layer_state[i].hidden;
+    }
+
+    for (int i = 0; i < b; ++i)
+        output[i] = layer_output[i] * extra_params.out_weight[i] + extra_params.out_bias[i];
+}
+    
+
+// LSTM objective (loss function)
+template<typename T>
+void lstm_objective(int l, int c, int b, 
+    const T* main_params, const T* extra_params,
+    std::vector<T> state, const T* sequence,
+    T* loss)
+{
+    T total = 0.0;
+    int count = 0;
+    MainParams<T> main_params_wrap(main_params, b, l);
+    ExtraParams<T> extra_params_wrap(extra_params, b);
+    State<T> state_wrap(state.data(), b, l);
+    InputSequence<T> sequence_wrap(sequence, b, c);
+    std::vector<T> ypred(b), ynorm(b);
+    for (int t = 0; t < c - 1; ++t)
+    {
+        lstm_predict(l, b, main_params_wrap, extra_params_wrap, state_wrap, sequence_wrap.sequence[t], ypred.data());
+
+        T lse = logsumexp(ypred.data(), b);
+        for (int i = 0; i < b; ++i)
+            ynorm[i] = ypred[i] - lse;
+
+        const T* ygold = sequence_wrap.sequence[t + 1];
+        for (int i = 0; i < b; ++i)
+            total += ygold[i] * ynorm[i];
+
+        count += b;
+    }
+
+    *loss = -total / count;
+}

--- a/cpp/adbench/shared/matrix.h
+++ b/cpp/adbench/shared/matrix.h
@@ -1,0 +1,192 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+// https://github.com/microsoft/ADBench/blob/38cb7931303a830c3700ca36ba9520868327ac87/src/cpp/shared/matrix.h
+
+#pragma once
+
+#include <cmath>
+
+#include "defs.h"
+
+////////////////////////////////////////////////////////////
+//////////////////// Declarations //////////////////////////
+////////////////////////////////////////////////////////////
+
+// This throws error on n<1
+template<typename T>
+T arr_max(int n, const T* const x);
+template<typename T>
+int arr_max_idx(int n, const T* const x);
+
+template<typename T>
+T sqnorm(int n, const T* const x);
+
+template<typename T>
+void cross(
+    const T* const a,
+    const T* const b,
+    T* out);
+
+// out = a - b
+template<typename T1, typename T2, typename T3>
+void subtract(int d,
+    const T1* const x,
+    const T2* const y,
+    T3* out);
+
+// Multiplies n-dimensional vector x by a scalar factor
+// Writes the result to n-dimensional vector out
+template<typename T1, typename T2, typename T3>
+void scale(int n, T1 factor, const T2* const x, T3* out);
+
+// Multiplies n * m matrix x by m * p matrix y
+// Writes result to n * p matrix out
+// Matrices are stored column-major
+template<typename T1, typename T2, typename T3>
+void mat_mul(int n, int m, int p, const T1* const x, const T2* const y, T3* out);
+
+// Adds n-dimensional vector x to n-dimensional vector acc
+// Writes result to acc
+template<typename T>
+void add_to(int n, T* acc, const T* const x);
+
+// Dot product of n-dimensional vectors x and y
+// n must be greater or equal than 1
+// n < 1 is UNDEFINED BEHAVIOR
+template<typename T>
+T dot(int n, const T* const x, const T* const y);
+
+template<typename T>
+void p2e(
+    const T* const projective_coord,
+    T* euclidean_coord);
+
+////////////////////////////////////////////////////////////
+//////////////////// Definitions ///////////////////////////
+////////////////////////////////////////////////////////////
+
+// inline so that it could be defined in the header
+inline double log_gamma_distrib(double a, double p)
+{
+    double out = 0.25 * p * (p - 1) * log(PI);
+    for (int j = 1; j <= p; j++)
+    {
+        out = out + lgamma(a + 0.5 * (1 - j));
+    }
+    return out;
+}
+
+// This throws error on n<1
+template<typename T>
+T arr_max(int n, const T* const x)
+{
+    T m = x[0];
+    for (int i = 1; i < n; i++)
+    {
+#ifdef TOOL_ADEPT
+        if (m < x[i])
+            m = x[i];
+#else
+        m = fmax(m, x[i]);
+#endif
+    }
+    return m;
+}
+
+template<typename T>
+int arr_max_idx(int n, const T* const x)
+{
+    int max_idx = 0;
+    for (int i = 1; i < n; i++)
+    {
+        if (x[max_idx] < x[i])
+        {
+            max_idx = i;
+        }
+    }
+    return max_idx;
+}
+
+template<typename T>
+T sqnorm(int n, const T* const x)
+{
+    T res = x[0] * x[0];
+    for (int i = 1; i < n; i++)
+        res = res + x[i] * x[i];
+    return res;
+}
+
+template<typename T>
+void cross(
+    const T* const a,
+    const T* const b,
+    T* out)
+{
+    out[0] = a[1] * b[2] - a[2] * b[1];
+    out[1] = a[2] * b[0] - a[0] * b[2];
+    out[2] = a[0] * b[1] - a[1] * b[0];
+}
+
+// out = a - b
+template<typename T1, typename T2, typename T3>
+void subtract(int d,
+    const T1* const x,
+    const T2* const y,
+    T3* out)
+{
+    for (int id = 0; id < d; id++)
+    {
+        out[id] = x[id] - y[id];
+    }
+}
+
+template<typename T1, typename T2, typename T3>
+void scale(int n, T1 factor, const T2* const x, T3* out)
+{
+    for (int i = 0; i < n; ++i)
+        out[i] = factor * x[i];
+}
+
+template<typename T1, typename T2, typename T3>
+void mat_mul(int n, int m, int p, const T1* const x, const T2* const y, T3* out)
+{
+    for (int i = 0; i < n; ++i)
+    {
+        for (int j = 0; j < p; ++j)
+        {
+            double rij = 0;
+            for (int k = 0; k < m; ++k)
+            {
+                rij += x[k * n + i] * y[j * m + k];
+            }
+            out[j * n + i] = rij;
+        }
+    }
+}
+
+template<typename T>
+void add_to(int n, T* acc, const T* const x)
+{
+    for (int i = 0; i < n; ++i)
+        acc[i] += x[i];
+}
+
+template<typename T>
+T dot(int n, const T* const x, const T* const y)
+{
+    T acc = x[0] * y[0];
+    for (int i = 1; i < n; ++i)
+        acc += x[i] * y[i];
+
+    return acc;
+}
+
+template<typename T>
+void p2e(
+    const T* const projective_coord,
+    T* euclidean_coord)
+{
+    euclidean_coord[0] = projective_coord[0] / projective_coord[2];
+    euclidean_coord[1] = projective_coord[1] / projective_coord[2];
+}

--- a/tools/finite/.gitignore
+++ b/tools/finite/.gitignore
@@ -1,0 +1,6 @@
+*.o
+run_hello
+run_gmm
+run_ba
+run_lstm
+run_ht

--- a/tools/finite/Dockerfile
+++ b/tools/finite/Dockerfile
@@ -1,0 +1,19 @@
+FROM python:3.11-slim
+
+WORKDIR /home/gradbench
+
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    python3 \
+    wget
+
+COPY cpp /home/gradbench/cpp
+
+RUN make -C cpp
+
+COPY tools/finite/ /home/gradbench/tools/finite
+
+RUN make -j -B -C tools/finite
+
+ENTRYPOINT ["python3", "/home/gradbench/tools/finite/run.py"]
+LABEL org.opencontainers.image.source=https://github.com/gradbench/gradbench

--- a/tools/finite/FiniteBA.cpp
+++ b/tools/finite/FiniteBA.cpp
@@ -1,0 +1,76 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+// https://github.com/microsoft/ADBench/blob/38cb7931303a830c3700ca36ba9520868327ac87/src/cpp/modules/finite/FiniteBA.cpp
+
+// FiniteBA.cpp : Defines the exported functions for the DLL.
+#include "FiniteBA.h"
+#include "adbench/shared/ba.h"
+#include "finite.h"
+
+// This function must be called before any other function.
+void FiniteBA::prepare(BAInput&& input)
+{
+    this->input = input;
+    result = { std::vector<double>(2 * this->input.p), std::vector<double>(this->input.p), BASparseMat(this->input.n, this->input.m, this->input.p) };
+    int n_new_cols = BA_NCAMPARAMS + 3 + 1;
+    reproj_err_d = std::vector<double>(2 * n_new_cols);
+    engine.set_max_output_size(2);
+}
+
+BAOutput FiniteBA::output()
+{
+    return result;
+}
+
+void FiniteBA::calculate_objective(int times)
+{
+    for (int i = 0; i < times; ++i) {
+        ba_objective(input.n, input.m, input.p, input.cams.data(), input.X.data(), input.w.data(),
+            input.obs.data(), input.feats.data(), result.reproj_err.data(), result.w_err.data());
+    }
+}
+
+void FiniteBA::calculate_jacobian(int times)
+{
+    for (int i = 0; i < times; ++i) {
+        result.J.clear();
+        for (int j = 0; j < input.p; ++j)
+        {
+            std::fill(reproj_err_d.begin(), reproj_err_d.end(), (double)0);
+
+            int camIdx = input.obs[2 * j + 0];
+            int ptIdx = input.obs[2 * j + 1];
+
+            engine.finite_differences([&](double* cam_in, double* reproj_err) {
+                computeReprojError(cam_in, &input.X[ptIdx * 3], &input.w[j], &input.feats[2 * j], reproj_err);
+                }, &input.cams[camIdx * BA_NCAMPARAMS], BA_NCAMPARAMS, 2, reproj_err_d.data());
+
+            engine.finite_differences([&](double* X_in, double* reproj_err) {
+                computeReprojError(&input.cams[camIdx * BA_NCAMPARAMS], X_in, &input.w[j], &input.feats[2 * j], reproj_err);
+                }, &input.X[ptIdx * 3], 3, 2, &reproj_err_d.data()[2 * BA_NCAMPARAMS]);
+
+            engine.finite_differences([&](double* w_in, double* reproj_err) {
+                computeReprojError(&input.cams[camIdx * BA_NCAMPARAMS], &input.X[ptIdx * 3], w_in, &input.feats[2 * j], reproj_err);
+                }, &input.w[j], 1, 2, &reproj_err_d.data()[2 * (BA_NCAMPARAMS + 3)]);
+
+            result.J.insert_reproj_err_block(j, camIdx, ptIdx, reproj_err_d.data());
+        }
+
+        double w_d;
+
+        for (int j = 0; j < input.p; ++j)
+        {
+            engine.finite_differences([&](double* w_in, double* w_er) {
+                computeZachWeightError(w_in, w_er);
+                }, &input.w[j], 1, 1, &w_d);
+
+            result.J.insert_w_err_block(j, w_d);
+        }
+    }
+}
+
+extern "C" DLL_PUBLIC ITest<BAInput, BAOutput>* get_ba_test()
+{
+    return new FiniteBA();
+}

--- a/tools/finite/FiniteBA.h
+++ b/tools/finite/FiniteBA.h
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+// https://github.com/microsoft/ADBench/blob/38cb7931303a830c3700ca36ba9520868327ac87/src/cpp/modules/finite/FiniteBA.h
+
+#pragma once
+
+#include "adbench/shared/ITest.h"
+#include "adbench/shared/BAData.h"
+#include "finite.h"
+
+#include <vector>
+
+class FiniteBA : public ITest<BAInput, BAOutput> {
+private:
+    BAInput input;
+    BAOutput result;
+    std::vector<double> reproj_err_d;
+    FiniteDifferencesEngine<double> engine;
+
+public:
+    // This function must be called before any other function.
+    virtual void prepare(BAInput&& input) override;
+
+    virtual void calculate_objective(int times) override;
+    virtual void calculate_jacobian(int times) override;
+    virtual BAOutput output() override;
+
+    ~FiniteBA() = default;
+};

--- a/tools/finite/FiniteGMM.cpp
+++ b/tools/finite/FiniteGMM.cpp
@@ -1,0 +1,53 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+// https://github.com/microsoft/ADBench/blob/38cb7931303a830c3700ca36ba9520868327ac87/src/cpp/modules/finite/FiniteGMM.cpp
+
+// FiniteGMM.cpp : Defines the exported functions for the DLL.
+#include "FiniteGMM.h"
+#include "adbench/shared/gmm.h"
+#include "finite.h"
+
+// This function must be called before any other function.
+void FiniteGMM::prepare(GMMInput&& input)
+{
+    this->input = input;
+    int Jcols = (this->input.k * (this->input.d + 1) * (this->input.d + 2)) / 2;
+    result = { 0,  std::vector<double>(Jcols) };
+    engine.set_max_output_size(1);
+}
+
+GMMOutput FiniteGMM::output()
+{
+    return result;
+}
+
+void FiniteGMM::calculate_objective(int times)
+{
+    for (int i = 0; i < times; ++i) {
+        gmm_objective(input.d, input.k, input.n, input.alphas.data(), input.means.data(),
+            input.icf.data(), input.x.data(), input.wishart, &result.objective);
+    }
+}
+
+void FiniteGMM::calculate_jacobian(int times)
+{
+    for (int i = 0; i < times; ++i) {
+        engine.finite_differences([&](double* alphas_in, double* err) {
+            gmm_objective(input.d, input.k, input.n, alphas_in, input.means.data(), input.icf.data(), input.x.data(), input.wishart, err);
+            }, input.alphas.data(), input.alphas.size(), 1, result.gradient.data());
+
+        engine.finite_differences([&](double* means_in, double* err) {
+            gmm_objective(input.d, input.k, input.n, input.alphas.data(), means_in, input.icf.data(), input.x.data(), input.wishart, err);
+            }, input.means.data(), input.means.size(), 1, &result.gradient.data()[input.k]);
+
+        engine.finite_differences([&](double* icf_in, double* err) {
+            gmm_objective(input.d, input.k, input.n, input.alphas.data(), input.means.data(), icf_in, input.x.data(), input.wishart, err);
+            }, input.icf.data(), input.icf.size(), 1, &result.gradient.data()[input.k + input.d * input.k]);
+    }
+}
+
+extern "C" DLL_PUBLIC ITest<GMMInput, GMMOutput>* get_gmm_test()
+{
+    return new FiniteGMM();
+}

--- a/tools/finite/FiniteGMM.h
+++ b/tools/finite/FiniteGMM.h
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+// https://github.com/microsoft/ADBench/blob/38cb7931303a830c3700ca36ba9520868327ac87/src/cpp/modules/finite/FiniteGMM.h
+
+#pragma once
+
+#include "adbench/shared/ITest.h"
+#include "adbench/shared/GMMData.h"
+#include "finite.h"
+
+class FiniteGMM : public ITest<GMMInput, GMMOutput> {
+    GMMInput input;
+    GMMOutput result;
+    FiniteDifferencesEngine<double> engine;
+
+public:
+    // This function must be called before any other function.
+    void prepare(GMMInput&& input) override;
+
+    void calculate_objective(int times) override;
+    void calculate_jacobian(int times) override;
+    GMMOutput output() override;
+
+    ~FiniteGMM() = default;
+};

--- a/tools/finite/FiniteHT.cpp
+++ b/tools/finite/FiniteHT.cpp
@@ -1,0 +1,82 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+// https://github.com/microsoft/ADBench/blob/38cb7931303a830c3700ca36ba9520868327ac87/src/cpp/modules/finite/FiniteHand.cpp
+
+// Changes made: fixed trivial warnings.
+
+#include "FiniteHT.h"
+
+#include "adbench/shared/ht_light_matrix.h"
+#include "finite.h"
+
+// This function must be called before any other function.
+void FiniteHand::prepare(HandInput&& input)
+{
+    this->input = input;
+    complicated = this->input.us.size() != 0;
+    int err_size = 3 * this->input.data.correspondences.size();
+    int ncols = (complicated ? 2 : 0) + this->input.theta.size();
+    result = { std::vector<double>(err_size), ncols, err_size, std::vector<double>(err_size * ncols) };
+    engine.set_max_output_size(err_size);
+    if (complicated)
+        jacobian_by_us = std::vector<double>(2 * err_size);
+}
+
+HandOutput FiniteHand::output()
+{
+    return result;
+}
+
+void FiniteHand::calculate_objective(int times)
+{
+    if (complicated)
+    {
+        for (int i = 0; i < times; ++i) {
+            hand_objective(input.theta.data(), input.us.data(), input.data, result.objective.data());
+        }
+    }
+    else
+    {
+        for (int i = 0; i < times; ++i) {
+            hand_objective(input.theta.data(), input.data, result.objective.data());
+        }
+    }
+}
+
+void FiniteHand::calculate_jacobian(int times)
+{
+    if (complicated)
+    {
+        for (int i = 0; i < times; ++i) {
+            engine.finite_differences([&](double* theta_in, double* err) {
+                hand_objective(theta_in, input.us.data(), input.data, err);
+                }, input.theta.data(), input.theta.size(), result.objective.size(), &result.jacobian.data()[6 * input.data.correspondences.size()]);
+
+            for (unsigned int j = 0; j < input.us.size() / 2; ++j) {
+                engine.finite_differences([&](double* us_in, double* err) {
+                    // us_in points into the middle of _input.us.data()
+                    hand_objective(input.theta.data(), input.us.data(), input.data, err);
+                    }, &input.us.data()[j * 2], 2, result.objective.size(), jacobian_by_us.data());
+
+                for (int k = 0; k < 3; ++k) {
+                    result.jacobian[j * 3 + k] = jacobian_by_us[j * 3 + k];
+                    result.jacobian[j * 3 + k + result.objective.size()] = jacobian_by_us[j * 3 + k + result.objective.size()];
+                }
+            }
+        }
+    }
+    else
+    {
+        for (int i = 0; i < times; ++i) {
+            engine.finite_differences([&](double* theta_in, double* err) {
+                hand_objective(theta_in, input.data, err);
+                }, input.theta.data(), input.theta.size(), result.objective.size(), result.jacobian.data());
+        }
+    }
+}
+
+extern "C" DLL_PUBLIC ITest<HandInput, HandOutput>* get_hand_test()
+{
+    return new FiniteHand();
+}

--- a/tools/finite/FiniteHT.h
+++ b/tools/finite/FiniteHT.h
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+// https://github.com/microsoft/ADBench/blob/38cb7931303a830c3700ca36ba9520868327ac87/src/cpp/modules/finite/FiniteHand.h
+
+#pragma once
+
+#include "adbench/shared/ITest.h"
+#include "adbench/shared/HTData.h"
+#include "finite.h"
+
+class FiniteHand : public ITest<HandInput, HandOutput> {
+    HandInput input;
+    HandOutput result;
+    bool complicated = false;
+    std::vector<double> jacobian_by_us;
+    FiniteDifferencesEngine<double> engine;
+
+public:
+    // This function must be called before any other function.
+    void prepare(HandInput&& input) override;
+
+    void calculate_objective(int times) override;
+    void calculate_jacobian(int times) override;
+    HandOutput output() override;
+
+    ~FiniteHand() = default;
+};

--- a/tools/finite/FiniteHello.cpp
+++ b/tools/finite/FiniteHello.cpp
@@ -1,0 +1,30 @@
+#include "FiniteHello.h"
+#include "adbench/shared/hello.h"
+#include "finite.h"
+
+void FiniteHello::prepare(HelloInput&& input)
+{
+    _input = input;
+    engine.set_max_output_size(1);
+}
+
+HelloOutput FiniteHello::output()
+{
+    return _output;
+}
+
+void FiniteHello::calculate_objective(int times)
+{
+    for (int i = 0; i < times; ++i) {
+      _output.objective = hello_objective(_input.x);
+    }
+}
+
+void FiniteHello::calculate_jacobian(int times)
+{
+  for (int i = 0; i < times; ++i) {
+    engine.finite_differences([&](double* x, double *out) {
+      *out = hello_objective(*x);
+    }, &_input.x, 1, 1, &_output.gradient);
+  }
+}

--- a/tools/finite/FiniteHello.h
+++ b/tools/finite/FiniteHello.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "adbench/shared/ITest.h"
+#include "adbench/shared/HelloData.h"
+#include "finite.h"
+
+#include <vector>
+
+class FiniteHello : public ITest<HelloInput, HelloOutput> {
+private:
+    HelloInput _input;
+    HelloOutput _output;
+    FiniteDifferencesEngine<double> engine;
+
+public:
+    // This function must be called before any other function.
+    virtual void prepare(HelloInput&& input) override;
+
+    virtual void calculate_objective(int times) override;
+    virtual void calculate_jacobian(int times) override;
+    virtual HelloOutput output() override;
+
+    ~FiniteHello() = default;
+};

--- a/tools/finite/FiniteLSTM.cpp
+++ b/tools/finite/FiniteLSTM.cpp
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+// https://github.com/microsoft/ADBench/blob/38cb7931303a830c3700ca36ba9520868327ac87/src/cpp/modules/finite/FiniteLSTM.cpp
+
+#include "FiniteLSTM.h"
+#include "adbench/shared/lstm.h"
+#include "finite.h"
+
+// This function must be called before any other function.
+void FiniteLSTM::prepare(LSTMInput&& input)
+{
+    this->input = input;
+    int Jcols = 8 * this->input.l * this->input.b + 3 * this->input.b;
+    state = std::vector<double>(this->input.state.size());
+    result = { 0, std::vector<double>(Jcols) };
+    engine.set_max_output_size(1);
+}
+
+LSTMOutput FiniteLSTM::output()
+{
+    return result;
+}
+
+void FiniteLSTM::calculate_objective(int times)
+{
+    for (int i = 0; i < times; ++i) {
+        state = input.state;
+        lstm_objective(input.l, input.c, input.b, input.main_params.data(), input.extra_params.data(), state, input.sequence.data(), &result.objective);
+    }
+}
+
+void FiniteLSTM::calculate_jacobian(int times)
+{
+    for (int i = 0; i < times; ++i) {
+        state = input.state;
+        engine.finite_differences([&](double* main_params_in, double* loss) {
+            lstm_objective(input.l, input.c, input.b, main_params_in,
+                input.extra_params.data(), state, input.sequence.data(), loss);
+            }, input.main_params.data(), input.main_params.size(), 1, result.gradient.data());
+
+        engine.finite_differences([&](double* extra_params_in, double* loss) {
+            lstm_objective(input.l, input.c, input.b, input.main_params.data(),
+                extra_params_in, state, input.sequence.data(), loss);
+            }, input.extra_params.data(), input.extra_params.size(), 1, &result.gradient.data()[2 * input.l * 4 * input.b]);
+    }
+}
+
+extern "C" DLL_PUBLIC ITest<LSTMInput, LSTMOutput>*  get_lstm_test()
+{
+    return new FiniteLSTM();
+}

--- a/tools/finite/FiniteLSTM.h
+++ b/tools/finite/FiniteLSTM.h
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+// https://github.com/microsoft/ADBench/blob/38cb7931303a830c3700ca36ba9520868327ac87/src/cpp/modules/finite/FiniteLSTM.h
+
+#pragma once
+
+#include "adbench/shared/ITest.h"
+#include "adbench/shared/LSTMData.h"
+#include "finite.h"
+
+#include <vector>
+
+class FiniteLSTM : public ITest<LSTMInput, LSTMOutput> {
+private:
+    LSTMInput input;
+    LSTMOutput result;
+    std::vector<double> state;
+    FiniteDifferencesEngine<double> engine;
+
+public:
+    // This function must be called before any other function.
+    virtual void prepare(LSTMInput&& input) override;
+
+    virtual void calculate_objective(int times) override;
+    virtual void calculate_jacobian(int times) override;
+    virtual LSTMOutput output() override;
+
+    ~FiniteLSTM() {}
+};

--- a/tools/finite/Makefile
+++ b/tools/finite/Makefile
@@ -1,0 +1,38 @@
+CXX?=c++
+CC?=cc
+CFLAGS=-std=c++17 -O3 -Wall
+LDFLAGS=-lm
+
+UTIL_OBJECTS=../../cpp/adbench/shared/utils.o ../../cpp/adbench/io.o
+HELLO_OBJECTS=FiniteHello.o run_hello.o
+GMM_OBJECTS=FiniteGMM.o run_gmm.o
+BA_OBJECTS=FiniteBA.o run_ba.o
+LSTM_OBJECTS=FiniteLSTM.o run_lstm.o
+HT_OBJECTS=FiniteHT.o run_ht.o
+EXECUTABLES=run_hello run_gmm run_ba run_lstm run_ht
+
+all: $(EXECUTABLES)
+
+run_hello: $(HELLO_OBJECTS) $(UTIL_OBJECTS)
+	$(CXX) -o $@ $^ $(LDFLAGS)
+
+run_ba: $(BA_OBJECTS) $(UTIL_OBJECTS)
+	$(CXX) -o $@ $^ $(LDFLAGS)
+
+run_gmm: $(GMM_OBJECTS) $(UTIL_OBJECTS)
+	$(CXX) -o $@ $^ $(LDFLAGS)
+
+run_lstm: $(LSTM_OBJECTS) $(UTIL_OBJECTS)
+	$(CXX) -o $@ $^ $(LDFLAGS)
+
+run_ht: $(HT_OBJECTS) $(UTIL_OBJECTS)
+	$(CXX) -o $@ $^ $(LDFLAGS)
+
+%.o: %.c
+	$(CC) $< -c -o $@ $(CFLAGS) -I../../cpp
+
+%.o: %.cpp
+	$(CXX) $< -c -o $@ $(CFLAGS) -I../../cpp
+
+clean:
+	rm -f $(UTIL_OBJECTS) $(GMM_OBJECTS) $(BA_OBJECTS) $(LSTM_OBJECTS) $(HT_OBJECTS) $(EXECUTABLES)

--- a/tools/finite/README.md
+++ b/tools/finite/README.md
@@ -1,0 +1,20 @@
+# Finite Differences
+
+This repository contains programs that are differentiated by Finite
+Differences. This is likely to be both slower and less efficient than
+any AD tool, but it is certainly the most convenient option.
+
+To run this outside Docker, you'll first need to run the following
+commands from the GradBench repository root to setup the C++ build and
+build the programs:
+
+```sh
+make -C cpp
+make -C tools/finite
+```
+
+Then, to run the tool itself:
+
+```sh
+python3 tools/finite/run.py
+```

--- a/tools/finite/README.md
+++ b/tools/finite/README.md
@@ -1,12 +1,8 @@
 # Finite Differences
 
-This repository contains programs that are differentiated by Finite
-Differences. This is likely to be both slower and less efficient than
-any AD tool, but it is certainly the most convenient option.
+This tool contains programs that are differentiated by Finite Differences. This is likely to be both slower and less efficient than any AD tool, but it is certainly the most convenient option.
 
-To run this outside Docker, you'll first need to run the following
-commands from the GradBench repository root to setup the C++ build and
-build the programs:
+To run this outside Docker, you'll first need to run the following commands from the GradBench repository root to setup the C++ build and build the programs:
 
 ```sh
 make -C cpp

--- a/tools/finite/ba.py
+++ b/tools/finite/ba.py
@@ -1,0 +1,27 @@
+import json
+import subprocess
+import tempfile
+from os import listdir
+
+
+def compile():
+    # Nothing to do here. We assume everything is precompiled.
+    return True
+
+
+def calculate_objectiveBA(input):
+    with tempfile.NamedTemporaryFile("w") as tmp:
+        json.dump(input, tmp)
+        tmp.flush()
+        return subprocess.run(
+            ["tools/finite/run_ba", tmp.name, "F"], text=True, capture_output=True
+        )
+
+
+def calculate_jacobianBA(input):
+    with tempfile.NamedTemporaryFile("w") as tmp:
+        json.dump(input, tmp)
+        tmp.flush()
+        return subprocess.run(
+            ["tools/finite/run_ba", tmp.name, "J"], text=True, capture_output=True
+        )

--- a/tools/finite/finite.h
+++ b/tools/finite/finite.h
@@ -1,0 +1,143 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+// https://github.com/microsoft/ADBench/blob/38cb7931303a830c3700ca36ba9520868327ac87/src/cpp/modules/finite/finite.h
+
+// Changes made: elimination of trivial warnings.
+
+#pragma once
+
+#include <vector>
+#include <functional>
+#include <algorithm>
+#include <iostream>
+#include <limits>
+#include <cmath>
+
+const double FINITE_DIFFERENCES_DEFAULT_EPSILON = std::cbrt(std::numeric_limits<double>::epsilon());
+const double FINITE_DIFFERENCES_DEFAULT_ZERO_NEIGHBORHOOD_RADIUS = 1;
+const double FINITE_DIFFERENCES_DEFAULT_ZERO_NEIGHBORHOOD_CHARACTERISTIC_SCALE = 1;
+
+/// <summary>Generates a function that returns a value proportional to some characteristic scale
+///     when the argument lies within a neighborhood of zero or a value proportional to the
+///     argument itself otherwise.</summary>
+/// <param name="epsilon">Coefficient by which the value of the input variable is multiplied
+///     to determine the difference to use in finite differentiation when the absolute value
+///     of the said variable is greater or equal to zero_neighborhood_radius</param>
+/// <param name="zero_neighborhood_radius">Radius of the neighborhood of zero where the difference
+///     used in finite differentiation should not be proportional to the input</param>
+/// <param name="zero_neighborhood_characteristic_scale">Value, which when multiplied by epsilon
+///     gives the difference to use in finite differentiation when the absolute value
+///     of the said variable is lesser than zero_neighborhood_radius</param>
+template<typename T>
+std::function<T(T)> finite_differences_default_step_function(T epsilon = FINITE_DIFFERENCES_DEFAULT_EPSILON, T zero_neighborhood_radius = FINITE_DIFFERENCES_DEFAULT_ZERO_NEIGHBORHOOD_RADIUS, T zero_neighborhood_characteristic_scale = FINITE_DIFFERENCES_DEFAULT_ZERO_NEIGHBORHOOD_CHARACTERISTIC_SCALE) {
+    return [epsilon, zero_neighborhood_radius, zero_neighborhood_characteristic_scale](T x) {
+        T absx = std::abs(x);
+        return absx >= zero_neighborhood_radius ? absx * epsilon : zero_neighborhood_characteristic_scale * epsilon;
+    };
+}
+
+// Engine for arrpoximate differentiation using finite differences.
+// Shares temporary memory buffer between calls.
+// Encapsulates a function that chooses the step for finite differences
+// based on the input value.
+template<typename T>
+class FiniteDifferencesEngine
+{
+private:
+    std::vector<T> tmp_output_f;
+    std::vector<T> tmp_output_b;
+    int max_output_size;
+
+    // VECTOR UTILS
+
+    // Subtract B from A
+    static T* sub_vec(T* a, const T* b, int sz) {
+        for (int i = 0; i < sz; ++i)
+            a[i] -= b[i];
+        return a;
+    }
+
+    // Divide vector A by scalar B
+    static T* div_vec(T* a, int a_sz, T b) {
+        for (int i = 0; i < a_sz; ++i)
+            a[i] /= b;
+        return a;
+    }
+
+    // Insert B starting at a point in A
+    static T* vec_ins(T* a, const T* b, int b_sz) {
+        for (int i = 0; i < b_sz; ++i)
+            a[i] = b[i];
+        return a;
+    }
+
+public:
+    // max_output_size - maximum size of the ouputs of the functions
+    // this engine will be able to approximately differentiate.
+    // step_function - a function that chooses the step for finite differences
+    // based on the input value. Defaults to finite_differences_default_step_function().
+    // For fixed step use [](T x){ return STEP_VALUE; }
+    FiniteDifferencesEngine(int max_output_size = 0, std::function<T(T)> step_function = finite_differences_default_step_function<T>()): tmp_output_f(max_output_size), tmp_output_b(max_output_size), max_output_size(max_output_size), step(step_function)
+    {}
+
+    // Computes finite differences step for given argument.
+    std::function<T(T)> step;
+
+    // sets max_output_size - maximum size of the ouputs of the functions
+    // this engine is be able to approximately differentiate
+    void set_max_output_size(int size)
+    {
+        tmp_output_f.resize(size);
+        tmp_output_b.resize(size);
+        max_output_size = size;
+    }
+
+    // gets max_output_size - maximum size of the ouputs of the functions
+    // this engine is be able to approximately differentiate
+    int current_max_output_size()
+    {
+        return max_output_size;
+    }
+
+    // FINITE DIFFERENTIATION FUNCTION
+
+    /// <summary>Approximately differentiate a function using finite differences
+    ///     Step for differentiation is determined separately for every input
+    ///     by calling this.step(input)</summary>
+    /// <param name="func">Function to be differentiated.
+    ///		Should accept 2 pointers as arguments (one input, one output).
+    ///		Each output will be differentiated with respect to each input.</param>
+    /// <param name="input">Pointer to input data (scalar or vector)</param>
+    /// <param name="input_size">Input data size (1 for scalar)</param>
+    /// <param name="output_size">Size of 'func' output data</param>
+    /// <param name="result">Pointer to where resultant Jacobian should go.
+    ///		Will be stored as a vector(input_size * output_size).
+    ///		Will store in format foreach (input) { foreach (output) {} }</param>
+    void finite_differences(std::function<void(T*, T*)> func,
+        T* input, int input_size, int output_size,
+        T* result)
+    {
+        volatile T tmp_f, tmp_b;
+        for (int i = 0; i < input_size; i++)
+        {
+            T originalInput = input[i];
+            T delta = step(originalInput);
+            tmp_b = originalInput - delta;
+            T dx = delta * 2;
+            tmp_f = tmp_b + dx;
+            // adjusting dx so that (tmp_b + dx) - tmp_b == dx
+            dx = tmp_f - tmp_b;
+            if (dx < delta * 0.5)
+                std::cerr << "WARNING: Finite difference step " << delta << " seems incompatible with the argument " << originalInput << std::endl;
+
+            input[i] = tmp_f;
+            func(input, tmp_output_f.data());
+            input[i] = tmp_b;
+            func(input, tmp_output_b.data());
+            div_vec(sub_vec(tmp_output_f.data(), tmp_output_b.data(), output_size), output_size, dx);
+            vec_ins(&result[output_size * i], tmp_output_f.data(), output_size);
+            input[i] = originalInput;
+        }
+    }
+};

--- a/tools/finite/gmm.py
+++ b/tools/finite/gmm.py
@@ -1,0 +1,27 @@
+import json
+import subprocess
+import tempfile
+from os import listdir
+
+
+def compile():
+    # Nothing to do here. We assume everything is precompiled.
+    return True
+
+
+def calculate_objectiveGMM(input):
+    with tempfile.NamedTemporaryFile("w") as tmp:
+        json.dump(input, tmp)
+        tmp.flush()
+        return subprocess.run(
+            ["tools/finite/run_gmm", tmp.name, "F"], text=True, capture_output=True
+        )
+
+
+def calculate_jacobianGMM(input):
+    with tempfile.NamedTemporaryFile("w") as tmp:
+        json.dump(input, tmp)
+        tmp.flush()
+        return subprocess.run(
+            ["tools/finite/run_gmm", tmp.name, "J"], text=True, capture_output=True
+        )

--- a/tools/finite/hello.py
+++ b/tools/finite/hello.py
@@ -1,0 +1,27 @@
+import json
+import subprocess
+import tempfile
+from os import listdir
+
+
+def compile():
+    # Nothing to do here. We assume everything is precompiled.
+    return True
+
+
+def square(input):
+    with tempfile.NamedTemporaryFile("w") as tmp:
+        json.dump(input, tmp)
+        tmp.flush()
+        return subprocess.run(
+            ["tools/finite/run_hello", tmp.name, "F"], text=True, capture_output=True
+        )
+
+
+def double(input):
+    with tempfile.NamedTemporaryFile("w") as tmp:
+        json.dump(input, tmp)
+        tmp.flush()
+        return subprocess.run(
+            ["tools/finite/run_hello", tmp.name, "J"], text=True, capture_output=True
+        )

--- a/tools/finite/ht.py
+++ b/tools/finite/ht.py
@@ -1,0 +1,27 @@
+import json
+import subprocess
+import tempfile
+from os import listdir
+
+
+def compile():
+    # Nothing to do here. We assume everything is precompiled.
+    return True
+
+
+def calculate_objectiveHT(input):
+    with tempfile.NamedTemporaryFile("w") as tmp:
+        json.dump(input, tmp)
+        tmp.flush()
+        return subprocess.run(
+            ["tools/finite/run_ht", tmp.name, "F"], text=True, capture_output=True
+        )
+
+
+def calculate_jacobianHT(input):
+    with tempfile.NamedTemporaryFile("w") as tmp:
+        json.dump(input, tmp)
+        tmp.flush()
+        return subprocess.run(
+            ["tools/finite/run_ht", tmp.name, "J"], text=True, capture_output=True
+        )

--- a/tools/finite/lstm.py
+++ b/tools/finite/lstm.py
@@ -1,0 +1,27 @@
+import json
+import subprocess
+import tempfile
+from os import listdir
+
+
+def compile():
+    # Nothing to do here. We assume everything is precompiled.
+    return True
+
+
+def calculate_objectiveLSTM(input):
+    with tempfile.NamedTemporaryFile("w") as tmp:
+        json.dump(input, tmp)
+        tmp.flush()
+        return subprocess.run(
+            ["tools/finite/run_lstm", tmp.name, "F"], text=True, capture_output=True
+        )
+
+
+def calculate_jacobianLSTM(input):
+    with tempfile.NamedTemporaryFile("w") as tmp:
+        json.dump(input, tmp)
+        tmp.flush()
+        return subprocess.run(
+            ["tools/finite/run_lstm", tmp.name, "J"], text=True, capture_output=True
+        )

--- a/tools/finite/run.py
+++ b/tools/finite/run.py
@@ -1,0 +1,41 @@
+import json
+import sys
+import time
+from importlib import import_module
+
+
+def resolve(module, name):
+    functions = import_module(module)
+    return getattr(functions, name)
+
+
+def run(params):
+    func = resolve(params["module"], params["name"])
+    vals = params["input"]
+
+    # start = time.perf_counter_ns()
+    ret, time = func(vals).stdout.split("\n")
+    # end = time.perf_counter_ns()
+
+    return {"output": json.loads(ret), "nanoseconds": {"evaluate": int(time)}}
+
+
+def main():
+    for line in sys.stdin:
+        message = json.loads(line)
+        response = {}
+        if message["kind"] == "evaluate":
+            response = run(message)
+        elif message["kind"] == "define":
+            try:
+                functions = import_module(message["module"])
+                func = getattr(functions, "compile")
+                success = func()  # compiles C code
+                response["success"] = success
+            except:
+                response["success"] = False
+        print(json.dumps({"id": message["id"]} | response), flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/finite/run_ba.cpp
+++ b/tools/finite/run_ba.cpp
@@ -1,0 +1,11 @@
+#include "FiniteBA.h"
+#include "adbench/main.h"
+#include "adbench/shared/BAData.h"
+
+int main(int argc, char* argv[]) {
+  return generic_main<BAInput,
+                      FiniteBA,
+                      read_BAInput_json,
+                      write_BAOutput_objective_json,
+                      write_BAOutput_jacobian_json>(argc, argv);
+}

--- a/tools/finite/run_gmm.cpp
+++ b/tools/finite/run_gmm.cpp
@@ -1,0 +1,11 @@
+#include "FiniteGMM.h"
+#include "adbench/main.h"
+#include "adbench/shared/GMMData.h"
+
+int main(int argc, char* argv[]) {
+  return generic_main<GMMInput,
+                      FiniteGMM,
+                      read_GMMInput_json,
+                      write_GMMOutput_objective_json,
+                      write_GMMOutput_jacobian_json>(argc, argv);
+}

--- a/tools/finite/run_hello.cpp
+++ b/tools/finite/run_hello.cpp
@@ -1,0 +1,11 @@
+#include "FiniteHello.h"
+#include "adbench/main.h"
+#include "adbench/shared/HelloData.h"
+
+int main(int argc, char* argv[]) {
+  return generic_main<HelloInput,
+                      FiniteHello,
+                      read_HelloInput_json,
+                      write_HelloOutput_objective_json,
+                      write_HelloOutput_jacobian_json>(argc, argv);
+}

--- a/tools/finite/run_ht.cpp
+++ b/tools/finite/run_ht.cpp
@@ -1,0 +1,11 @@
+#include "FiniteHT.h"
+#include "adbench/main.h"
+#include "adbench/shared/HTData.h"
+
+int main(int argc, char* argv[]) {
+  return generic_main<HandInput,
+                      FiniteHand,
+                      read_HandInput_json,
+                      write_HandOutput_objective_json,
+                      write_HandOutput_jacobian_json>(argc, argv);
+}

--- a/tools/finite/run_lstm.cpp
+++ b/tools/finite/run_lstm.cpp
@@ -1,0 +1,11 @@
+#include "FiniteLSTM.h"
+#include "adbench/main.h"
+#include "adbench/shared/LSTMData.h"
+
+int main(int argc, char* argv[]) {
+  return generic_main<LSTMInput,
+                      FiniteLSTM,
+                      read_LSTMInput_json,
+                      write_LSTMOutput_objective_json,
+                      write_LSTMOutput_jacobian_json>(argc, argv);
+}

--- a/tools/manual/.gitignore
+++ b/tools/manual/.gitignore
@@ -1,0 +1,6 @@
+*.o
+run_hello
+run_gmm
+run_ba
+run_lstm
+run_ht

--- a/tools/manual/Dockerfile
+++ b/tools/manual/Dockerfile
@@ -1,0 +1,19 @@
+FROM python:3.11-slim
+
+WORKDIR /home/gradbench
+
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    python3 \
+    wget
+
+COPY cpp /home/gradbench/cpp
+
+RUN make -C cpp
+
+COPY tools/manual/ /home/gradbench/tools/manual
+
+RUN make -j -B -C tools/manual
+
+ENTRYPOINT ["python3", "/home/gradbench/tools/manual/run.py"]
+LABEL org.opencontainers.image.source=https://github.com/gradbench/gradbench

--- a/tools/manual/Makefile
+++ b/tools/manual/Makefile
@@ -1,0 +1,38 @@
+CXX?=c++
+CC?=cc
+CFLAGS=-std=c++17 -O3 -Wall
+LDFLAGS=-lm
+
+UTIL_OBJECTS=../../cpp/adbench/shared/utils.o ../../cpp/adbench/io.o
+HELLO_OBJECTS=ManualHello.o run_hello.o hello_d.o
+GMM_OBJECTS=ManualGMM.o run_gmm.o gmm_d.o
+BA_OBJECTS=ManualBA.o run_ba.o ba_d.o
+LSTM_OBJECTS=ManualLSTM.o run_lstm.o lstm_d.o
+HT_OBJECTS=ManualHT.o run_ht.o ht_d.o
+EXECUTABLES=run_hello run_gmm run_ba run_lstm run_ht
+
+all: $(EXECUTABLES)
+
+run_hello: $(HELLO_OBJECTS) $(UTIL_OBJECTS)
+	$(CXX) -o $@ $^ $(LDFLAGS)
+
+run_ba: $(BA_OBJECTS) $(UTIL_OBJECTS)
+	$(CXX) -o $@ $^ $(LDFLAGS)
+
+run_gmm: $(GMM_OBJECTS) $(UTIL_OBJECTS)
+	$(CXX) -o $@ $^ $(LDFLAGS)
+
+run_lstm: $(LSTM_OBJECTS) $(UTIL_OBJECTS)
+	$(CXX) -o $@ $^ $(LDFLAGS)
+
+run_ht: $(HT_OBJECTS) $(UTIL_OBJECTS)
+	$(CXX) -o $@ $^ $(LDFLAGS)
+
+%.o: %.c
+	$(CC) $< -c -o $@ $(CFLAGS) -I../../cpp
+
+%.o: %.cpp
+	$(CXX) $< -c -o $@ $(CFLAGS) -I../../cpp
+
+clean:
+	rm -f $(UTIL_OBJECTS) $(GMM_OBJECTS) $(BA_OBJECTS) $(LSTM_OBJECTS) $(HT_OBJECTS) $(EXECUTABLES)

--- a/tools/manual/ManualBA.cpp
+++ b/tools/manual/ManualBA.cpp
@@ -1,0 +1,67 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+// https://github.com/microsoft/ADBench/blob/38cb7931303a830c3700ca36ba9520868327ac87/src/cpp/modules/manual/ManualBA.cpp
+
+// ManualBA.cpp : Defines the exported functions for the DLL.
+#include "ManualBA.h"
+#include "adbench/shared/ba.h"
+#include "ba_d.h"
+
+// This function must be called before any other function.
+void ManualBA::prepare(BAInput&& input)
+{
+    _input = input;
+    _output = { std::vector<double>(2 * _input.p), std::vector<double>(_input.p), BASparseMat(_input.n, _input.m, _input.p) };
+    int n_new_cols = BA_NCAMPARAMS + 3 + 1;
+    _reproj_err_d = std::vector<double>(2 * n_new_cols);
+}
+
+BAOutput ManualBA::output()
+{
+    return _output;
+}
+
+void ManualBA::calculate_objective(int times)
+{
+    for (int i = 0; i < times; ++i) {
+        ba_objective(_input.n, _input.m, _input.p, _input.cams.data(), _input.X.data(), _input.w.data(),
+            _input.obs.data(), _input.feats.data(), _output.reproj_err.data(), _output.w_err.data());
+    }
+}
+
+void ManualBA::calculate_jacobian(int times)
+{
+    for (int i = 0; i < times; ++i) {
+        _output.J.clear();
+        for (int i = 0; i < _input.p; i++)
+        {
+            std::fill(_reproj_err_d.begin(), _reproj_err_d.end(), (double)0);
+
+            int camIdx = _input.obs[2 * i + 0];
+            int ptIdx = _input.obs[2 * i + 1];
+            compute_reproj_error_d(
+                &_input.cams[BA_NCAMPARAMS * camIdx],
+                &_input.X[ptIdx * 3],
+                _input.w[i],
+                _input.feats[2 * i + 0], _input.feats[2 * i + 1],
+                &_output.reproj_err[2 * i],
+                _reproj_err_d.data());
+
+            _output.J.insert_reproj_err_block(i, camIdx, ptIdx, _reproj_err_d.data());
+        }
+
+        for (int i = 0; i < _input.p; i++)
+        {
+            double w_d = 0;
+            compute_zach_weight_error_d(_input.w[i], &_output.w_err[i], &w_d);
+
+            _output.J.insert_w_err_block(i, w_d);
+        }
+    }
+}
+
+extern "C" DLL_PUBLIC ITest<BAInput, BAOutput>* get_ba_test()
+{
+    return new ManualBA();
+}

--- a/tools/manual/ManualBA.h
+++ b/tools/manual/ManualBA.h
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+// https://github.com/microsoft/ADBench/blob/38cb7931303a830c3700ca36ba9520868327ac87/src/cpp/modules/manual/ManualBA.h
+
+// ManualBA.h - Contains declarations of GMM tester functions
+#pragma once
+
+#include "adbench/shared/ITest.h"
+#include "adbench/shared/BAData.h"
+
+#include <vector>
+
+class ManualBA : public ITest<BAInput, BAOutput> {
+private:
+    BAInput _input;
+    BAOutput _output;
+    std::vector<double> _reproj_err_d;
+
+public:
+    // This function must be called before any other function.
+    virtual void prepare(BAInput&& input) override;
+
+    virtual void calculate_objective(int times) override;
+    virtual void calculate_jacobian(int times) override;
+    virtual BAOutput output() override;
+
+    ~ManualBA() {}
+};

--- a/tools/manual/ManualGMM.cpp
+++ b/tools/manual/ManualGMM.cpp
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+// https://github.com/microsoft/ADBench/blob/38cb7931303a830c3700ca36ba9520868327ac87/src/cpp/modules/manual/ManualGMM.cpp
+
+// ManualGMM.cpp : Defines the exported functions for the DLL.
+#include "ManualGMM.h"
+#include "adbench/shared/gmm.h"
+#include "gmm_d.h"
+
+#include <iostream>
+
+// This function must be called before any other function.
+void ManualGMM::prepare(GMMInput&& input)
+{
+    _input = input;
+    int Jcols = (_input.k * (_input.d + 1) * (_input.d + 2)) / 2;
+    _output = { 0,  std::vector<double>(Jcols) };
+}
+
+GMMOutput ManualGMM::output()
+{
+    return _output;
+}
+
+void ManualGMM::calculate_objective(int times)
+{
+    for (int i = 0; i < times; ++i) {
+        gmm_objective(_input.d, _input.k, _input.n, _input.alphas.data(), _input.means.data(),
+            _input.icf.data(), _input.x.data(), _input.wishart, &_output.objective);
+    }
+}
+
+void ManualGMM::calculate_jacobian(int times)
+{
+    for (int i = 0; i < times; ++i) {
+        gmm_objective_d(_input.d, _input.k, _input.n, _input.alphas.data(), _input.means.data(),
+            _input.icf.data(), _input.x.data(), _input.wishart, &_output.objective, _output.gradient.data());
+    }
+}
+
+extern "C" DLL_PUBLIC ITest<GMMInput, GMMOutput>* get_gmm_test()
+{
+    return new ManualGMM();
+}

--- a/tools/manual/ManualGMM.h
+++ b/tools/manual/ManualGMM.h
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+// https://github.com/microsoft/ADBench/blob/38cb7931303a830c3700ca36ba9520868327ac87/src/cpp/modules/manual/ManualGMM.h
+
+// ManualGMM.h - Contains declarations of GMM tester functions
+#pragma once
+
+#include "adbench/shared/ITest.h"
+#include "adbench/shared/GMMData.h"
+
+#include <vector>
+
+class ManualGMM : public ITest<GMMInput, GMMOutput> {
+    GMMInput _input;
+    GMMOutput _output;
+
+public:
+    // This function must be called before any other function.
+    void prepare(GMMInput&& input) override;
+
+    void calculate_objective(int times) override;
+    void calculate_jacobian(int times) override;
+    GMMOutput output() override; 
+
+    ~ManualGMM() = default;
+};

--- a/tools/manual/ManualHT.cpp
+++ b/tools/manual/ManualHT.cpp
@@ -1,0 +1,62 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+// https://github.com/microsoft/ADBench/blob/38cb7931303a830c3700ca36ba9520868327ac87/src/cpp/modules/manual/ManualHand.cpp
+
+// ManualHand.cpp : Defines the exported functions for the DLL.
+#include "ManualHT.h"
+
+#include "adbench/shared/ht_light_matrix.h"
+#include "ht_d.h"
+
+// This function must be called before any other function.
+void ManualHand::prepare(HandInput&& input)
+{
+    _input = input;
+    _complicated = _input.us.size() != 0;
+    int err_size = 3 * _input.data.correspondences.size();
+    int ncols = (_complicated ? 2 : 0) + _input.theta.size();
+    _output = { std::vector<double>(err_size), ncols, err_size, std::vector<double>(err_size * ncols) };
+}
+
+HandOutput ManualHand::output()
+{
+    return _output;
+}
+
+void ManualHand::calculate_objective(int times)
+{
+    if (_complicated)
+    {
+        for (int i = 0; i < times; ++i) {
+            hand_objective(_input.theta.data(), _input.us.data(), _input.data, _output.objective.data());
+        }
+    }
+    else
+    {
+        for (int i = 0; i < times; ++i) {
+            hand_objective(_input.theta.data(), _input.data, _output.objective.data());
+        }
+    }
+}
+
+void ManualHand::calculate_jacobian(int times)
+{
+    if (_complicated)
+    {
+        for (int i = 0; i < times; ++i) {
+            hand_objective_d(_input.theta.data(), _input.us.data(), _input.data, _output.objective.data(), _output.jacobian.data());
+        }
+    }
+    else
+    {
+        for (int i = 0; i < times; ++i) {
+            hand_objective_d(_input.theta.data(), _input.data, _output.objective.data(), _output.jacobian.data());
+        }
+    }
+}
+
+extern "C" DLL_PUBLIC ITest<HandInput, HandOutput>* get_hand_test()
+{
+    return new ManualHand();
+}

--- a/tools/manual/ManualHT.h
+++ b/tools/manual/ManualHT.h
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+// https://github.com/microsoft/ADBench/blob/38cb7931303a830c3700ca36ba9520868327ac87/src/cpp/modules/manual/ManualHand.h
+
+// ManualHand.h - Contains declarations of GMM tester functions
+#pragma once
+
+#include "adbench/shared/ITest.h"
+#include "adbench/shared/HTData.h"
+
+class ManualHand : public ITest<HandInput, HandOutput> {
+    HandInput _input;
+    HandOutput _output;
+    bool _complicated = false;
+
+public:
+    // This function must be called before any other function.
+    void prepare(HandInput&& input) override;
+
+    void calculate_objective(int times) override;
+    void calculate_jacobian(int times) override;
+    HandOutput output() override;
+
+    ~ManualHand() = default;
+};

--- a/tools/manual/ManualHello.cpp
+++ b/tools/manual/ManualHello.cpp
@@ -1,0 +1,32 @@
+#include "ManualHello.h"
+#include "adbench/shared/hello.h"
+#include "hello_d.h"
+
+void ManualHello::prepare(HelloInput&& input)
+{
+    _input = input;
+}
+
+HelloOutput ManualHello::output()
+{
+    return _output;
+}
+
+void ManualHello::calculate_objective(int times)
+{
+    for (int i = 0; i < times; ++i) {
+      _output.objective = hello_objective(_input.x);
+    }
+}
+
+void ManualHello::calculate_jacobian(int times)
+{
+    for (int i = 0; i < times; ++i) {
+      _output.gradient = hello_objective_d(_input.x);
+    }
+}
+
+extern "C" DLL_PUBLIC ITest<HelloInput, HelloOutput>* get_ba_test()
+{
+    return new ManualHello();
+}

--- a/tools/manual/ManualHello.h
+++ b/tools/manual/ManualHello.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "adbench/shared/ITest.h"
+#include "adbench/shared/HelloData.h"
+
+#include <vector>
+
+class ManualHello : public ITest<HelloInput, HelloOutput> {
+private:
+    HelloInput _input;
+    HelloOutput _output;
+
+public:
+    virtual void prepare(HelloInput&& input) override;
+
+    virtual void calculate_objective(int times) override;
+    virtual void calculate_jacobian(int times) override;
+    virtual HelloOutput output() override;
+
+    ~ManualHello() {}
+};

--- a/tools/manual/ManualLSTM.cpp
+++ b/tools/manual/ManualLSTM.cpp
@@ -1,0 +1,44 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+// https://github.com/microsoft/ADBench/blob/38cb7931303a830c3700ca36ba9520868327ac87/src/cpp/modules/manual/ManualLSTM.cpp
+
+// ManualLSTM.cpp : Defines the exported functions for the DLL.
+#include "ManualLSTM.h"
+#include "adbench/shared/lstm.h"
+#include "lstm_d.h"
+
+// This function must be called before any other function.
+void ManualLSTM::prepare(LSTMInput&& input)
+{
+    this->input = input;
+    int Jcols = 8 * this->input.l * this->input.b + 3 * this->input.b;
+    state = std::vector<double>(this->input.state.size());
+    result = { 0, std::vector<double>(Jcols) };
+}
+
+LSTMOutput ManualLSTM::output()
+{
+    return result;
+}
+
+void ManualLSTM::calculate_objective(int times)
+{
+    for (int i = 0; i < times; ++i) {
+        state = input.state;
+        lstm_objective(input.l, input.c, input.b, input.main_params.data(), input.extra_params.data(), state, input.sequence.data(), &result.objective);
+    }
+}
+
+void ManualLSTM::calculate_jacobian(int times)
+{
+    for (int i = 0; i < times; ++i) {
+        state = input.state;
+        lstm_objective_d(input.l, input.c, input.b, input.main_params.data(), input.extra_params.data(), state, input.sequence.data(), &result.objective, result.gradient.data());
+    }
+}
+
+extern "C" DLL_PUBLIC ITest<LSTMInput, LSTMOutput>*  get_lstm_test()
+{
+    return new ManualLSTM();
+}

--- a/tools/manual/ManualLSTM.h
+++ b/tools/manual/ManualLSTM.h
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+// https://github.com/microsoft/ADBench/blob/38cb7931303a830c3700ca36ba9520868327ac87/src/cpp/modules/manual/ManualLSTM.h
+
+// ManualLSTM.h - Contains declarations of LSTM tester functions
+#pragma once
+
+#include "adbench/shared/ITest.h"
+#include "adbench/shared/LSTMData.h"
+
+#include <vector>
+
+class ManualLSTM : public ITest<LSTMInput, LSTMOutput> {
+private:
+    LSTMInput input;
+    LSTMOutput result;
+    std::vector<double> state;
+
+public:
+    // This function must be called before any other function.
+    virtual void prepare(LSTMInput&& input) override;
+
+    virtual void calculate_objective(int times) override;
+    virtual void calculate_jacobian(int times) override;
+    virtual LSTMOutput output() override;
+
+    ~ManualLSTM() {}
+};

--- a/tools/manual/README.md
+++ b/tools/manual/README.md
@@ -1,11 +1,8 @@
 # Manual
 
-This repository contains programs that have been differentiated by
-hand.
+This tool contains programs that have been differentiated by hand.
 
-To run this outside Docker, you'll first need to run the following
-commands from the GradBench repository root to setup the C++ build and
-build the programs:
+To run this outside Docker, you'll first need to run the following commands from the GradBench repository root to setup the C++ build and build the programs:
 
 ```sh
 make -C cpp

--- a/tools/manual/README.md
+++ b/tools/manual/README.md
@@ -1,0 +1,19 @@
+# Manual
+
+This repository contains programs that have been differentiated by
+hand.
+
+To run this outside Docker, you'll first need to run the following
+commands from the GradBench repository root to setup the C++ build and
+build the programs:
+
+```sh
+make -C cpp
+make -C tools/manual
+```
+
+Then, to run the tool itself:
+
+```sh
+python3 tools/manual/run.py
+```

--- a/tools/manual/ba.py
+++ b/tools/manual/ba.py
@@ -1,0 +1,27 @@
+import json
+import subprocess
+import tempfile
+from os import listdir
+
+
+def compile():
+    # Nothing to do here. We assume everything is precompiled.
+    return True
+
+
+def calculate_objectiveBA(input):
+    with tempfile.NamedTemporaryFile("w") as tmp:
+        json.dump(input, tmp)
+        tmp.flush()
+        return subprocess.run(
+            ["tools/manual/run_ba", tmp.name, "F"], text=True, capture_output=True
+        )
+
+
+def calculate_jacobianBA(input):
+    with tempfile.NamedTemporaryFile("w") as tmp:
+        json.dump(input, tmp)
+        tmp.flush()
+        return subprocess.run(
+            ["tools/manual/run_ba", tmp.name, "J"], text=True, capture_output=True
+        )

--- a/tools/manual/ba_d.cpp
+++ b/tools/manual/ba_d.cpp
@@ -1,0 +1,247 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+// https://github.com/microsoft/ADBench/blob/38cb7931303a830c3700ca36ba9520868327ac87/src/cpp/modules/manual/ba_d.cpp
+
+#include <cstring>
+#include <cstdlib>
+#include <cmath>
+#include <cfloat>
+
+#include "adbench/shared/defs.h"
+#include "adbench/shared/matrix.h"
+#include "adbench/shared/ba.h"
+#include "ba_d.h"
+
+void compute_zach_weight_error_d(double w, double* err, double* J)
+{
+    *err = 1 - w * w;
+    *J = -2 * w;
+}
+
+// Arguments:
+// v - double[3]
+// M - double[9] (3x3 col-major matrix)
+void set_cross_mat(
+    const double* v,
+    double* M)
+{
+    //      0.    -v[2]   v[1]
+    // M =  v[2]   0.    -v[0]
+    //     -v[1]   v[0]   0.
+    M[0 * 3 + 0] = 0.;    M[1 * 3 + 0] = -v[2]; M[2 * 3 + 0] = v[1];
+    M[0 * 3 + 1] = v[2];  M[1 * 3 + 1] = 0.;    M[2 * 3 + 1] = -v[0];
+    M[0 * 3 + 2] = -v[1]; M[1 * 3 + 2] = v[0];  M[2 * 3 + 2] = 0.;
+}
+
+// Adapted from the version using Eigen.
+// Arguments:
+// rot - double[3]
+// X - double[3]
+// rotatedX - double[3]
+// rodri_rot_d - double[9] (3x3 col-major matrix)
+// rodri_X_d - double[9] (3x3 col-major matrix)
+void rodrigues_rotate_point_d(
+    const double* rot,
+    const double* X,
+    double* rotatedX,
+    double* rodri_rot_d,
+    double* rodri_X_d)
+{
+    double sqtheta = sqnorm(3, rot);
+    if (sqtheta != 0.)
+    {
+        double w[3], w_cross_X[3], acc[3], acc2[3]; // Vector3d
+        double tmp_d[3], theta_d_scaled[3], x_scaled[3]; // RowVector3d
+        double w_d[9], M[9], X_cross[9], accm[9]; // Matrix3d
+
+        double theta = sqrt(sqtheta);
+        double costheta = cos(theta);
+        double sintheta = sin(theta);
+        double theta_inverse = 1.0 / theta;
+
+        scale(3, theta_inverse, rot, w);
+
+        scale(3, -theta_inverse * theta_inverse, w, tmp_d);
+        mat_mul(3, 1, 3, rot, tmp_d, w_d);
+        for (int i = 0; i < 3; i++)
+            w_d[i * 3 + i] += theta_inverse;
+
+        cross(w, X, w_cross_X);
+
+        double w_dot_X = dot(3, w, X);
+        double tmp = (1. - costheta) * (w_dot_X);
+        scale(3, 1. - costheta, X, x_scaled);
+        mat_mul(1, 3, 3, x_scaled, w_d, tmp_d);
+        scale(3, w_dot_X * sintheta, w, theta_d_scaled);
+        add_to(3, tmp_d, theta_d_scaled);
+
+        scale(3, costheta, X, rotatedX);
+        scale(3, sintheta, w_cross_X, acc);
+        add_to(3, rotatedX, acc);
+        scale(3, tmp, w, acc);
+        add_to(3, rotatedX, acc);
+
+        set_cross_mat(X, M);
+        for (int i = 0; i < 9; ++i)
+            M[i] *= -sintheta;
+        for (int i = 0; i < 3; i++)
+            M[i * 3 + i] = tmp;
+
+        scale(3, costheta, w_cross_X, acc);
+        scale(3, -sintheta, X, acc2);
+        add_to(3, acc, acc2);
+        mat_mul(3, 1, 3, acc, w, rodri_rot_d);
+        mat_mul(3, 3, 3, M, w_d, accm);
+        for (int i = 0; i < 9; ++i)
+            rodri_rot_d[i] += accm[i];
+        mat_mul(3, 1, 3, w, tmp_d, accm);
+        add_to(9, rodri_rot_d, accm);
+
+        set_cross_mat(w, X_cross);
+        for (int i = 0; i < 9; ++i)
+            rodri_X_d[i] = X_cross[i] * sintheta;
+        scale(3, 1. - costheta, w, acc);
+        mat_mul(3, 1, 3, acc, w, accm);
+        add_to(9, rodri_X_d, accm);
+        for (int i = 0; i < 3; i++)
+            rodri_X_d[i * 3 + i] += costheta;
+    }
+    else
+    {
+        set_cross_mat(X, rodri_rot_d);
+        for (int i = 0; i < 9; ++i)
+            rodri_rot_d[i] *= -1;
+        set_cross_mat(rot, rodri_X_d);
+        mat_mul(3, 3, 1, rodri_X_d, X, rotatedX);
+        add_to(3, rotatedX, X);
+        for (int i = 0; i < 3; i++)
+            rodri_X_d[i * 3 + i] += 1;
+    }
+}
+
+// Arguments:
+// rad_params - double[2]
+// proj - double[2]
+// distort_proj_d - double[4] (2x2 col-major matrix)
+// distort_rad_d - double[4] (2x2 col-major matrix)
+void radial_distort_d(
+    const double* rad_params,
+    double* proj,
+    double* distort_proj_d,
+    double* distort_rad_d)
+{
+    double rsq = sqnorm(2, proj);
+    double L = 1 + rad_params[0] * rsq + rad_params[1] * rsq * rsq;
+    double distort_proj_d_coef = 2 * rad_params[0] + 4 * rad_params[1] * rsq;
+    distort_proj_d[0 * 2 + 0] = distort_proj_d_coef * proj[0] * proj[0] + L;
+    distort_proj_d[1 * 2 + 0] = distort_proj_d_coef * proj[0] * proj[1];
+    distort_proj_d[0 * 2 + 1] = distort_proj_d_coef * proj[1] * proj[0];
+    distort_proj_d[1 * 2 + 1] = distort_proj_d_coef * proj[1] * proj[1] + L;
+    distort_rad_d[0 * 2 + 0] = rsq * proj[0];
+    distort_rad_d[0 * 2 + 1] = rsq * proj[1];
+    distort_rad_d[1 * 2 + 0] = rsq * distort_rad_d[0 * 2 + 0];
+    distort_rad_d[1 * 2 + 1] = rsq * distort_rad_d[0 * 2 + 1];
+    proj[0] *= L;
+    proj[1] *= L;
+}
+
+// Arguments:
+// cam - double[BA_NCAMPARAMS]
+// X - double[3]
+// proj - double[2]
+// J - 2 x (BA_NCAMPARAMS+3+1) in column major
+void project_d(
+    const double* const cam,
+    const double* const X,
+    double* proj,
+    double* J)
+{
+    double Xo[3], Xcam[3];
+    const double* const rot = &cam[BA_ROT_IDX];
+    const double* const C = &cam[BA_C_IDX];
+    double f = cam[BA_F_IDX];
+    const double* const x0 = &cam[BA_X0_IDX];
+    const double* const rad = &cam[BA_RAD_IDX];
+
+    double* Jrot = &J[2 * BA_ROT_IDX];
+    double* JC = &J[2 * BA_C_IDX];
+    double* Jf = &J[2 * BA_F_IDX];
+    double* Jx0 = &J[2 * BA_X0_IDX];
+    double* Jrad = &J[2 * BA_RAD_IDX];
+    double* JX = &J[2 * BA_NCAMPARAMS];
+
+    subtract(3, X, C, Xo);
+
+    double rodri_rot_d[9], rodri_Xo_d[9];
+    rodrigues_rotate_point_d(rot, Xo, Xcam, rodri_rot_d,
+        rodri_Xo_d);
+
+    p2e(Xcam, proj);
+
+    double distort_proj_d[4], distort_rad_d[4];
+    radial_distort_d(rad, proj, distort_proj_d, distort_rad_d);
+
+    double hnorm_right_col[2];
+    double tmp = 1. / (Xcam[2] * Xcam[2]);
+    hnorm_right_col[0] = -Xcam[0] * tmp;
+    hnorm_right_col[1] = -Xcam[1] * tmp;
+    double distort_hnorm_d[6];
+
+    for (int i = 0; i < 4; i++)
+        distort_hnorm_d[i] = distort_proj_d[i] / Xcam[2];
+    distort_hnorm_d[2 * 2 + 0] = distort_proj_d[0 * 2 + 0] * hnorm_right_col[0] + distort_proj_d[1 * 2 + 0] * hnorm_right_col[1];
+    distort_hnorm_d[2 * 2 + 1] = distort_proj_d[0 * 2 + 1] * hnorm_right_col[0] + distort_proj_d[1 * 2 + 1] * hnorm_right_col[1];
+
+    mat_mul(2, 3, 3, distort_hnorm_d, rodri_rot_d, Jrot);
+    for (int i = 0; i < 6; ++i)
+        Jrot[i] *= f;
+
+    mat_mul(2, 3, 3, distort_hnorm_d, rodri_Xo_d, JC);
+    for (int i = 0; i < 6; ++i)
+        JC[i] *= -f;
+    Jf[0] = proj[0];
+    Jf[1] = proj[1];
+
+    // Initializind Jx0 to identity
+    Jx0[0] = 1.;
+    Jx0[1] = 0.;
+    Jx0[2] = 0.;
+    Jx0[3] = 1.;
+    for (int i = 0; i < 4; ++i)
+        Jrad[i] = distort_rad_d[i] * f;
+    for (int i = 0; i < 6; ++i)
+        JX[i] = -JC[i];
+
+    proj[0] = proj[0] * f + x0[0];
+    proj[1] = proj[1] * f + x0[1];
+}
+
+// Arguments:
+// cam - double[BA_NCAMPARAMS]
+// X - double[3]
+// w, feat_x, feat_y - double
+// err - double[2]
+// J - 2 x (BA_NCAMPARAMS+3+1) in column major
+void compute_reproj_error_d(
+    const double* const cam,
+    const double* const X,
+    double w,
+    double feat_x,
+    double feat_y,
+    double* err,
+    double* J)
+{
+    double proj[2];
+    project_d(cam, X, proj, J);
+
+    int Jw_idx = 2 * (BA_NCAMPARAMS + 3);
+    J[Jw_idx + 0] = (proj[0] - feat_x);
+    J[Jw_idx + 1] = (proj[1] - feat_y);
+    err[0] = w * J[Jw_idx + 0];
+    err[1] = w * J[Jw_idx + 1];
+    for (int i = 0; i < 2 * (BA_NCAMPARAMS + 3); i++)
+    {
+        J[i] *= w;
+    }
+}

--- a/tools/manual/ba_d.h
+++ b/tools/manual/ba_d.h
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+// https://github.com/microsoft/ADBench/blob/38cb7931303a830c3700ca36ba9520868327ac87/src/cpp/modules/manual/ba_d.h
+
+#pragma once
+
+// Arguments:
+// cam - double[BA_NCAMPARAMS]
+// X - double[3]
+// w, feat_x, feat_y - double
+// err - double[2]
+// J - 2 x (BA_NCAMPARAMS+3+1) in column major
+void compute_reproj_error_d(
+  const double* const cam,
+  const double* const X,
+  double w, 
+  double feat_x,
+  double feat_y, 
+  double *err, 
+  double *J);
+
+void compute_zach_weight_error_d(double w, double *err, double *J);

--- a/tools/manual/gmm.py
+++ b/tools/manual/gmm.py
@@ -1,0 +1,27 @@
+import json
+import subprocess
+import tempfile
+from os import listdir
+
+
+def compile():
+    # Nothing to do here. We assume everything is precompiled.
+    return True
+
+
+def calculate_objectiveGMM(input):
+    with tempfile.NamedTemporaryFile("w") as tmp:
+        json.dump(input, tmp)
+        tmp.flush()
+        return subprocess.run(
+            ["tools/manual/run_gmm", tmp.name, "F"], text=True, capture_output=True
+        )
+
+
+def calculate_jacobianGMM(input):
+    with tempfile.NamedTemporaryFile("w") as tmp:
+        json.dump(input, tmp)
+        tmp.flush()
+        return subprocess.run(
+            ["tools/manual/run_gmm", tmp.name, "J"], text=True, capture_output=True
+        )

--- a/tools/manual/gmm_d.cpp
+++ b/tools/manual/gmm_d.cpp
@@ -1,0 +1,172 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+// https://github.com/microsoft/ADBench/blob/38cb7931303a830c3700ca36ba9520868327ac87/src/cpp/modules/manual/gmm_d.cpp
+
+#include "gmm_d.h"
+
+#include <cmath>
+#include <vector>
+#include <algorithm>
+
+#include "adbench/shared/defs.h"
+#include "adbench/shared/matrix.h"
+
+using std::vector;
+
+#include "adbench/shared/gmm.h"
+
+void Qtransposetimesx(int d,
+    const double* const Ldiag,
+    const double* const icf,
+    const double* const x,
+    double* Ltransposex)
+{
+    int Lparamsidx = d;
+    for (int i = 0; i < d; i++)
+        Ltransposex[i] = Ldiag[i] * x[i];
+
+    for (int i = 0; i < d; i++)
+        for (int j = i + 1; j < d; j++)
+        {
+            Ltransposex[i] += icf[Lparamsidx] * x[j];
+            Lparamsidx++;
+        }
+}
+
+void compute_q_inner_term(int d,
+    const double* const Ldiag,
+    const double* const xcentered,
+    const double* const Lxcentered,
+    double* logLdiag_d)
+{
+    for (int i = 0; i < d; i++)
+    {
+        logLdiag_d[i] = 1. - Ldiag[i] * xcentered[i] * Lxcentered[i];
+    }
+}
+
+void compute_L_inner_term(int d,
+    const double* const xcentered,
+    const double* const Lxcentered,
+    double* L_d)
+{
+    int Lparamsidx = 0;
+    for (int i = 0; i < d; i++)
+    {
+        int n_curr_elems = d - i - 1;
+        for (int j = 0; j < n_curr_elems; j++)
+        {
+            L_d[Lparamsidx] = -xcentered[i] * Lxcentered[d - n_curr_elems + j];
+            Lparamsidx++;
+        }
+    }
+}
+
+double logsumexp_d(int n, const double* const x, double *logsumexp_partial_d)
+{
+    int max_elem = arr_max_idx(n, x);
+    double mx = x[max_elem];
+    double semx = 0.;
+    for (int i = 0; i < n; i++)
+    {
+        logsumexp_partial_d[i] = exp(x[i] - mx);
+        semx += logsumexp_partial_d[i];
+    }
+    if (semx == 0.)
+    {
+        std::fill(logsumexp_partial_d, logsumexp_partial_d + n, 0.0);
+    }
+    else
+    {
+        logsumexp_partial_d[max_elem] -= semx;
+        for (int i = 0; i < n; i++)
+            logsumexp_partial_d[i] /= semx;
+    }
+    logsumexp_partial_d[max_elem] += 1.;
+    return log(semx) + mx;
+}
+
+void gmm_objective_d(int d, int k, int n,
+    const double *alphas,
+    const double *means,
+    const double *icf,
+    const double *x,
+    Wishart wishart,
+    double *err,
+    double *J)
+{
+    const double CONSTANT = -n * d*0.5*log(2 * PI);
+    int icf_sz = d * (d + 1) / 2;
+
+    vector<double> Qdiags(d*k);
+    vector<double> sum_qs(k);
+    vector<double> main_term(k);
+    vector<double> xcentered(d);
+    vector<double> Qxcentered(d);
+
+    preprocess_qs(d, k, icf, sum_qs.data(), Qdiags.data());
+
+    std::fill(J, J + (k + d * k + icf_sz * k), 0.0);
+
+    vector<double> curr_means_d(d*k);
+    vector<double> curr_q_d(d*k);
+    vector<double> curr_L_d((icf_sz - d) * k);
+
+    double *alphas_d = J;
+    double *means_d = &J[k];
+    double *icf_d = &J[k + d * k];
+
+    double slse = 0.;
+    for (int ix = 0; ix < n; ix++)
+    {
+        const double* const curr_x = &x[ix*d];
+        for (int ik = 0; ik < k; ik++)
+        {
+            int icf_off = ik * icf_sz;
+            double *Qdiag = &Qdiags[ik*d];
+
+            subtract(d, curr_x, &means[ik*d], xcentered.data());
+            Qtimesx(d, Qdiag, &icf[ik*icf_sz + d], xcentered.data(), Qxcentered.data());
+            Qtransposetimesx(d, Qdiag, &icf[icf_off], Qxcentered.data(), &curr_means_d[ik*d]);
+            compute_q_inner_term(d, Qdiag, xcentered.data(), Qxcentered.data(), &curr_q_d[ik*d]);
+            compute_L_inner_term(d, xcentered.data(), Qxcentered.data(), &curr_L_d[ik*(icf_sz - d)]);
+            main_term[ik] = alphas[ik] + sum_qs[ik] - 0.5*sqnorm(d, Qxcentered.data());
+        }
+        slse += logsumexp_d(k, main_term.data(), main_term.data());
+        for (int ik = 0; ik < k; ik++)
+        {
+            int means_off = ik * d;
+            int icf_off = ik * icf_sz;
+            alphas_d[ik] += main_term[ik];
+            for (int id = 0; id < d; id++)
+            {
+                means_d[means_off + id] += curr_means_d[means_off + id] * main_term[ik];
+                icf_d[icf_off + id] += curr_q_d[ik*d + id] * main_term[ik];
+            }
+            for (int i = d; i < icf_sz; i++)
+            {
+                icf_d[icf_off + i] += curr_L_d[ik*(icf_sz - d) + (i - d)] * main_term[ik];
+            }
+        }
+    }
+
+    vector<double> lse_alphas_d(k);
+    double lse_alphas = logsumexp_d(k, alphas, lse_alphas_d.data());
+    for (int ik = 0; ik < k; ik++)
+    {
+        alphas_d[ik] -= n * lse_alphas_d[ik];
+        for (int id = 0; id < d; id++)
+        {
+            icf_d[ik*icf_sz + id] += wishart.gamma*wishart.gamma * Qdiags[ik*d + id] * Qdiags[ik*d + id]
+                - wishart.m;
+        }
+        for (int i = d; i < icf_sz; i++)
+        {
+            icf_d[ik*icf_sz + i] += wishart.gamma*wishart.gamma*icf[ik*icf_sz + i];
+        }
+    }
+
+    *err = CONSTANT + slse - n * lse_alphas;
+    *err += log_wishart_prior(d, k, wishart, sum_qs.data(), Qdiags.data(), icf);
+}

--- a/tools/manual/gmm_d.h
+++ b/tools/manual/gmm_d.h
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+// https://github.com/microsoft/ADBench/blob/38cb7931303a830c3700ca36ba9520868327ac87/src/cpp/modules/manual/gmm_d.h
+
+#pragma once
+
+#include "adbench/shared/defs.h"
+
+// d: dim
+// k: number of gaussians
+// n: number of points
+// alphas: k logs of mixture weights (unnormalized), so
+//          weights = exp(log_alphas) / sum(exp(log_alphas))
+// means: d*k component means
+// icf: (d*(d+1)/2)*k inverse covariance factors 
+//                  every icf entry stores firstly log of diagonal and then 
+//          columnwise other entries
+//          To generate icf in MATLAB given covariance C :
+//              L = inv(chol(C, 'lower'));
+//              inv_cov_factor = [log(diag(L)); L(au_tril_indices(d, -1))]
+// wishart: wishart distribution parameters
+// x: d*n points
+// err: objective function output
+// J: gradient output
+void gmm_objective_d(int d, int k, int n,
+    const double *alphas,
+    const double *means,
+    const double *icf,
+    const double *x,
+    Wishart wishart,
+    double *err,
+    double *J);

--- a/tools/manual/hello.py
+++ b/tools/manual/hello.py
@@ -1,0 +1,27 @@
+import json
+import subprocess
+import tempfile
+from os import listdir
+
+
+def compile():
+    # Nothing to do here. We assume everything is precompiled.
+    return True
+
+
+def square(input):
+    with tempfile.NamedTemporaryFile("w") as tmp:
+        json.dump(input, tmp)
+        tmp.flush()
+        return subprocess.run(
+            ["tools/manual/run_hello", tmp.name, "F"], text=True, capture_output=True
+        )
+
+
+def double(input):
+    with tempfile.NamedTemporaryFile("w") as tmp:
+        json.dump(input, tmp)
+        tmp.flush()
+        return subprocess.run(
+            ["tools/manual/run_hello", tmp.name, "J"], text=True, capture_output=True
+        )

--- a/tools/manual/hello_d.cpp
+++ b/tools/manual/hello_d.cpp
@@ -1,0 +1,3 @@
+double hello_objective_d(double x) {
+  return 2 * x;
+}

--- a/tools/manual/hello_d.h
+++ b/tools/manual/hello_d.h
@@ -1,0 +1,3 @@
+#pragma once
+
+double hello_objective_d(double);

--- a/tools/manual/ht.py
+++ b/tools/manual/ht.py
@@ -1,0 +1,27 @@
+import json
+import subprocess
+import tempfile
+from os import listdir
+
+
+def compile():
+    # Nothing to do here. We assume everything is precompiled.
+    return True
+
+
+def calculate_objectiveHT(input):
+    with tempfile.NamedTemporaryFile("w") as tmp:
+        json.dump(input, tmp)
+        tmp.flush()
+        return subprocess.run(
+            ["tools/manual/run_ht", tmp.name, "F"], text=True, capture_output=True
+        )
+
+
+def calculate_jacobianHT(input):
+    with tempfile.NamedTemporaryFile("w") as tmp:
+        json.dump(input, tmp)
+        tmp.flush()
+        return subprocess.run(
+            ["tools/manual/run_ht", tmp.name, "J"], text=True, capture_output=True
+        )

--- a/tools/manual/ht_d.cpp
+++ b/tools/manual/ht_d.cpp
@@ -1,0 +1,686 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+// https://github.com/microsoft/ADBench/blob/38cb7931303a830c3700ca36ba9520868327ac87/src/cpp/modules/manual/hand_d.cpp
+
+/*
+ * Manual differentiation of the hand tracking problem.
+ * Adapted from the Eigen-based version.
+ *
+ * Functions in this file do not perform any checks on input parameters
+ * for the sake of better performance.
+*/
+
+#include "ht_d.h"
+
+#include "adbench/shared/matrix.h"
+
+// Inputs:
+// angle_axis - double[3]
+// Outputs:
+// R - preallocated 3x3 matrix
+// dR - array of 3 preallocated 3x3 matrices
+void angle_axis_to_rotation_matrix_d(
+    const double* angle_axis,
+    LightMatrix<double>& R,
+    std::array<LightMatrix<double>, 3>& dR)
+{
+    double _sqnorm = sqnorm(3, angle_axis);
+    double norm = sqrt(_sqnorm);
+    if (norm < .0001)
+    {
+        R.set_identity();
+        for (int i = 0; i < 3; i++)
+            dR[i].fill(0.);
+        return;
+    }
+    double inv_norm = 1. / norm;
+    double inv_sqnorm = 1. / _sqnorm;
+    double d_norm[3];
+    scale(3, inv_norm, angle_axis, d_norm);
+
+    double x = angle_axis[0] * inv_norm;
+    double y = angle_axis[1] * inv_norm;
+    double z = angle_axis[2] * inv_norm;
+    double dx[3], dy[3], dz[3];
+    for (int i = 0; i < 3; i++)
+    {
+        dx[i] = -angle_axis[0] * d_norm[i] * inv_sqnorm;
+        dy[i] = -angle_axis[1] * d_norm[i] * inv_sqnorm;
+        dz[i] = -angle_axis[2] * d_norm[i] * inv_sqnorm;
+    }
+    dx[0] += inv_norm;
+    dy[1] += inv_norm;
+    dz[2] += inv_norm;
+
+    double s = sin(norm);
+    double c = cos(norm);
+    double dc[3], ds[3];
+    scale(3, c, d_norm, ds);
+    scale(3, -s, d_norm, dc);
+
+    double r_val[9] = 
+    {
+        x * x + (1 - x * x) * c, x * y * (1 - c) + z * s, x * z * (1 - c) - y * s,
+        x * y * (1 - c) - z * s, y * y + (1 - y * y) * c, z * y * (1 - c) + x * s,
+        x * z * (1 - c) + y * s, y * z * (1 - c) - x * s, z * z + (1 - z * z) * c
+    }; // col-major
+    R.set(r_val);
+
+    for (int i = 0; i < 3; i++)
+    {
+        double tmp[9] = 
+        {
+            2 * x * dx[i] - 2 * x * dx[i] * c + (1 - x * x) * dc[i],
+            dx[i] * y * (1 - c) + x * dy[i] * (1 - c) - x * y * dc[i] + dz[i] * s + z * ds[i],
+            dx[i] * z * (1 - c) + x * dz[i] * (1 - c) - x * z * dc[i] - dy[i] * s - y * ds[i],
+            dx[i] * y * (1 - c) + x * dy[i] * (1 - c) - x * y * dc[i] - dz[i] * s - z * ds[i],
+            2 * y * dy[i] - 2 * y * dy[i] * c + (1 - y * y) * dc[i],
+            dz[i] * y * (1 - c) + z * dy[i] * (1 - c) - z * y * dc[i] + dx[i] * s + x * ds[i],
+            dx[i] * z * (1 - c) + x * dz[i] * (1 - c) - x * z * dc[i] + dy[i] * s + y * ds[i],
+            dy[i] * z * (1 - c) + y * dz[i] * (1 - c) - y * z * dc[i] - dx[i] * s - x * ds[i],
+            2 * z * dz[i] - 2 * z * dz[i] * c + (1 - z * z) * dc[i]
+        }; // col-major
+        dR[i].set(tmp);
+    }
+}
+
+// Inputs:
+// pose_params - 3xN matrix
+// Outputs:
+// R - preallocated 3x3 matrix
+// dR - array of 3 preallocated 3x3 matrices
+void apply_global_transform_d_common(
+    const LightMatrix<double>& pose_params, LightMatrix<double>& R, std::array<LightMatrix<double>, 3>& dR)
+{
+    const double* global_rotation = pose_params.get_col(0);
+    angle_axis_to_rotation_matrix_d(global_rotation, R, dR);
+
+    // const Vector3d& global_rotation = pose_params.col(0);
+    // angle_axis_to_rotation_matrix_d(global_rotation, &R, &dR);
+    // coef-wise multiplying each row of R by pose_params.get_col(1)
+    const double* pose_params_col1 = pose_params.get_col(1);
+    R.scale_col(0, pose_params_col1[0]);
+    R.scale_col(1, pose_params_col1[1]);
+    R.scale_col(2, pose_params_col1[2]);
+
+    // same for all dR    
+    for (int i = 0; i < 3; ++i)
+    {
+        dR[i].scale_col(0, pose_params_col1[0]);
+        dR[i].scale_col(1, pose_params_col1[1]);
+        dR[i].scale_col(2, pose_params_col1[2]);
+    }
+}
+
+// Inputs:
+// npts - int
+// R - 3x3 matrix
+// pose_params - 3xN matrix
+// References
+// positions - 3xN matrix,
+// Outputs:
+// pJ - pointer to memory allocated for the jacobian
+void apply_global_translation_d(const size_t& npts, const LightMatrix<double>& R, const LightMatrix<double>& pose_params, LightMatrix<double>& positions, double* pJ)
+{
+    // global translation
+    LightMatrix<double> tmp;
+    LightMatrix<double> J_glob_translation(3 * npts, 3, &pJ[3 * 3 * npts], false);
+    double minusIbuf[9] = { -1., 0., 0., 0., -1., 0., 0., 0., -1. };
+    LightMatrix<double> minusI(3, 3, minusIbuf, false);
+    for (size_t i = 0; i < npts; ++i)
+    {
+        J_glob_translation.set_block(i * 3, 0, minusI);
+    }
+
+    mat_mult(R, positions, &tmp);
+    const double* pose_params_col2 = pose_params.get_col(2);
+    for (int i = 0; i < positions.cols(); ++i)
+    {
+        double* col = tmp.get_col_ptr(i);
+        add_to(3, col, pose_params_col2);
+        positions.set_col(i, col);
+    }
+}
+
+// Inputs:
+// corresp - vector<int>
+// pose_params - 3xN matrix
+// References
+// positions - 3xN matrix,
+// Outputs:
+// pJ - pointer to memory allocated for the jacobian
+// R - preallocated 3x3 matrix
+void apply_global_transform_d(
+    const std::vector<int>& corresp,
+    const LightMatrix<double>& pose_params,
+    LightMatrix<double>& positions,
+    double* pJ,
+    LightMatrix<double>& R)
+{
+    std::array<LightMatrix<double>, 3> dR = { LightMatrix<double>(3, 3), LightMatrix<double>(3, 3) , LightMatrix<double>(3, 3) };
+    apply_global_transform_d_common(pose_params, R, dR);
+
+    // global rotation
+    size_t npts = corresp.size();
+    LightMatrix<double> tmp;
+    for (int i_param = 0; i_param < 3; ++i_param)
+    {
+        LightMatrix<double> J_glob_rot(3, npts, &pJ[i_param * 3 * npts], false);
+        for (size_t i_pt = 0; i_pt < npts; i_pt++)
+        {
+            mat_mult(dR[i_param], LightMatrix<double>(3, 1, positions.get_col_ptr(corresp[i_pt]), false), &tmp);
+            J_glob_rot.set_col(i_pt, tmp.get_col(0));
+            J_glob_rot.scale_col(i_pt, -1.);
+        }
+    }
+
+    apply_global_translation_d(npts, R, pose_params, positions, pJ);
+}
+
+// Inputs:
+// us - double[2 * corresp.size()]
+// triangles - vector<Triangle>,
+// corresp - vector<int>
+// pose_params - 3xN matrix
+// References
+// positions - 3xN matrix,
+// Outputs:
+// pJ - pointer to memory allocated for the jacobian
+// R - preallocated 3x3 matrix
+void apply_global_transform_d(
+    const double* const us,
+    const std::vector<Triangle>& triangles,
+    const std::vector<int>& corresp,
+    const LightMatrix<double>& pose_params,
+    LightMatrix<double>& positions,
+    double* pJ,
+    LightMatrix<double>& R)
+{
+    std::array<LightMatrix<double>, 3> dR = { LightMatrix<double>(3, 3), LightMatrix<double>(3, 3) , LightMatrix<double>(3, 3) };
+    apply_global_transform_d_common(pose_params, R, dR);
+
+    // global rotation
+    size_t npts = corresp.size();
+    double tmp1[3], tmp2[3];
+    LightMatrix<double> tmp1_wrapper(3, 1, tmp1, false), tmp_matrix;
+    for (int i_param = 0; i_param < 3; ++i_param)
+    {
+        LightMatrix<double> J_glob_rot(3, npts, &pJ[i_param * 3 * npts], false);
+        for (size_t i_pt = 0; i_pt < npts; ++i_pt)
+        {
+            // tmp1 = u[0] * positions.get_col(verts[0]) + u[1] * positions.get_col(verts[1]) + (1. - u[0] - u[1]) * positions.get_col(verts[2]
+            const auto& verts = triangles[corresp[i_pt]].verts;
+            const double* const u = &us[2 * i_pt];
+            scale(3, u[0], positions.get_col(verts[0]), tmp1);
+            scale(3, u[1], positions.get_col(verts[1]), tmp2);
+            add_to(3, tmp1, tmp2);
+            scale(3, 1. - u[0] - u[1], positions.get_col(verts[2]), tmp2);
+            add_to(3, tmp1, tmp2);
+
+            //J_glob_rot.col(i_pt) = -dR[i_param] * tmp1;
+            mat_mult(dR[i_param], tmp1_wrapper, &tmp_matrix);
+            tmp_matrix.scale_col(0, -1.);
+            J_glob_rot.set_block(0, i_pt, tmp_matrix);
+        }
+    }
+
+    apply_global_translation_d(npts, R, pose_params, positions, pJ);
+}
+
+// Inputs:
+// relatives - vector of parents.size() 4x4 matrices
+// relatives_d  - vector of 4x4 matrices
+// parents - vector<int>
+// Outputs:
+// absolutes - vector of 4x4 matrices, allocated in this function
+// absolutes_d - vector of vectors of 4x4 matrices, allocated in this function
+void relatives_to_absolutes_d(
+    const std::vector<LightMatrix<double>>& relatives,
+    const std::vector<LightMatrix<double>>& relatives_d,
+    const std::vector<int>& parents,
+    std::vector<LightMatrix<double>>& absolutes,
+    std::vector<std::vector<LightMatrix<double>>>& absolutes_d)
+{
+    absolutes.resize(parents.size());
+    absolutes_d.resize(parents.size());
+    int rel_d_tail = 0;
+    for (size_t i = 0; i < parents.size(); ++i)
+    {
+        if (parents[i] == -1)
+            absolutes[i] = relatives[i];
+        else
+        {
+            // absolutes[i] = absolutes[parents[i]] * relatives[i];
+            if (parents[i] != i)
+                mat_mult(absolutes[parents[i]], relatives[i], &absolutes[i]);
+            else
+            {
+                LightMatrix<double> tmp;
+                mat_mult(absolutes[parents[i]], relatives[i], &tmp);
+                absolutes[i] = std::move(tmp);
+            }
+        }
+
+        int n_finger_bone = (i - 1) % 4;
+        if (i > 0 && i < parents.size() - 1 && n_finger_bone > 0)
+        {
+            absolutes_d[i].resize(n_finger_bone + 1);
+            int curr_tail = 0;
+            int parent = parents[i];
+
+            // absolutes_d[i][curr_tail++] = absolute_d_parent * relatives[i];
+            if (parent != i)
+            {
+                for (const auto& absolute_d_parent : absolutes_d[parent])
+                    mat_mult(absolute_d_parent, relatives[i], &absolutes_d[i][curr_tail++]);
+            }
+            else
+            {
+                for (int j = 0; j < absolutes_d[parent].size(); ++j)
+                {
+                    LightMatrix<double> tmp;
+                    mat_mult(absolutes_d[parent][j], relatives[i], &tmp);
+                    absolutes_d[i][curr_tail++] = std::move(tmp);
+                }
+            }
+
+            mat_mult(absolutes[parent], relatives_d[rel_d_tail++], &absolutes_d[i][curr_tail++]);
+            if (n_finger_bone == 1)
+                mat_mult(absolutes[parent], relatives_d[rel_d_tail++], &absolutes_d[i][curr_tail++]);
+        }
+    }
+}
+
+// Inputs:
+// xzy - double[3]
+// Outputs:
+// R - 3x3 matrix, allocated in this function
+// pdR0 - nullable pointer to 3x3 matrix (computed only if not null)
+// pdR1 - nullable pointer to 3x3 matrix (computed only if not null)
+void euler_angles_to_rotation_matrix(
+    const double* xzy,
+    LightMatrix<double>& R,
+    LightMatrix<double>* pdR0,
+    LightMatrix<double>* pdR1)
+{
+    double tx = xzy[0], ty = xzy[2], tz = xzy[1];
+    LightMatrix<double> Rx(3, 3), Ry(3, 3), Rz(3, 3), RzRy(3, 3);
+    Rx.set_identity();
+    Ry.set_identity();
+    Rz.set_identity();
+    Rx(1, 1) = cos(tx);
+    Rx(2, 1) = sin(tx);
+    Rx(1, 2) = -Rx(2, 1);
+    Rx(2, 2) = Rx(1, 1);
+
+    Ry(0, 0) = cos(ty);
+    Ry(0, 2) = sin(ty);
+    Ry(2, 0) = -Ry(0, 2);
+    Ry(2, 2) = Ry(0, 0);
+
+    Rz(0, 0) = cos(tz);
+    Rz(1, 0) = sin(tz);
+    Rz(0, 1) = -Rz(1, 0);
+    Rz(1, 1) = Rz(0, 0);
+
+    mat_mult(Rz, Ry, &RzRy);
+    mat_mult(RzRy, Rx, &R);
+
+    if (pdR0)
+    {
+        double zero[9] = { 0., 0., 0., 0., 0., 0., 0., 0., 0. };
+        LightMatrix<double> dRx(3, 3, zero, false);
+        dRx(1, 1) = -Rx(2, 1);
+        dRx(2, 1) = Rx(1, 1);
+        dRx(1, 2) = -dRx(2, 1);
+        dRx(2, 2) = dRx(1, 1);
+        mat_mult(RzRy, dRx, pdR0);
+    }
+    if (pdR1)
+    {
+        double zero[9] = { 0., 0., 0., 0., 0., 0., 0., 0., 0. };
+        LightMatrix<double> dRz(3, 3, zero, false), RyRx(3, 3);
+        dRz(0, 0) = -Rz(1, 0);
+        dRz(1, 0) = Rz(0, 0);
+        dRz(0, 1) = -dRz(1, 0);
+        dRz(1, 1) = dRz(0, 0);
+        mat_mult(Ry, Rx, &RyRx);
+        mat_mult(dRz, RyRx, pdR1);
+    }
+}
+
+// Inputs:
+// model - HandModelEigen
+// pose_params - 3xN matrix
+// relatives - vector of 4x4 matrices, allocated in this function
+// relatives_d - vector of 4x4 matrices, allocated in this function
+void get_posed_relatives_d(
+    const HandModelLightMatrix& model,
+    const LightMatrix<double>& pose_params,
+    std::vector<LightMatrix<double>>& relatives,
+    std::vector<LightMatrix<double>>& relatives_d)
+{
+    relatives.resize(model.base_relatives.size());
+    relatives_d.resize(4 * 5); // 4 parameters in every finger
+
+    int offset = 3;
+    int tail = 0;
+    for (size_t i = 0; i < model.bone_names.size(); ++i)
+    {
+        LightMatrix<double> tr(4, 4), R(3, 3);
+        tr.set_identity();
+
+        int n_finger_bone = (i - 1) % 4;
+        if (i == 0 || i == model.bone_names.size() - 1 || n_finger_bone == 0)
+        {
+            euler_angles_to_rotation_matrix(pose_params.get_col(i + offset), R);
+        }
+        else
+        {
+            LightMatrix<double> dtr0(4, 4), dR0(3, 3);
+            dtr0.fill(0.);
+            if (n_finger_bone == 1)
+            {
+                LightMatrix<double> dtr1(4, 4), dR1(3, 3);
+                dtr1.fill(0.);
+                euler_angles_to_rotation_matrix(pose_params.get_col(i + offset), R, &dR0, &dR1);
+                dtr1.set_block(0, 0, dR1);
+                mat_mult(model.base_relatives[i], dtr1, &relatives_d[tail + 1]);
+            }
+            else
+                euler_angles_to_rotation_matrix(pose_params.get_col(i + offset), R, &dR0);
+
+            dtr0.set_block(0, 0, dR0);
+            mat_mult(model.base_relatives[i], dtr0, &relatives_d[tail++]);
+            if (n_finger_bone == 1)
+                tail++;
+        }
+        tr.set_block(0, 0, R);
+
+        mat_mult(model.base_relatives[i], tr, &relatives[i]);
+    }
+}
+
+// Inputs:
+// model - HandModelEigen
+// pose_params 3xN matrix
+// corresp - vector<int>
+// Outputs:
+// positions - 3xN matrix, allocated in this function
+// positions_d - vector of 3xN matrices, allocated in this function
+// pJ - pointer to memory allocated for the jacobian
+void get_skinned_vertex_positions_d_common(
+    const HandModelLightMatrix& model,
+    const LightMatrix<double>& pose_params,
+    const std::vector<int>& corresp,
+    LightMatrix<double>& positions,
+    std::vector<LightMatrix<double>>& positions_d,
+    double* pJ)
+{
+    std::vector<LightMatrix<double>> relatives, absolutes, transforms; // vector<Matrix4d>
+    std::vector<LightMatrix<double>> relatives_d; // vector<Matrix4d>
+    std::vector<std::vector<LightMatrix<double>>> absolutes_d, transforms_d; // vector<vector<Matrix4d>>
+    get_posed_relatives_d(model, pose_params, relatives, relatives_d);
+    relatives_to_absolutes_d(relatives, relatives_d, model.parents, absolutes, absolutes_d);
+
+    // Get bone transforms.
+    transforms.resize(absolutes.size());
+    transforms_d.resize(absolutes.size());
+    for (size_t i = 0; i < absolutes.size(); ++i)
+    {
+        mat_mult(absolutes[i], model.inverse_base_absolutes[i], &transforms[i]);
+        transforms_d[i].resize(absolutes_d[i].size());
+        for (size_t j = 0; j < absolutes_d[i].size(); j++)
+            mat_mult(absolutes_d[i][j], model.inverse_base_absolutes[i], &transforms_d[i][j]);
+    }
+
+    // Transform vertices by necessary transforms. + apply skinning
+    positions = LightMatrix<double>(3, model.base_positions.cols());
+    positions.fill(0.);
+    positions_d.resize(4 * 5, positions);
+    LightMatrix<double> base_positions_homogenized(4, model.base_positions.cols()), tmp;
+    base_positions_homogenized.set_block(0, 0, model.base_positions);
+    base_positions_homogenized.set_row(3, 1.);
+    for (int i = 0; i < (int)transforms.size(); ++i)
+    {
+        //*positions +=
+        //    ((transforms[i] * model.base_positions.colwise().homogeneous()).array()
+        //        .rowwise() * model.weights.row(i)).matrix()
+        //    .topRows(3);
+        mat_mult(transforms[i], base_positions_homogenized, &tmp);
+        for (int l = 0; l < 3; ++l)
+        {
+            for (int k = 0; k < tmp.cols(); ++k)
+                positions(l, k) += tmp(l, k) * model.weights(i, k);
+        }
+
+        int i_finger = (i - 1) / 4;
+        for (int j = 0; j < (int)transforms_d[i].size(); j++)
+        {
+            int i_param = j + 4 * i_finger;
+            mat_mult(transforms_d[i][j], base_positions_homogenized, &tmp);
+
+            //(*positions_d)[i_param] +=
+            //    ((transforms_d[i][j] * model.base_positions.colwise().homogeneous()).array()
+            //        .rowwise() * model.weights.row(i)).matrix()
+            //    .topRows(3);
+            for (int l = 0; l < 3; ++l)
+            {
+                for (int k = 0; k < tmp.cols(); ++k)
+                    positions_d[i_param](l, k) += tmp(l, k) * model.weights(i, k);
+            }
+        }
+    }
+
+    if (model.is_mirrored)
+        positions.scale_row(0, -1.);
+}
+
+// Inputs:
+// model - HandModelEigen
+// pose_params 3xN matrix
+// corresp - vector<int>
+// apply_global - bool, defaults to true
+// Outputs:
+// positions - 3xN matrix, allocated in this function
+// pJ - pointer to memory allocated for the jacobian
+void get_skinned_vertex_positions_d(
+    const HandModelLightMatrix& model,
+    const LightMatrix<double>& pose_params,
+    const std::vector<int>& corresp,
+    LightMatrix<double>& positions,
+    double* pJ,
+    bool apply_global)
+{
+    std::vector<LightMatrix<double>> positions_d; //vector<Matrix3Xd>
+    get_skinned_vertex_positions_d_common(model, pose_params, corresp, positions,
+        positions_d, pJ);
+
+    LightMatrix<double> Rglob(3, 3);
+    Rglob.set_identity();
+    if (apply_global)
+        apply_global_transform_d(corresp, pose_params, positions, pJ, Rglob);
+
+    // finger parameters
+    size_t ncorresp = corresp.size();
+    LightMatrix<double> tmp(3, 1);
+    for (int i = 0; i < 4 * 5; ++i)
+    {
+        LightMatrix<double> curr_J(3, ncorresp, &pJ[(6 + i) * 3 * ncorresp], false); // 6 is offset (global params)
+        for (int j = 0; j < curr_J.cols(); ++j)
+        {
+            // curr_J.col(j) = -Rglob * positions_d[i].get_col(corresp[j]);
+            mat_mult(Rglob, LightMatrix<double>(3, 1, positions_d[i].get_col_ptr(corresp[j]), false), &tmp);
+            curr_J.set_col(j, tmp.get_col(0));
+            curr_J.scale_col(j, -1.);
+        }
+    }
+}
+
+// Inputs:
+// us - double[2 * corresp.size()]
+// model - HandModelEigen
+// pose_params 3xN matrix
+// corresp - vector<int>
+// apply_global - bool, defaults to true
+// Outputs:
+// positions - 3xN matrix, allocated in this function
+// pJ - pointer to memory allocated for the jacobian
+void get_skinned_vertex_positions_d(
+    const double* const us,
+    const HandModelLightMatrix& model,
+    const LightMatrix<double>& pose_params,
+    const std::vector<int>& corresp,
+    LightMatrix<double>& positions,
+    double* pJ,
+    bool apply_global)
+{
+    std::vector<LightMatrix<double>> positions_d; //vector<Matrix3Xd>
+    get_skinned_vertex_positions_d_common(model, pose_params, corresp, positions,
+        positions_d, pJ);
+
+    LightMatrix<double> Rglob(3, 3);
+    Rglob.set_identity();
+    if (apply_global)
+        apply_global_transform_d(us, model.triangles, corresp, pose_params, positions, pJ, Rglob);
+
+    // finger parameters
+    size_t ncorresp = corresp.size();
+    LightMatrix<double> tmp1(3, 1), tmp2(3, 1);
+    for (int i = 0; i < 4 * 5; ++i)
+    {
+        LightMatrix<double> curr_J(3, ncorresp, &pJ[(6 + i) * 3 * ncorresp], false); // 6 is offset (global params)
+        for (int j = 0; j < curr_J.cols(); ++j)
+        {
+            const auto& verts = model.triangles[corresp[j]].verts;
+            const double* const u = &us[2 * j];
+
+            //tmp1 = u[0] * positions_d[i].col(verts[0]) + u[1] * positions_d[i].col(verts[1])
+            //    + (1. - u[0] - u[1]) * positions_d[i].col(verts[2]);
+            tmp1.set(positions_d[i].get_col(verts[0]));
+            tmp1.scale_col(0, u[0]);
+            tmp2.set(positions_d[i].get_col(verts[1]));
+            tmp2.scale_col(0, u[1]);
+            tmp1.add(tmp2);
+            tmp2.set(positions_d[i].get_col(verts[2]));
+            tmp2.scale_col(0, 1. - u[0] - u[1]);
+            tmp1.add(tmp2);
+
+            //curr_J.col(j) = -Rglob * tmp1;
+            mat_mult(Rglob, tmp1, &tmp2);
+            curr_J.set_col(j, tmp2.get_col(0));
+            curr_J.scale_col(j, -1.);
+        }
+    }
+}
+
+// Inputs:
+// theta - double[]
+// bone_names - vector<string>
+// Outputs:
+// pose_params - 3xN matrix, allocated in this function
+void to_pose_params_d(
+    const double* const theta,
+    const std::vector<std::string>& bone_names,
+    LightMatrix<double>& pose_params)
+{
+    pose_params.resize(3, bone_names.size() + 3);
+    pose_params.fill(0.);
+
+    pose_params.set_col(0, &theta[0]);
+    pose_params.set_col(1, 1.);
+    pose_params.set_col(2, &theta[3]);
+
+    int i_theta = 6;
+    int i_pose_params = 5;
+    int n_fingers = 5;
+    for (int i_finger = 0; i_finger < n_fingers; ++i_finger)
+    {
+        for (int i = 2; i <= 4; ++i)
+        {
+            pose_params(0, i_pose_params) = theta[i_theta++];
+            if (i == 2)
+            {
+                pose_params(1, i_pose_params) = theta[i_theta++];
+            }
+            i_pose_params++;
+        }
+        i_pose_params++;
+    }
+}
+
+// Inputs:
+// theta - double[]
+// data - HandDataEigen
+// Outputs:
+// perr - pointer to memory allocated for the objective - double[3 * data.correspondences.size()]
+// pJ - pointer to memory allocated for the jacobian
+void hand_objective_d(
+    const double* const theta,
+    const HandDataLightMatrix& data,
+    double* perr,
+    double* pJ)
+{
+    LightMatrix<double> pose_params; // Matrix3Xd
+    to_pose_params_d(theta, data.model.bone_names, pose_params);
+
+    LightMatrix<double> vertex_positions; // Matrix3Xd
+    get_skinned_vertex_positions_d(data.model, pose_params, data.correspondences, vertex_positions, pJ);
+
+    size_t npts = data.correspondences.size();
+    //Map<Matrix3Xd> err(perr, 3, npts);
+    LightMatrix<double> err(3, npts, perr, false);
+    for (size_t i = 0; i < data.correspondences.size(); ++i)
+    {
+        //err.col(i) = data.points.col(i) - vertex_positions.col(data.correspondences[i]);
+        subtract(3, data.points.get_col(i), vertex_positions.get_col(data.correspondences[i]), err.get_col_ptr(i));
+    }
+}
+
+// Inputs:
+// theta - double[]
+// us - double[2 * data.correspondences.size()]
+// data - HandDataEigen
+// Outputs:
+// perr - pointer to memory allocated for the objective - double[3 * data.correspondences.size()]
+// pJ - pointer to memory allocated for the jacobian
+void hand_objective_d(
+    const double* const theta,
+    const double* const us,
+    const HandDataLightMatrix& data,
+    double* perr,
+    double* pJ)
+{
+    LightMatrix<double> pose_params; // Matrix3Xd
+    to_pose_params_d(theta, data.model.bone_names, pose_params);
+
+    size_t npts = data.correspondences.size();
+    LightMatrix<double> vertex_positions; // Matrix3Xd
+    get_skinned_vertex_positions_d(us, data.model, pose_params, data.correspondences, vertex_positions, &pJ[2 * 3 * npts]);
+
+    LightMatrix<double> err(3, npts, perr, false);
+    LightMatrix<double> du0(3, npts, &pJ[0], false), du1(3, npts, &pJ[3 * npts], false);
+    LightMatrix<double> hand_point(3, 1), tmp(3, 1);
+    for (size_t i = 0; i < data.correspondences.size(); ++i)
+    {
+        const auto& verts = data.model.triangles[data.correspondences[i]].verts;
+        const double* const u = &us[2 * i];
+
+        subtract(3, vertex_positions.get_col(verts[2]), vertex_positions.get_col(verts[0]), du0.get_col_ptr(i));
+        subtract(3, vertex_positions.get_col(verts[2]), vertex_positions.get_col(verts[1]), du1.get_col_ptr(i));
+
+        //hand_point = u[0] * vertex_positions.col(verts[0]) + u[1] * vertex_positions.col(verts[1])
+        //    + (1. - u[0] - u[1]) * vertex_positions.col(verts[2]);
+        hand_point.set(vertex_positions.get_col(verts[0]));
+        hand_point.scale_col(0, u[0]);
+        tmp.set(vertex_positions.get_col(verts[1]));
+        tmp.scale_col(0, u[1]);
+        hand_point.add(tmp);
+        tmp.set(vertex_positions.get_col(verts[2]));
+        tmp.scale_col(0, 1. - u[0] - u[1]);
+        hand_point.add(tmp);
+
+        subtract(3, data.points.get_col(i), hand_point.get_col(0), err.get_col_ptr(i));
+    }
+}

--- a/tools/manual/ht_d.h
+++ b/tools/manual/ht_d.h
@@ -1,0 +1,206 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+// https://github.com/microsoft/ADBench/blob/38cb7931303a830c3700ca36ba9520868327ac87/src/cpp/modules/manual/ht_d.h
+
+#pragma once
+
+/*
+ * Manual differentiation of the hand tracking problem.
+ * Adapted from the Eigen-based version.
+ *
+ * Functions in this file do not perform any checks on input parameters
+ * for the sake of better performance.
+*/
+
+#include <array>
+#include <vector>
+#include <string>
+
+#include "adbench/shared/defs.h"
+#include "adbench/shared/light_matrix.h"
+#include "adbench/shared/utils.h"
+
+// Inputs:
+// angle_axis - double[3]
+// Outputs:
+// R - preallocated 3x3 matrix
+// dR - array of 3 preallocated 3x3 matrices
+void angle_axis_to_rotation_matrix_d(
+    const double* angle_axis,
+    LightMatrix<double>& R,
+    std::array<LightMatrix<double>, 3>& dR);
+
+// Inputs:
+// pose_params - 3xN matrix
+// Outputs:
+// R - preallocated 3x3 matrix
+// dR - array of 3 preallocated 3x3 matrices
+void apply_global_transform_d_common(const LightMatrix<double>& pose_params, LightMatrix<double>& R, std::array<LightMatrix<double>, 3> & dR);
+
+// Inputs:
+// npts - int
+// R - 3x3 matrix
+// pose_params - 3xN matrix
+// References
+// positions - 3xN matrix,
+// Outputs:
+// pJ - pointer to memory allocated for the jacobian
+void apply_global_translation_d(const size_t& npts, const LightMatrix<double>& R, const LightMatrix<double>& pose_params, LightMatrix<double>& positions, double* pJ);
+
+// Inputs:
+// corresp - vector<int>
+// pose_params - 3xN matrix
+// References
+// positions - 3xN matrix,
+// Outputs:
+// pJ - pointer to memory allocated for the jacobian
+// R - preallocated 3x3 matrix
+void apply_global_transform_d(
+    const std::vector<int>& corresp,
+    const LightMatrix<double>& pose_params,
+    LightMatrix<double>& positions,
+    double* pJ,
+    LightMatrix<double>& R);
+
+// Inputs:
+// us - double[2 * corresp.size()]
+// triangles - vector<Triangle>,
+// corresp - vector<int>
+// pose_params - 3xN matrix
+// References
+// positions - 3xN matrix,
+// Outputs:
+// pJ - pointer to memory allocated for the jacobian
+// R - preallocated 3x3 matrix
+void apply_global_transform_d(
+    const double* const us,
+    const std::vector<Triangle>& triangles,
+    const std::vector<int>& corresp,
+    const LightMatrix<double>& pose_params,
+    LightMatrix<double>& positions,
+    double* pJ,
+    LightMatrix<double>& R);
+
+// Inputs:
+// relatives - vector of parents.size() 4x4 matrices
+// relatives_d  - vector of 4x4 matrices
+// parents - vector<int>
+// Outputs:
+// absolutes - vector of 4x4 matrices, allocated in this function
+// absolutes_d - vector of vectors of 4x4 matrices, allocated in this function
+void relatives_to_absolutes_d(
+    const std::vector<LightMatrix<double>>& relatives,
+    const std::vector<LightMatrix<double>>& relatives_d,
+    const std::vector<int>& parents,
+    std::vector<LightMatrix<double>>& absolutes,
+    std::vector<std::vector<LightMatrix<double>>>& absolutes_d);
+
+// Inputs:
+// xzy - double[3]
+// Outputs:
+// R - 3x3 matrix, allocated in this function
+// pdR0 - nullable pointer to 3x3 matrix (computed only if not null)
+// pdR1 - nullable pointer to 3x3 matrix (computed only if not null)
+void euler_angles_to_rotation_matrix(
+    const double* xzy,
+    LightMatrix<double>& R,
+    LightMatrix<double>* pdR0 = nullptr,
+    LightMatrix<double>* pdR1 = nullptr);
+
+// Inputs:
+// model - HandModelEigen
+// pose_params - 3xN matrix
+// relatives - vector of 4x4 matrices, allocated in this function
+// relatives_d - vector of 4x4 matrices, allocated in this function
+void get_posed_relatives_d(
+    const HandModelLightMatrix& model,
+    const LightMatrix<double>& pose_params,
+    std::vector<LightMatrix<double>>& relatives,
+    std::vector<LightMatrix<double>>& relatives_d);
+
+// Inputs:
+// model - HandModelEigen
+// pose_params 3xN matrix
+// corresp - vector<int>
+// Outputs:
+// positions - 3xN matrix, allocated in this function
+// positions_d - vector of 3xN matrices, allocated in this function
+// pJ - pointer to memory allocated for the jacobian
+void get_skinned_vertex_positions_d_common(
+    const HandModelLightMatrix& model,
+    const LightMatrix<double>& pose_params,
+    const std::vector<int>& corresp,
+    LightMatrix<double>& positions,
+    std::vector<LightMatrix<double>>& positions_d,
+    double* pJ);
+
+// Inputs:
+// model - HandModelEigen
+// pose_params 3xN matrix
+// corresp - vector<int>
+// apply_global - bool, defaults to true
+// Outputs:
+// positions - 3xN matrix, allocated in this function
+// pJ - pointer to memory allocated for the jacobian
+void get_skinned_vertex_positions_d(
+    const HandModelLightMatrix& model,
+    const LightMatrix<double>& pose_params,
+    const std::vector<int>& corresp,
+    LightMatrix<double>& positions,
+    double* pJ,
+    bool apply_global = true);
+
+// Inputs:
+// us - double[2 * corresp.size()]
+// model - HandModelEigen
+// pose_params 3xN matrix
+// corresp - vector<int>
+// apply_global - bool, defaults to true
+// Outputs:
+// positions - 3xN matrix, allocated in this function
+// pJ - pointer to memory allocated for the jacobian
+void get_skinned_vertex_positions_d(
+    const double* const us,
+    const HandModelLightMatrix& model,
+    const LightMatrix<double>& pose_params,
+    const std::vector<int>& corresp,
+    LightMatrix<double>& positions,
+    double* pJ,
+    bool apply_global = true);
+
+// Inputs:
+// theta - double[]
+// bone_names - vector<string>
+// Outputs:
+// pose_params - 3xN matrix, allocated in this function
+void to_pose_params_d(
+    const double* const theta,
+    const std::vector<std::string>& bone_names,
+    LightMatrix<double>& pose_params);
+
+// Inputs:
+// theta - double[]
+// data - HandDataEigen
+// Outputs:
+// perr - pointer to memory allocated for the objective - double[3 * data.correspondences.size()]
+// pJ - pointer to memory allocated for the jacobian
+void hand_objective_d(
+    const double* const theta,
+    const HandDataLightMatrix& data,
+    double* perr,
+    double* pJ);
+
+// Inputs:
+// theta - double[]
+// us - double[2 * data.correspondences.size()]
+// data - HandDataEigen
+// Outputs:
+// perr - pointer to memory allocated for the objective - double[3 * data.correspondences.size()]
+// pJ - pointer to memory allocated for the jacobian
+void hand_objective_d(
+    const double* const theta,
+    const double* const us,
+    const HandDataLightMatrix& data,
+    double* perr,
+    double* pJ);

--- a/tools/manual/lstm.py
+++ b/tools/manual/lstm.py
@@ -1,0 +1,27 @@
+import json
+import subprocess
+import tempfile
+from os import listdir
+
+
+def compile():
+    # Nothing to do here. We assume everything is precompiled.
+    return True
+
+
+def calculate_objectiveLSTM(input):
+    with tempfile.NamedTemporaryFile("w") as tmp:
+        json.dump(input, tmp)
+        tmp.flush()
+        return subprocess.run(
+            ["tools/manual/run_lstm", tmp.name, "F"], text=True, capture_output=True
+        )
+
+
+def calculate_jacobianLSTM(input):
+    with tempfile.NamedTemporaryFile("w") as tmp:
+        json.dump(input, tmp)
+        tmp.flush()
+        return subprocess.run(
+            ["tools/manual/run_lstm", tmp.name, "J"], text=True, capture_output=True
+        )

--- a/tools/manual/lstm_d.cpp
+++ b/tools/manual/lstm_d.cpp
@@ -1,0 +1,545 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+// https://github.com/microsoft/ADBench/blob/38cb7931303a830c3700ca36ba9520868327ac87/src/cpp/modules/manual/lstm_d.cpp
+
+#include "lstm_d.h"
+#include "lstm_d_structures.h"
+#include "adbench/shared/lstm.h"
+
+// UTILS
+
+// Sigmoid diff on scalar
+template<typename T>
+T sigmoid_d(T x, T* d) {
+    T s = sigmoid(x);
+    *d = s * (1 - s);
+    return s;
+}
+
+// tanh diff on scalar
+template<typename T>
+T tanh_d(T x, T* d) {
+    T t = tanh(x);
+    *d = 1 - t * t;
+    return t;
+}
+
+// value (returned) and gradient (written to J) of log(sum(exp(x), 2))
+template<typename T>
+T logsumexp_d(const T* vect, int sz, T* J) {
+    for (int i = 0; i < sz; i++) J[i] = exp(vect[i]);
+    T sum = 0.0;
+    for (int i = 0; i < sz; i++) sum += J[i];
+    sum += 2.;
+
+    for (int i = 0; i < sz; i++) J[i] /= sum;
+    return log(sum);
+}
+
+template<typename T>
+void swap(StateJacobianPredict<T>& j1, StateJacobianPredict<T>& j2)
+{
+    j1.layer.swap(j2.layer);
+}
+
+// OBJECTIVE
+
+// Manual Jacobian of lstm_model
+// Outputs jacobian containing the derivatives of the new state
+// with relation to params, state, and input
+template<typename T>
+void lstm_model_d(int hsize,
+    const LayerParams<T>& params,
+    LayerState<T>& state,
+    const T* input,
+    ModelJacobian<T>& jacobian)
+{
+    for (int i = 0; i < hsize; i++) {
+        // Only get relevant derivatives
+
+        T forget_in = input[i] * params.weight.forget[i] + params.bias.forget[i];
+        T forget_sd;
+        T forget = sigmoid_d(forget_in, &forget_sd);
+        T forget_dw = forget_sd * input[i];
+        T forget_db = forget_sd;
+        T forget_di = forget_sd * params.weight.forget[i];
+
+        T ingate_in = state.hidden[i] * params.weight.ingate[i] + params.bias.ingate[i];
+        T ingate_sd;
+        T ingate = sigmoid_d(ingate_in, &ingate_sd);
+        T ingate_dw = ingate_sd * state.hidden[i];
+        T ingate_db = ingate_sd;
+        T ingate_dh = ingate_sd * params.weight.ingate[i];
+
+        T outgate_in = input[i] * params.weight.outgate[i] + params.bias.outgate[i];
+        T outgate_sd;
+        T outgate = sigmoid_d(outgate_in, &outgate_sd);
+        T outgate_dw = outgate_sd * input[i];
+        T outgate_db = outgate_sd;
+        T outgate_di = outgate_sd * params.weight.outgate[i];
+
+        T change_in = state.hidden[i] * params.weight.change[i] + params.bias.change[i];
+        T change_td;
+        T change = tanh_d(change_in, &change_td);
+        T change_dw = change_td * state.hidden[i];
+        T change_db = change_td;
+        T change_dh = change_td * params.weight.change[i];
+
+        // Cell derivatives
+
+        T orig_cell = state.cell[i];
+        state.cell[i] = orig_cell * forget + ingate * change;
+        // wrt weight
+        jacobian.cell[i].d_weight.forget = orig_cell * forget_dw;
+        jacobian.cell[i].d_weight.ingate = change * ingate_dw;
+        jacobian.cell[i].d_weight.outgate = 0.;
+        jacobian.cell[i].d_weight.change = ingate * change_dw;
+        // wrt bias
+        jacobian.cell[i].d_bias.forget = orig_cell * forget_db;
+        jacobian.cell[i].d_bias.ingate = change * ingate_db;
+        jacobian.cell[i].d_bias.outgate = 0.;
+        jacobian.cell[i].d_bias.change = ingate * change_db;
+        // wrt hidden, cell(original), input
+        jacobian.cell[i].d_hidden = ingate * change_dh + change * ingate_dh;
+        jacobian.cell[i].d_cell = forget;
+        jacobian.cell[i].d_input = orig_cell * forget_di;
+
+        // Hidden derivatives
+        T hidden_td;
+        T hidden_t = tanh_d(state.cell[i], &hidden_td);
+        state.hidden[i] = outgate * hidden_t;
+        hidden_td *= outgate;
+        // wrt weight
+        jacobian.hidden[i].d_weight.forget = hidden_td * jacobian.cell[i].d_weight.forget;
+        jacobian.hidden[i].d_weight.ingate = hidden_td * jacobian.cell[i].d_weight.ingate;
+        jacobian.hidden[i].d_weight.outgate = hidden_t * outgate_dw;
+        jacobian.hidden[i].d_weight.change = hidden_td * jacobian.cell[i].d_weight.change;
+        // wrt bias
+        jacobian.hidden[i].d_bias.forget = hidden_td * jacobian.cell[i].d_bias.forget;
+        jacobian.hidden[i].d_bias.ingate = hidden_td * jacobian.cell[i].d_bias.ingate;
+        jacobian.hidden[i].d_bias.outgate = hidden_t * outgate_db;
+        jacobian.hidden[i].d_bias.change = hidden_td * jacobian.cell[i].d_bias.change;
+        // wrt hidden, cell (original), input
+        jacobian.hidden[i].d_hidden = hidden_td * jacobian.cell[i].d_hidden;
+        jacobian.hidden[i].d_cell = hidden_td * jacobian.cell[i].d_cell;
+        jacobian.hidden[i].d_input = outgate_di * hidden_t + hidden_td * jacobian.cell[i].d_input;
+    }
+}
+
+
+// Manual jacobian of lstm_predict
+// Outputs state_jacobian containing the derivatives of the new state
+// and output_jacobian containing the derivatives of the output
+// with relation to main_params, extra_params, and state
+//
+// zero_layer_jacobian and layer_state_d are references to
+// pre-allocated structures that will be used in computations.
+// This function is being called from a long loop, so allocating them only once
+// can save some time.
+template<typename T>
+void lstm_predict_d(int l, int b,
+    const MainParams<T>& main_params, const ExtraParams<T>& extra_params,
+    State<T>& state,
+    const T* input,
+    LayerStateJacobianPredict<T>& zero_layer_jacobian,
+    ModelJacobian<T>& layer_state_d,
+    T* output,
+    StateJacobianPredict<T>& state_jacobian,
+    PredictionJacobian<T>& output_jacobian)
+{
+    // Intial setup (from predict())
+    for (int i = 0; i < b; ++i) {
+        output[i] = input[i] * extra_params.in_weight[i];
+        // note that the rest of zero_layer_jacobian.d_hidden and zero_layer_jacobian.d_cell are unused
+        *zero_layer_jacobian.d_hidden[i].d_extra_in_weight = input[i];
+    }
+
+    // Pointer to current output/next layer's input
+    T* layer_output = output;
+    // Pointer to the jacobian of the previous layer
+    LayerStateJacobianPredict<T>* prev_layer_jacobian = &zero_layer_jacobian;
+
+    // Main LSTM loop (from predict())
+    for (int i = 0; i < l; ++i)
+    {
+        lstm_model_d(b, main_params.layer_params[i], state.layer_state[i], layer_output, layer_state_d);
+        layer_output = state.layer_state[i].hidden;
+
+        // set state_jacobian.layer[i]
+        for (int j = 0; j < b; ++j)
+        {
+            T hidden_j_d_input = layer_state_d.hidden[j].d_input;
+            T cell_j_d_input = layer_state_d.cell[j].d_input;
+            // derivatives by variables on which layer_output depends
+            *state_jacobian.layer[i].d_hidden[j].d_extra_in_weight = hidden_j_d_input * (*prev_layer_jacobian->d_hidden[j].d_extra_in_weight);
+            *state_jacobian.layer[i].d_cell[j].d_extra_in_weight = cell_j_d_input * (*prev_layer_jacobian->d_hidden[j].d_extra_in_weight);
+            for (int k = 0; k < i ; ++k)
+            {
+                state_jacobian.layer[i].d_hidden[j].d_weight_forget[k] = hidden_j_d_input * prev_layer_jacobian->d_hidden[j].d_weight_forget[k];
+                state_jacobian.layer[i].d_hidden[j].d_weight_ingate[k] = hidden_j_d_input * prev_layer_jacobian->d_hidden[j].d_weight_ingate[k];
+                state_jacobian.layer[i].d_hidden[j].d_weight_outgate[k] = hidden_j_d_input * prev_layer_jacobian->d_hidden[j].d_weight_outgate[k];
+                state_jacobian.layer[i].d_hidden[j].d_weight_change[k] = hidden_j_d_input * prev_layer_jacobian->d_hidden[j].d_weight_change[k];
+                state_jacobian.layer[i].d_hidden[j].d_bias_forget[k] = hidden_j_d_input * prev_layer_jacobian->d_hidden[j].d_bias_forget[k];
+                state_jacobian.layer[i].d_hidden[j].d_bias_ingate[k] = hidden_j_d_input * prev_layer_jacobian->d_hidden[j].d_bias_ingate[k];
+                state_jacobian.layer[i].d_hidden[j].d_bias_outgate[k] = hidden_j_d_input * prev_layer_jacobian->d_hidden[j].d_bias_outgate[k];
+                state_jacobian.layer[i].d_hidden[j].d_bias_change[k] = hidden_j_d_input * prev_layer_jacobian->d_hidden[j].d_bias_change[k];
+                state_jacobian.layer[i].d_hidden[j].d_hidden[k] = hidden_j_d_input * prev_layer_jacobian->d_hidden[j].d_hidden[k];
+                state_jacobian.layer[i].d_hidden[j].d_cell[k] = hidden_j_d_input * prev_layer_jacobian->d_hidden[j].d_cell[k];
+                state_jacobian.layer[i].d_cell[j].d_weight_forget[k] = cell_j_d_input * prev_layer_jacobian->d_hidden[j].d_weight_forget[k];
+                state_jacobian.layer[i].d_cell[j].d_weight_ingate[k] = cell_j_d_input * prev_layer_jacobian->d_hidden[j].d_weight_ingate[k];
+                state_jacobian.layer[i].d_cell[j].d_weight_outgate[k] = cell_j_d_input * prev_layer_jacobian->d_hidden[j].d_weight_outgate[k];
+                state_jacobian.layer[i].d_cell[j].d_weight_change[k] = cell_j_d_input * prev_layer_jacobian->d_hidden[j].d_weight_change[k];
+                state_jacobian.layer[i].d_cell[j].d_bias_forget[k] = cell_j_d_input * prev_layer_jacobian->d_hidden[j].d_bias_forget[k];
+                state_jacobian.layer[i].d_cell[j].d_bias_ingate[k] = cell_j_d_input * prev_layer_jacobian->d_hidden[j].d_bias_ingate[k];
+                state_jacobian.layer[i].d_cell[j].d_bias_outgate[k] = cell_j_d_input * prev_layer_jacobian->d_hidden[j].d_bias_outgate[k];
+                state_jacobian.layer[i].d_cell[j].d_bias_change[k] = cell_j_d_input * prev_layer_jacobian->d_hidden[j].d_bias_change[k];
+                state_jacobian.layer[i].d_cell[j].d_hidden[k] = cell_j_d_input * prev_layer_jacobian->d_hidden[j].d_hidden[k];
+                state_jacobian.layer[i].d_cell[j].d_cell[k] = cell_j_d_input * prev_layer_jacobian->d_hidden[j].d_cell[k];
+            }
+            // derivatives by variables on which lstm_model_d depends directly
+            state_jacobian.layer[i].d_hidden[j].d_weight_forget[i] = layer_state_d.hidden[j].d_weight.forget;
+            state_jacobian.layer[i].d_hidden[j].d_weight_ingate[i] = layer_state_d.hidden[j].d_weight.ingate;
+            state_jacobian.layer[i].d_hidden[j].d_weight_outgate[i] = layer_state_d.hidden[j].d_weight.outgate;
+            state_jacobian.layer[i].d_hidden[j].d_weight_change[i] = layer_state_d.hidden[j].d_weight.change;
+            state_jacobian.layer[i].d_hidden[j].d_bias_forget[i] = layer_state_d.hidden[j].d_bias.forget;
+            state_jacobian.layer[i].d_hidden[j].d_bias_ingate[i] = layer_state_d.hidden[j].d_bias.ingate;
+            state_jacobian.layer[i].d_hidden[j].d_bias_outgate[i] = layer_state_d.hidden[j].d_bias.outgate;
+            state_jacobian.layer[i].d_hidden[j].d_bias_change[i] = layer_state_d.hidden[j].d_bias.change;
+            state_jacobian.layer[i].d_hidden[j].d_hidden[i] = layer_state_d.hidden[j].d_hidden;
+            state_jacobian.layer[i].d_hidden[j].d_cell[i] = layer_state_d.hidden[j].d_cell;
+            state_jacobian.layer[i].d_cell[j].d_weight_forget[i] = layer_state_d.cell[j].d_weight.forget;
+            state_jacobian.layer[i].d_cell[j].d_weight_ingate[i] = layer_state_d.cell[j].d_weight.ingate;
+            state_jacobian.layer[i].d_cell[j].d_weight_outgate[i] = layer_state_d.cell[j].d_weight.outgate;
+            state_jacobian.layer[i].d_cell[j].d_weight_change[i] = layer_state_d.cell[j].d_weight.change;
+            state_jacobian.layer[i].d_cell[j].d_bias_forget[i] = layer_state_d.cell[j].d_bias.forget;
+            state_jacobian.layer[i].d_cell[j].d_bias_ingate[i] = layer_state_d.cell[j].d_bias.ingate;
+            state_jacobian.layer[i].d_cell[j].d_bias_outgate[i] = layer_state_d.cell[j].d_bias.outgate;
+            state_jacobian.layer[i].d_cell[j].d_bias_change[i] = layer_state_d.cell[j].d_bias.change;
+            state_jacobian.layer[i].d_cell[j].d_hidden[i] = layer_state_d.cell[j].d_hidden;
+            state_jacobian.layer[i].d_cell[j].d_cell[i] = layer_state_d.cell[j].d_cell;
+            // derivatives by variable on which lstm_model_d does not depend (zero)
+            for (int k = i + 1; k < l; ++k)
+            {
+                state_jacobian.layer[i].d_hidden[j].d_weight_forget[k] = 0.;
+                state_jacobian.layer[i].d_hidden[j].d_weight_ingate[k] = 0.;
+                state_jacobian.layer[i].d_hidden[j].d_weight_outgate[k] = 0.;
+                state_jacobian.layer[i].d_hidden[j].d_weight_change[k] = 0.;
+                state_jacobian.layer[i].d_hidden[j].d_bias_forget[k] = 0.;
+                state_jacobian.layer[i].d_hidden[j].d_bias_ingate[k] = 0.;
+                state_jacobian.layer[i].d_hidden[j].d_bias_outgate[k] = 0.;
+                state_jacobian.layer[i].d_hidden[j].d_bias_change[k] = 0.;
+                state_jacobian.layer[i].d_hidden[j].d_hidden[k] = 0.;
+                state_jacobian.layer[i].d_hidden[j].d_cell[k] = 0.;
+                state_jacobian.layer[i].d_cell[j].d_weight_forget[k] = 0.;
+                state_jacobian.layer[i].d_cell[j].d_weight_ingate[k] = 0.;
+                state_jacobian.layer[i].d_cell[j].d_weight_outgate[k] = 0.;
+                state_jacobian.layer[i].d_cell[j].d_weight_change[k] = 0.;
+                state_jacobian.layer[i].d_cell[j].d_bias_forget[k] = 0.;
+                state_jacobian.layer[i].d_cell[j].d_bias_ingate[k] = 0.;
+                state_jacobian.layer[i].d_cell[j].d_bias_outgate[k] = 0.;
+                state_jacobian.layer[i].d_cell[j].d_bias_change[k] = 0.;
+                state_jacobian.layer[i].d_cell[j].d_hidden[k] = 0.;
+                state_jacobian.layer[i].d_cell[j].d_cell[k] = 0.;
+            }
+        }
+        prev_layer_jacobian = &state_jacobian.layer[i];
+    }
+
+    // Final changes (from predict())
+    for (int i = 0; i < b; ++i)
+    {
+        T cur_out_weight = extra_params.out_weight[i];
+        // compute output
+        output[i] = layer_output[i] * cur_out_weight + extra_params.out_bias[i];
+        // compute the derivatives of output
+        *output_jacobian.d_prediction[i].d_extra_in_weight = cur_out_weight * (*prev_layer_jacobian->d_hidden[i].d_extra_in_weight);
+        *output_jacobian.d_prediction[i].d_extra_out_weight = layer_output[i];
+        *output_jacobian.d_prediction[i].d_extra_out_bias = 1.;
+        for (int j = 0; j < l; ++j)
+        {
+            output_jacobian.d_prediction[i].d_weight_forget[j] = cur_out_weight * prev_layer_jacobian->d_hidden[i].d_weight_forget[j];
+            output_jacobian.d_prediction[i].d_weight_ingate[j] = cur_out_weight * prev_layer_jacobian->d_hidden[i].d_weight_ingate[j];
+            output_jacobian.d_prediction[i].d_weight_outgate[j] = cur_out_weight * prev_layer_jacobian->d_hidden[i].d_weight_outgate[j];
+            output_jacobian.d_prediction[i].d_weight_change[j] = cur_out_weight * prev_layer_jacobian->d_hidden[i].d_weight_change[j];
+            output_jacobian.d_prediction[i].d_bias_forget[j] = cur_out_weight * prev_layer_jacobian->d_hidden[i].d_bias_forget[j];
+            output_jacobian.d_prediction[i].d_bias_ingate[j] = cur_out_weight * prev_layer_jacobian->d_hidden[i].d_bias_ingate[j];
+            output_jacobian.d_prediction[i].d_bias_outgate[j] = cur_out_weight * prev_layer_jacobian->d_hidden[i].d_bias_outgate[j];
+            output_jacobian.d_prediction[i].d_bias_change[j] = cur_out_weight * prev_layer_jacobian->d_hidden[i].d_bias_change[j];
+            output_jacobian.d_prediction[i].d_hidden[j] = cur_out_weight * prev_layer_jacobian->d_hidden[i].d_hidden[j];
+            output_jacobian.d_prediction[i].d_cell[j] = cur_out_weight * prev_layer_jacobian->d_hidden[i].d_cell[j];
+        }
+    }
+}
+
+// Gradient of the logsumexp(prediction(params)) with relation to params
+void logsumexp_grad(int n_layers, int hsize, const std::vector<double>& lse_d, const PredictionJacobian<double>& ypred_jacobian, GradByParams<double>& grad_lse_ypred)
+{
+    for (int i = 0; i < hsize; ++i)
+    {
+        double lse_d_i = lse_d[i];
+        for (int j = 0; j < n_layers; ++j)
+        {
+            grad_lse_ypred.layer[j].d_weight.forget[i] = lse_d_i * ypred_jacobian.d_prediction[i].d_weight_forget[j];
+            grad_lse_ypred.layer[j].d_weight.ingate[i] = lse_d_i * ypred_jacobian.d_prediction[i].d_weight_ingate[j];
+            grad_lse_ypred.layer[j].d_weight.outgate[i] = lse_d_i * ypred_jacobian.d_prediction[i].d_weight_outgate[j];
+            grad_lse_ypred.layer[j].d_weight.change[i] = lse_d_i * ypred_jacobian.d_prediction[i].d_weight_change[j];
+            grad_lse_ypred.layer[j].d_bias.forget[i] = lse_d_i * ypred_jacobian.d_prediction[i].d_bias_forget[j];
+            grad_lse_ypred.layer[j].d_bias.ingate[i] = lse_d_i * ypred_jacobian.d_prediction[i].d_bias_ingate[j];
+            grad_lse_ypred.layer[j].d_bias.outgate[i] = lse_d_i * ypred_jacobian.d_prediction[i].d_bias_outgate[j];
+            grad_lse_ypred.layer[j].d_bias.change[i] = lse_d_i * ypred_jacobian.d_prediction[i].d_bias_change[j];
+        }
+        grad_lse_ypred.d_in_weight[i] = lse_d_i * (*ypred_jacobian.d_prediction[i].d_extra_in_weight);
+        grad_lse_ypred.d_out_weight[i] = lse_d_i * (*ypred_jacobian.d_prediction[i].d_extra_out_weight);
+        grad_lse_ypred.d_out_bias[i] = lse_d_i * (*ypred_jacobian.d_prediction[i].d_extra_out_bias);
+    }
+}
+
+// Updates the gradient of the loss function (loss_grad) after doing a prediction
+// using the gold value for the prediction (ygold),
+// jacobian of the prediction with relation to params (ypred_jacobian),
+// and the gradient of the logsumexp(prediction(params)) with relation to params (grad_lse_ypred)
+void update_loss_gradient(int n_layers, int hsize, const double* ygold, const GradByParams<double>& grad_lse_ypred, const PredictionJacobian<double>& ypred_jacobian, GradByParams<double>& loss_grad)
+{
+    for (int i = 0; i < hsize; ++i)
+    {
+        double ygold_i = ygold[i];
+
+        for (int j = 0; j < hsize; ++j)
+        {
+            if (i != j)
+            {
+                for (int k = 0; k < n_layers; ++k)
+                {
+                    loss_grad.layer[k].d_weight.forget[j] -= ygold_i * grad_lse_ypred.layer[k].d_weight.forget[j];
+                    loss_grad.layer[k].d_weight.ingate[j] -= ygold_i * grad_lse_ypred.layer[k].d_weight.ingate[j];
+                    loss_grad.layer[k].d_weight.outgate[j] -= ygold_i * grad_lse_ypred.layer[k].d_weight.outgate[j];
+                    loss_grad.layer[k].d_weight.change[j] -= ygold_i * grad_lse_ypred.layer[k].d_weight.change[j];
+                    loss_grad.layer[k].d_bias.ingate[j] -= ygold_i * grad_lse_ypred.layer[k].d_bias.ingate[j];
+                    loss_grad.layer[k].d_bias.forget[j] -= ygold_i * grad_lse_ypred.layer[k].d_bias.forget[j];
+                    loss_grad.layer[k].d_bias.outgate[j] -= ygold_i * grad_lse_ypred.layer[k].d_bias.outgate[j];
+                    loss_grad.layer[k].d_bias.change[j] -= ygold_i * grad_lse_ypred.layer[k].d_bias.change[j];
+                }
+                loss_grad.d_in_weight[j] -= ygold_i * grad_lse_ypred.d_in_weight[j];
+                loss_grad.d_out_weight[j] -= ygold_i * grad_lse_ypred.d_out_weight[j];
+                loss_grad.d_out_bias[j] -= ygold_i * grad_lse_ypred.d_out_bias[j];
+            }
+            else
+            {
+                for (int k = 0; k < n_layers; ++k)
+                {
+                    loss_grad.layer[k].d_weight.forget[j] += ygold_i * (ypred_jacobian.d_prediction[i].d_weight_forget[k] - grad_lse_ypred.layer[k].d_weight.forget[j]);
+                    loss_grad.layer[k].d_weight.ingate[j] += ygold_i * (ypred_jacobian.d_prediction[i].d_weight_ingate[k] - grad_lse_ypred.layer[k].d_weight.ingate[j]);
+                    loss_grad.layer[k].d_weight.outgate[j] += ygold_i * (ypred_jacobian.d_prediction[i].d_weight_outgate[k] - grad_lse_ypred.layer[k].d_weight.outgate[j]);
+                    loss_grad.layer[k].d_weight.change[j] += ygold_i * (ypred_jacobian.d_prediction[i].d_weight_change[k] - grad_lse_ypred.layer[k].d_weight.change[j]);
+                    loss_grad.layer[k].d_bias.forget[j] += ygold_i * (ypred_jacobian.d_prediction[i].d_bias_forget[k] - grad_lse_ypred.layer[k].d_bias.forget[j]);
+                    loss_grad.layer[k].d_bias.ingate[j] += ygold_i * (ypred_jacobian.d_prediction[i].d_bias_ingate[k] - grad_lse_ypred.layer[k].d_bias.ingate[j]);
+                    loss_grad.layer[k].d_bias.outgate[j] += ygold_i * (ypred_jacobian.d_prediction[i].d_bias_outgate[k] - grad_lse_ypred.layer[k].d_bias.outgate[j]);
+                    loss_grad.layer[k].d_bias.change[j] += ygold_i * (ypred_jacobian.d_prediction[i].d_bias_change[k] - grad_lse_ypred.layer[k].d_bias.change[j]);
+                }
+                loss_grad.d_in_weight[j] += ygold_i * ((*ypred_jacobian.d_prediction[i].d_extra_in_weight) - grad_lse_ypred.d_in_weight[j]);
+                loss_grad.d_out_weight[j] += ygold_i * ((*ypred_jacobian.d_prediction[i].d_extra_out_weight) - grad_lse_ypred.d_out_weight[j]);
+                loss_grad.d_out_bias[j] += ygold_i * ((*ypred_jacobian.d_prediction[i].d_extra_out_bias) - grad_lse_ypred.d_out_bias[j]);
+            }
+        }
+    }
+}
+
+// Add (D pred / D state_(t-1)) * (D state_(t-1) / D params) to ypred_jacobian with relation to params
+void update_pred_jacobian_with_prev_state_jacobian(int n_layers, int hsize, const StateJacobianPredict<double>& prev_state_jacobian, PredictionJacobian<double>& ypred_jacobian)
+{
+    for (int pos = 0; pos < hsize; ++pos)
+    {
+        for (int i = 0; i < n_layers; ++i)
+        {
+            for (int j = 0; j < n_layers; ++j)
+            {
+                ypred_jacobian.d_prediction[pos].d_weight_forget[j] +=
+                    ypred_jacobian.d_prediction[pos].d_hidden[i] * prev_state_jacobian.layer[i].d_hidden[pos].d_weight_forget[j]
+                    + ypred_jacobian.d_prediction[pos].d_cell[i] * prev_state_jacobian.layer[i].d_cell[pos].d_weight_forget[j];
+                ypred_jacobian.d_prediction[pos].d_weight_ingate[j] +=
+                    ypred_jacobian.d_prediction[pos].d_hidden[i] * prev_state_jacobian.layer[i].d_hidden[pos].d_weight_ingate[j]
+                    + ypred_jacobian.d_prediction[pos].d_cell[i] * prev_state_jacobian.layer[i].d_cell[pos].d_weight_ingate[j];
+                ypred_jacobian.d_prediction[pos].d_weight_outgate[j] +=
+                    ypred_jacobian.d_prediction[pos].d_hidden[i] * prev_state_jacobian.layer[i].d_hidden[pos].d_weight_outgate[j]
+                    + ypred_jacobian.d_prediction[pos].d_cell[i] * prev_state_jacobian.layer[i].d_cell[pos].d_weight_outgate[j];
+                ypred_jacobian.d_prediction[pos].d_weight_change[j] +=
+                    ypred_jacobian.d_prediction[pos].d_hidden[i] * prev_state_jacobian.layer[i].d_hidden[pos].d_weight_change[j]
+                    + ypred_jacobian.d_prediction[pos].d_cell[i] * prev_state_jacobian.layer[i].d_cell[pos].d_weight_change[j];
+
+                ypred_jacobian.d_prediction[pos].d_bias_forget[j] +=
+                    ypred_jacobian.d_prediction[pos].d_hidden[i] * prev_state_jacobian.layer[i].d_hidden[pos].d_bias_forget[j]
+                    + ypred_jacobian.d_prediction[pos].d_cell[i] * prev_state_jacobian.layer[i].d_cell[pos].d_bias_forget[j];
+                ypred_jacobian.d_prediction[pos].d_bias_ingate[j] +=
+                    ypred_jacobian.d_prediction[pos].d_hidden[i] * prev_state_jacobian.layer[i].d_hidden[pos].d_bias_ingate[j]
+                    + ypred_jacobian.d_prediction[pos].d_cell[i] * prev_state_jacobian.layer[i].d_cell[pos].d_bias_ingate[j];
+                ypred_jacobian.d_prediction[pos].d_bias_outgate[j] +=
+                    ypred_jacobian.d_prediction[pos].d_hidden[i] * prev_state_jacobian.layer[i].d_hidden[pos].d_bias_outgate[j]
+                    + ypred_jacobian.d_prediction[pos].d_cell[i] * prev_state_jacobian.layer[i].d_cell[pos].d_bias_outgate[j];
+                ypred_jacobian.d_prediction[pos].d_bias_change[j] +=
+                    ypred_jacobian.d_prediction[pos].d_hidden[i] * prev_state_jacobian.layer[i].d_hidden[pos].d_bias_change[j]
+                    + ypred_jacobian.d_prediction[pos].d_cell[i] * prev_state_jacobian.layer[i].d_cell[pos].d_bias_change[j];
+            }
+            *ypred_jacobian.d_prediction[pos].d_extra_in_weight +=
+                ypred_jacobian.d_prediction[pos].d_hidden[i] * (*prev_state_jacobian.layer[i].d_hidden[pos].d_extra_in_weight)
+                + ypred_jacobian.d_prediction[pos].d_cell[i] * (*prev_state_jacobian.layer[i].d_cell[pos].d_extra_in_weight);
+        }
+    }
+}
+
+// Add (D state_t / D state_(t-1)) * (D state_(t-1) / D params) to state_jacobian with relation to params
+void update_state_jacobian_with_prev_state_jacobian(int n_layers, int hsize, const StateJacobianPredict<double>& prev_state_jacobian, StateJacobianPredict<double>& state_jacobian)
+{
+    for (int pos = 0; pos < hsize; ++pos)
+    {
+        for (int i = 0; i < n_layers; ++i)
+        {
+            for (int j = 0; j < n_layers; ++j)
+            {
+                for (int k = 0; k < n_layers; ++k)
+                {
+                    state_jacobian.layer[i].d_hidden[pos].d_weight_forget[k] +=
+                        state_jacobian.layer[i].d_hidden[pos].d_hidden[j] * prev_state_jacobian.layer[j].d_hidden[pos].d_weight_forget[k]
+                        + state_jacobian.layer[i].d_hidden[pos].d_cell[j] * prev_state_jacobian.layer[j].d_cell[pos].d_weight_forget[k];
+                    state_jacobian.layer[i].d_cell[pos].d_weight_forget[k] +=
+                        state_jacobian.layer[i].d_cell[pos].d_hidden[j] * prev_state_jacobian.layer[j].d_hidden[pos].d_weight_forget[k]
+                        + state_jacobian.layer[i].d_cell[pos].d_cell[j] * prev_state_jacobian.layer[j].d_cell[pos].d_weight_forget[k];
+                    state_jacobian.layer[i].d_hidden[pos].d_weight_ingate[k] +=
+                        state_jacobian.layer[i].d_hidden[pos].d_hidden[j] * prev_state_jacobian.layer[j].d_hidden[pos].d_weight_ingate[k]
+                        + state_jacobian.layer[i].d_hidden[pos].d_cell[j] * prev_state_jacobian.layer[j].d_cell[pos].d_weight_ingate[k];
+                    state_jacobian.layer[i].d_cell[pos].d_weight_ingate[k] +=
+                        state_jacobian.layer[i].d_cell[pos].d_hidden[j] * prev_state_jacobian.layer[j].d_hidden[pos].d_weight_ingate[k]
+                        + state_jacobian.layer[i].d_cell[pos].d_cell[j] * prev_state_jacobian.layer[j].d_cell[pos].d_weight_ingate[k];
+                    state_jacobian.layer[i].d_hidden[pos].d_weight_outgate[k] +=
+                        state_jacobian.layer[i].d_hidden[pos].d_hidden[j] * prev_state_jacobian.layer[j].d_hidden[pos].d_weight_outgate[k]
+                        + state_jacobian.layer[i].d_hidden[pos].d_cell[j] * prev_state_jacobian.layer[j].d_cell[pos].d_weight_outgate[k];
+                    state_jacobian.layer[i].d_cell[pos].d_weight_outgate[k] +=
+                        state_jacobian.layer[i].d_cell[pos].d_hidden[j] * prev_state_jacobian.layer[j].d_hidden[pos].d_weight_outgate[k]
+                        + state_jacobian.layer[i].d_cell[pos].d_cell[j] * prev_state_jacobian.layer[j].d_cell[pos].d_weight_outgate[k];
+                    state_jacobian.layer[i].d_hidden[pos].d_weight_change[k] +=
+                        state_jacobian.layer[i].d_hidden[pos].d_hidden[j] * prev_state_jacobian.layer[j].d_hidden[pos].d_weight_change[k]
+                        + state_jacobian.layer[i].d_hidden[pos].d_cell[j] * prev_state_jacobian.layer[j].d_cell[pos].d_weight_change[k];
+                    state_jacobian.layer[i].d_cell[pos].d_weight_change[k] +=
+                        state_jacobian.layer[i].d_cell[pos].d_hidden[j] * prev_state_jacobian.layer[j].d_hidden[pos].d_weight_change[k]
+                        + state_jacobian.layer[i].d_cell[pos].d_cell[j] * prev_state_jacobian.layer[j].d_cell[pos].d_weight_change[k];
+
+                    state_jacobian.layer[i].d_hidden[pos].d_bias_forget[k] +=
+                        state_jacobian.layer[i].d_hidden[pos].d_hidden[j] * prev_state_jacobian.layer[j].d_hidden[pos].d_bias_forget[k]
+                        + state_jacobian.layer[i].d_hidden[pos].d_cell[j] * prev_state_jacobian.layer[j].d_cell[pos].d_bias_forget[k];
+                    state_jacobian.layer[i].d_cell[pos].d_bias_forget[k] +=
+                        state_jacobian.layer[i].d_cell[pos].d_hidden[j] * prev_state_jacobian.layer[j].d_hidden[pos].d_bias_forget[k]
+                        + state_jacobian.layer[i].d_cell[pos].d_cell[j] * prev_state_jacobian.layer[j].d_cell[pos].d_bias_forget[k];
+                    state_jacobian.layer[i].d_hidden[pos].d_bias_ingate[k] +=
+                        state_jacobian.layer[i].d_hidden[pos].d_hidden[j] * prev_state_jacobian.layer[j].d_hidden[pos].d_bias_ingate[k]
+                        + state_jacobian.layer[i].d_hidden[pos].d_cell[j] * prev_state_jacobian.layer[j].d_cell[pos].d_bias_ingate[k];
+                    state_jacobian.layer[i].d_cell[pos].d_bias_ingate[k] +=
+                        state_jacobian.layer[i].d_cell[pos].d_hidden[j] * prev_state_jacobian.layer[j].d_hidden[pos].d_bias_ingate[k]
+                        + state_jacobian.layer[i].d_cell[pos].d_cell[j] * prev_state_jacobian.layer[j].d_cell[pos].d_bias_ingate[k];
+                    state_jacobian.layer[i].d_hidden[pos].d_bias_outgate[k] +=
+                        state_jacobian.layer[i].d_hidden[pos].d_hidden[j] * prev_state_jacobian.layer[j].d_hidden[pos].d_bias_outgate[k]
+                        + state_jacobian.layer[i].d_hidden[pos].d_cell[j] * prev_state_jacobian.layer[j].d_cell[pos].d_bias_outgate[k];
+                    state_jacobian.layer[i].d_cell[pos].d_bias_outgate[k] +=
+                        state_jacobian.layer[i].d_cell[pos].d_hidden[j] * prev_state_jacobian.layer[j].d_hidden[pos].d_bias_outgate[k]
+                        + state_jacobian.layer[i].d_cell[pos].d_cell[j] * prev_state_jacobian.layer[j].d_cell[pos].d_bias_outgate[k];
+                    state_jacobian.layer[i].d_hidden[pos].d_bias_change[k] +=
+                        state_jacobian.layer[i].d_hidden[pos].d_hidden[j] * prev_state_jacobian.layer[j].d_hidden[pos].d_bias_change[k]
+                        + state_jacobian.layer[i].d_hidden[pos].d_cell[j] * prev_state_jacobian.layer[j].d_cell[pos].d_bias_change[k];
+                    state_jacobian.layer[i].d_cell[pos].d_bias_change[k] +=
+                        state_jacobian.layer[i].d_cell[pos].d_hidden[j] * prev_state_jacobian.layer[j].d_hidden[pos].d_bias_change[k]
+                        + state_jacobian.layer[i].d_cell[pos].d_cell[j] * prev_state_jacobian.layer[j].d_cell[pos].d_bias_change[k];
+                }
+                *state_jacobian.layer[i].d_hidden[pos].d_extra_in_weight +=
+                    state_jacobian.layer[i].d_hidden[pos].d_hidden[j] * (*prev_state_jacobian.layer[j].d_hidden[pos].d_extra_in_weight)
+                    + state_jacobian.layer[i].d_hidden[pos].d_cell[j] * (*prev_state_jacobian.layer[j].d_cell[pos].d_extra_in_weight);
+                *state_jacobian.layer[i].d_cell[pos].d_extra_in_weight +=
+                    state_jacobian.layer[i].d_cell[pos].d_hidden[j] * (*prev_state_jacobian.layer[j].d_hidden[pos].d_extra_in_weight)
+                    + state_jacobian.layer[i].d_cell[pos].d_cell[j] * (*prev_state_jacobian.layer[j].d_cell[pos].d_extra_in_weight);
+            }
+        }
+    }
+}
+
+// Manual gradient of lstm_objective loss (output)
+// with relation to main_params and extra_params (inputs)
+void lstm_objective_d(int l, int c, int b,
+    const double* main_params, const double* extra_params,
+    std::vector<double> state, const double* sequence,
+    double* loss, double* J)
+{
+    double total = 0.0;
+    int count = b * (c - 1);
+    int main_params_count = 8 * l * b;
+    int extra_params_count = 3 * b;
+    int total_params_count = main_params_count + extra_params_count;
+    MainParams<double> main_params_wrap(main_params, b, l);
+    ExtraParams<double> extra_params_wrap(extra_params, b);
+    State<double> state_wrap(state.data(), b, l);
+    InputSequence<double> sequence_wrap(sequence, b, c);
+    std::vector<double> ypred(b), lse_d(b);
+    StateJacobianPredict<double> prev_state_jacobian(l, b), state_jacobian(l, b);
+    PredictionJacobian<double> ypred_jacobian(l, b);
+    GradByParams<double> j_wrap(J, l, b), grad_lse_ypred(l, b);
+
+    // temps for lstm_predict_d
+    LayerStateJacobianPredict<double> zero_layer_jacobian(l, b);
+    ModelJacobian<double> layer_state_d(b);
+
+    std::fill_n(J, total_params_count, 0.);
+
+    lstm_predict_d(l, b, main_params_wrap, extra_params_wrap, state_wrap, sequence_wrap.sequence[0], zero_layer_jacobian, layer_state_d, ypred.data(), prev_state_jacobian, ypred_jacobian);
+
+    double lse = logsumexp_d(ypred.data(), b, lse_d.data());
+    logsumexp_grad(l, b, lse_d, ypred_jacobian, grad_lse_ypred);
+
+    const double* ygold = sequence_wrap.sequence[1];
+
+    for (int i = 0; i < b; ++i)
+        total += ygold[i] * (ypred[i] - lse);
+
+    update_loss_gradient(l, b, ygold, grad_lse_ypred, ypred_jacobian, j_wrap);
+
+    for (int t = 1; t < c - 2; ++t)
+    {
+        lstm_predict_d(l, b, main_params_wrap, extra_params_wrap, state_wrap, sequence_wrap.sequence[t], zero_layer_jacobian, layer_state_d, ypred.data(), state_jacobian, ypred_jacobian);
+
+        // Adding (D state_t / D state_(t-1)) * (D state_(t-1) / D params) to state_jacobian w.r.t. params
+        update_state_jacobian_with_prev_state_jacobian(l, b, prev_state_jacobian, state_jacobian);
+
+        // Adding (D pred / D state_(t-1)) * (D state_(t-1) / D params) to ypred_jacobian w.r.t. params
+        update_pred_jacobian_with_prev_state_jacobian(l, b, prev_state_jacobian, ypred_jacobian);
+
+        lse = logsumexp_d(ypred.data(), b, lse_d.data());
+        // D logsumexp(pred) / D params
+        logsumexp_grad(l, b, lse_d, ypred_jacobian, grad_lse_ypred);
+
+        ygold = sequence_wrap.sequence[t + 1];
+
+        for (int i = 0; i < b; ++i)
+            total += ygold[i] * (ypred[i] - lse);
+
+        update_loss_gradient(l, b, ygold, grad_lse_ypred, ypred_jacobian, j_wrap);
+
+        swap(state_jacobian, prev_state_jacobian);
+    }
+
+    lstm_predict_d(l, b, main_params_wrap, extra_params_wrap, state_wrap, sequence_wrap.sequence[c - 2], zero_layer_jacobian, layer_state_d, ypred.data(), state_jacobian, ypred_jacobian);
+    // No need to compute the jacobian for the last state
+    // Adding (D pred / D state_(t-1)) * (D state_(t-1) / D params) to ypred_jacobian w.r.t. params
+    update_pred_jacobian_with_prev_state_jacobian(l, b, prev_state_jacobian, ypred_jacobian);
+
+    lse = logsumexp_d(ypred.data(), b, lse_d.data());
+    // D logsumexp(pred) / D params
+    logsumexp_grad(l, b, lse_d, ypred_jacobian, grad_lse_ypred);
+
+    ygold = sequence_wrap.sequence[c - 1];
+
+    for (int i = 0; i < b; ++i)
+        total += ygold[i] * (ypred[i] - lse);
+
+    update_loss_gradient(l, b, ygold, grad_lse_ypred, ypred_jacobian, j_wrap);
+
+    *loss = -total / count;
+
+    for (int i = 0; i < total_params_count; ++i)
+        J[i] /= -(double)count;
+}

--- a/tools/manual/lstm_d.h
+++ b/tools/manual/lstm_d.h
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+// https://github.com/microsoft/ADBench/blob/38cb7931303a830c3700ca36ba9520868327ac87/src/cpp/modules/manual/lstm_d.h
+
+#pragma once
+
+#include <vector>
+
+// Manual gradient of lstm_objective loss (output)
+// with relation to main_params and extra_params (inputs)
+void lstm_objective_d(int l, int c, int b,
+    const double* main_params, const double* extra_params,
+    std::vector<double> state, const double* sequence,
+    double* loss, double* J);

--- a/tools/manual/lstm_d_structures.h
+++ b/tools/manual/lstm_d_structures.h
@@ -1,0 +1,296 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+// https://github.com/microsoft/ADBench/blob/38cb7931303a830c3700ca36ba9520868327ac87/src/cpp/modules/manual/lstm_d_structures.h
+
+// Changes made: eliminate some warnings.
+
+#pragma once
+
+#include <vector>
+
+template<typename T>
+struct StatePartWeightOrBiasDerivatives
+{
+    T forget;
+    T ingate;
+    T outgate;
+    T change;
+};
+
+template<typename T>
+struct StateElementGradientModel
+{
+    // 4 corresponding non-zero derivatives
+    StatePartWeightOrBiasDerivatives<T> d_weight;
+    // 4 corresponding non-zero derivatives
+    StatePartWeightOrBiasDerivatives<T> d_bias;
+    // a single corresponding non-zero derivative
+    T d_hidden;
+    // a single corresponding non-zero derivative
+    T d_cell;
+    // a single corresponding non-zero derivative
+    T d_input;
+};
+
+template<typename T>
+struct ModelJacobian
+{
+    std::vector<StateElementGradientModel<T>> hidden;
+    std::vector<StateElementGradientModel<T>> cell;
+
+    ModelJacobian(int hsize) :
+        hidden(hsize),
+        cell(hsize)
+    {}
+};
+
+template<typename T>
+struct StateElementGradientPredict
+{
+    // n_layers derivatives by corresponding weights from all layers
+    T* d_weight_forget;
+    // n_layers derivatives by corresponding weights from all layers
+    T* d_weight_ingate;
+    // n_layers derivatives by corresponding weights from all layers
+    T* d_weight_outgate;
+    // n_layers derivatives by corresponding weights from all layers
+    T* d_weight_change;
+    // n_layers derivatives by corresponding biases from all layers
+    T* d_bias_forget;
+    // n_layers derivatives by corresponding biases from all layers
+    T* d_bias_ingate;
+    // n_layers derivatives by corresponding biases from all layers
+    T* d_bias_outgate;
+    // n_layers derivatives by corresponding biases from all layers
+    T* d_bias_change;
+    // n_layers derivatives by corresponding hidden values from previous state from all layers
+    T* d_hidden;
+    // n_layers derivatives by corresponding cell values from previous state from all layers
+    T* d_cell;
+    // 1 derivative by the corresponding weight from extra params
+    T* d_extra_in_weight;
+
+    // raw_gradient must point to (10 * n_layers + 1) pre-allocated T
+    StateElementGradientPredict(T* raw_gradient, int n_layers) :
+        d_weight_forget(raw_gradient),
+        d_weight_ingate(&raw_gradient[n_layers]),
+        d_weight_outgate(&raw_gradient[2 * n_layers]),
+        d_weight_change(&raw_gradient[3 * n_layers]),
+        d_bias_forget(&raw_gradient[4 * n_layers]),
+        d_bias_ingate(&raw_gradient[5 * n_layers]),
+        d_bias_outgate(&raw_gradient[6 * n_layers]),
+        d_bias_change(&raw_gradient[7 * n_layers]),
+        d_hidden(&raw_gradient[8 * n_layers]),
+        d_cell(&raw_gradient[9 * n_layers]),
+        d_extra_in_weight(&raw_gradient[10 * n_layers])
+    {}
+};
+
+template<typename T>
+struct LayerStateJacobianPredict
+{
+    std::vector<StateElementGradientPredict<T>> d_hidden;
+    std::vector<StateElementGradientPredict<T>> d_cell;
+    T* raw_data;
+    bool owns_memory;
+
+    // raw_jacobian must point to ((10 * n_layers + 1) * 2 * hsize) pre-allocated T
+    LayerStateJacobianPredict(T* raw_jacobian, int n_layers, int hsize, bool should_own_memory = false) :
+        raw_data(raw_jacobian),
+        owns_memory(should_own_memory)
+    {
+        d_hidden.reserve(hsize);
+        d_cell.reserve(hsize);
+        int gradient_size = 10 * n_layers + 1;
+        for (int i = 0; i < hsize; ++i)
+        {
+            d_hidden.emplace_back(&raw_jacobian[i * gradient_size], n_layers);
+            d_cell.emplace_back(&raw_jacobian[(i + hsize) * gradient_size], n_layers);
+        }
+    }
+
+    LayerStateJacobianPredict(int n_layers, int hsize) :
+        LayerStateJacobianPredict(new T[(10 * n_layers + 1) * 2 * hsize], n_layers, hsize, true)
+    {}
+
+    ~LayerStateJacobianPredict()
+    {
+        if (owns_memory)
+            delete[] raw_data;
+    }
+};
+
+template<typename T>
+struct StateJacobianPredict
+{
+    std::vector<LayerStateJacobianPredict<T>> layer;
+    T* raw_data;
+    bool owns_memory;
+
+    // raw_jacobian must point to (((10 * n_layers + 1) * 2 * hsize) * n_layers) pre-allocated T
+    StateJacobianPredict(T* raw_jacobian, int n_layers, int hsize, bool should_own_memory = false) :
+        raw_data(raw_jacobian),
+        owns_memory(should_own_memory)
+    {
+        layer.reserve(n_layers);
+        int layer_size = (10 * n_layers + 1) * 2 * hsize;
+        for (int i = 0; i < n_layers; ++i)
+        {
+            layer.emplace_back(&raw_jacobian[i * layer_size], n_layers, hsize);
+        }
+    }
+
+    StateJacobianPredict(int n_layers, int hsize) :
+        StateJacobianPredict(new T[((10 * n_layers + 1) * 2 * hsize) * n_layers], n_layers, hsize, true)
+    {}
+
+    ~StateJacobianPredict()
+    {
+        if (owns_memory)
+            delete[] raw_data;
+    }
+};
+
+template<typename T>
+struct PredictionElementGradient
+{
+    // n_layers derivatives by corresponding weights from all layers
+    T* d_weight_forget;
+    // n_layers derivatives by corresponding weights from all layers
+    T* d_weight_ingate;
+    // n_layers derivatives by corresponding weights from all layers
+    T* d_weight_outgate;
+    // n_layers derivatives by corresponding weights from all layers
+    T* d_weight_change;
+    // n_layers derivatives by corresponding biases from all layers
+    T* d_bias_forget;
+    // n_layers derivatives by corresponding biases from all layers
+    T* d_bias_ingate;
+    // n_layers derivatives by corresponding biases from all layers
+    T* d_bias_outgate;
+    // n_layers derivatives by corresponding biases from all layers
+    T* d_bias_change;
+    // n_layers derivatives by corresponding hidden values from previous state from all layers
+    T* d_hidden;
+    // n_layers derivatives by corresponding cell values from previous state from all layers
+    T* d_cell;
+    // 1 derivative by the corresponding weight from extra params
+    T* d_extra_in_weight;
+    // 1 derivative by the corresponding weight from extra params
+    T* d_extra_out_weight;
+    // 1 derivative by the corresponding bias from extra params
+    T* d_extra_out_bias;
+
+    // raw_gradient must point to (10 * n_layers + 3) pre-allocated T
+    PredictionElementGradient(T* raw_gradient, int n_layers) :
+        d_weight_forget(raw_gradient),
+        d_weight_ingate(&raw_gradient[n_layers]),
+        d_weight_outgate(&raw_gradient[2 * n_layers]),
+        d_weight_change(&raw_gradient[3 * n_layers]),
+        d_bias_forget(&raw_gradient[4 * n_layers]),
+        d_bias_ingate(&raw_gradient[5 * n_layers]),
+        d_bias_outgate(&raw_gradient[6 * n_layers]),
+        d_bias_change(&raw_gradient[7 * n_layers]),
+        d_hidden(&raw_gradient[8 * n_layers]),
+        d_cell(&raw_gradient[9 * n_layers]),
+        d_extra_in_weight(&raw_gradient[10 * n_layers]),
+        d_extra_out_weight(&raw_gradient[10 * n_layers + 1]),
+        d_extra_out_bias(&raw_gradient[10 * n_layers + 2])
+    {}
+};
+
+template<typename T>
+struct PredictionJacobian
+{
+    std::vector<PredictionElementGradient<T>> d_prediction;
+    T* raw_data;
+    bool owns_memory;
+
+    // raw_jacobian must point to ((10 * n_layers + 3) * hsize) pre-allocated T
+    PredictionJacobian(T* raw_jacobian, int n_layers, int hsize, bool should_own_memory = false) :
+        raw_data(raw_jacobian),
+        owns_memory(should_own_memory)
+    {
+        d_prediction.reserve(hsize);
+        int gradient_size = 10 * n_layers + 3;
+        for (int i = 0; i < hsize; ++i)
+        {
+            d_prediction.emplace_back(&raw_jacobian[i * gradient_size], n_layers);
+        }
+    }
+
+    PredictionJacobian(int n_layers, int hsize) :
+        PredictionJacobian(new T[(10 * n_layers + 3) * hsize], n_layers, hsize, true)
+    {}
+
+    ~PredictionJacobian()
+    {
+        if (owns_memory)
+            delete[] raw_data;
+    }
+};
+
+template<typename T>
+struct GradByWeightOrBias
+{
+    T* forget;
+    T* ingate;
+    T* outgate;
+    T* change;
+
+    GradByWeightOrBias(T* grad_raw, int hsize) :
+        forget(grad_raw),
+        ingate(&grad_raw[hsize]),
+        outgate(&grad_raw[2 * hsize]),
+        change(&grad_raw[3 * hsize])
+    {}
+};
+
+template<typename T>
+struct GradByLayerParams
+{
+    GradByWeightOrBias<T> d_weight;
+    GradByWeightOrBias<T> d_bias;
+
+    GradByLayerParams(T* grad_raw, int hsize) :
+        d_weight(grad_raw, hsize),
+        d_bias(&grad_raw[hsize * 4], hsize)
+    {}
+};
+
+template<typename T>
+struct GradByParams
+{
+    std::vector<GradByLayerParams<T>> layer;
+    T* d_in_weight;
+    T* d_out_weight;
+    T* d_out_bias;
+    T* raw_data;
+    bool owns_memory;
+
+    // raw_jacobian must point to (8 * n_layers * hsize + 3 * hsize) pre-allocated T
+    GradByParams(T* grad_raw, int n_layers, int hsize, bool should_own_memory = false) :
+        d_in_weight(&grad_raw[8 * hsize * n_layers]),
+        d_out_weight(&grad_raw[8 * hsize * n_layers + hsize]),
+        d_out_bias(&grad_raw[8 * hsize * n_layers + 2 * hsize]),
+        raw_data(grad_raw),
+        owns_memory(should_own_memory)
+    {
+        layer.reserve(n_layers);
+        for (int i = 0; i < n_layers; ++i)
+        {
+            layer.emplace_back(&grad_raw[8 * hsize * i], hsize);
+        }
+    }
+
+    GradByParams(int n_layers, int hsize) :
+        GradByParams(new T[8 * n_layers * hsize + 3 * hsize], n_layers, hsize, true)
+    {}
+
+    ~GradByParams()
+    {
+        if (owns_memory)
+            delete[] raw_data;
+    }
+};

--- a/tools/manual/run.py
+++ b/tools/manual/run.py
@@ -1,0 +1,41 @@
+import json
+import sys
+import time
+from importlib import import_module
+
+
+def resolve(module, name):
+    functions = import_module(module)
+    return getattr(functions, name)
+
+
+def run(params):
+    func = resolve(params["module"], params["name"])
+    vals = params["input"]
+
+    # start = time.perf_counter_ns()
+    ret, time = func(vals).stdout.split("\n")
+    # end = time.perf_counter_ns()
+
+    return {"output": json.loads(ret), "nanoseconds": {"evaluate": int(time)}}
+
+
+def main():
+    for line in sys.stdin:
+        message = json.loads(line)
+        response = {}
+        if message["kind"] == "evaluate":
+            response = run(message)
+        elif message["kind"] == "define":
+            try:
+                functions = import_module(message["module"])
+                func = getattr(functions, "compile")
+                success = func()  # compiles C code
+                response["success"] = success
+            except:
+                response["success"] = False
+        print(json.dumps({"id": message["id"]} | response), flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/manual/run_ba.cpp
+++ b/tools/manual/run_ba.cpp
@@ -1,0 +1,11 @@
+#include "ManualBA.h"
+#include "adbench/main.h"
+#include "adbench/shared/BAData.h"
+
+int main(int argc, char* argv[]) {
+  return generic_main<BAInput,
+                      ManualBA,
+                      read_BAInput_json,
+                      write_BAOutput_objective_json,
+                      write_BAOutput_jacobian_json>(argc, argv);
+}

--- a/tools/manual/run_gmm.cpp
+++ b/tools/manual/run_gmm.cpp
@@ -1,0 +1,11 @@
+#include "ManualGMM.h"
+#include "adbench/main.h"
+#include "adbench/shared/GMMData.h"
+
+int main(int argc, char* argv[]) {
+  return generic_main<GMMInput,
+                      ManualGMM,
+                      read_GMMInput_json,
+                      write_GMMOutput_objective_json,
+                      write_GMMOutput_jacobian_json>(argc, argv);
+}

--- a/tools/manual/run_hello.cpp
+++ b/tools/manual/run_hello.cpp
@@ -1,0 +1,11 @@
+#include "ManualHello.h"
+#include "adbench/main.h"
+#include "adbench/shared/HelloData.h"
+
+int main(int argc, char* argv[]) {
+  return generic_main<HelloInput,
+                      ManualHello,
+                      read_HelloInput_json,
+                      write_HelloOutput_objective_json,
+                      write_HelloOutput_jacobian_json>(argc, argv);
+}

--- a/tools/manual/run_ht.cpp
+++ b/tools/manual/run_ht.cpp
@@ -1,0 +1,11 @@
+#include "ManualHT.h"
+#include "adbench/main.h"
+#include "adbench/shared/HTData.h"
+
+int main(int argc, char* argv[]) {
+  return generic_main<HandInput,
+                      ManualHand,
+                      read_HandInput_json,
+                      write_HandOutput_objective_json,
+                      write_HandOutput_jacobian_json>(argc, argv);
+}

--- a/tools/manual/run_lstm.cpp
+++ b/tools/manual/run_lstm.cpp
@@ -1,0 +1,11 @@
+#include "ManualLSTM.h"
+#include "adbench/main.h"
+#include "adbench/shared/LSTMData.h"
+
+int main(int argc, char* argv[]) {
+  return generic_main<LSTMInput,
+                      ManualLSTM,
+                      read_LSTMInput_json,
+                      write_LSTMOutput_objective_json,
+                      write_LSTMOutput_jacobian_json>(argc, argv);
+}


### PR DESCRIPTION
This PR ports the manually differentiated and finite differences implementations from ADBench.

It is marked as a draft as it depends on (and currently includes) the infrastructure added in #134. I intend to rebase it once the main branch has C++ infrastructure.

The Finite tool does not validate, due to roundoff errors. We will need to adjust validation to use a greater tolerance.