### PR TITLE
Increase tolerance when validating gmm and hello.

### DIFF
--- a/evals/hello/Dockerfile
+++ b/evals/hello/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.11-alpine
 
-RUN pip install pydantic
+RUN pip install numpy==1.26.0 pydantic
 
 COPY python /home/gradbench/python
 ENV PYTHONPATH=/home/gradbench/python

--- a/evals/hello/Dockerfile
+++ b/evals/hello/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-alpine
+FROM python:3.11-slim
 
 RUN pip install numpy==1.26.0 pydantic
 

--- a/python/gradbench/evals/gmm/run.py
+++ b/python/gradbench/evals/gmm/run.py
@@ -13,7 +13,7 @@ from gradbench.wrap_module import Functions
 def check(name: str, input: Any, output: Any) -> None:
     func: Functions = getattr(golden, name)
     expected = func.unwrap(func(func.prepare(input)))
-    assert np.all(np.isclose(expected, output))
+    assert np.all(np.isclose(expected, output, rtol=1e-02))
 
 
 def main():

--- a/python/gradbench/evals/hello/run.py
+++ b/python/gradbench/evals/hello/run.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 from typing import Any
+
 import numpy as np
 
 from gradbench.evaluation import SingleModuleValidatedEvaluation, assertion

--- a/python/gradbench/evals/hello/run.py
+++ b/python/gradbench/evals/hello/run.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 from typing import Any
+import numpy as np
 
 from gradbench.evaluation import SingleModuleValidatedEvaluation, assertion
 
@@ -7,9 +8,9 @@ from gradbench.evaluation import SingleModuleValidatedEvaluation, assertion
 def check(name: str, input: Any, output: Any) -> None:
     match name:
         case "double":
-            assert output == input * 2
+            assert np.isclose(output, input * 2)
         case "square":
-            assert output == input * input
+            assert np.isclose(output, input * input)
 
 
 def main():


### PR DESCRIPTION
The tolerances here are somewhat arbitrarily set to allow validation with an implementation based on finite differencing. There is room to bikeshed them, but I suggest not doing so, for the following reasons:

  0) Even with the very generous gmm tolerance, it is unlikely that a
  buggy implementation will have a validating Jacobian.

  1) Although a loose tolerance allows implementations to play
  mixed-precision games for performance, Gradbench is not a
  competition, and so we can assume "good faith" on behalf of the
  tools.

Options for configuring the tolerance can always be added later.