### PR TITLE
Bring back passing CLI args to evals and tools

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,6 +85,18 @@ Then use the `run` subcommand to run a given evaluation on a given tool. You can
 ./gradbench run --eval './gradbench eval hello' --tool './gradbench tool pytorch'
 ```
 
+Some evals support further configuration via their own CLI flags, which you can see by passing `--help` to the eval itself:
+
+```sh
+./gradbench eval gmm -- --help
+```
+
+So for instance, to run only a subset of the default inputs for the GMM eval:
+
+```sh
+./gradbench run --eval './gradbench eval gmm -- -n1000' --tool './gradbench tool pytorch'
+```
+
 ### Multi-platform images
 
 The above do not build a multi-platform image. If you have followed the above instructions to configure Docker for building such images, you can do so using the `--cross` flag:

--- a/crates/gradbench/src/cli.rs
+++ b/crates/gradbench/src/cli.rs
@@ -36,6 +36,9 @@ enum Commands {
         /// The Docker image tag, or `latest` by default. For example: `2024-12-01`
         #[clap(short, long)]
         tag: Option<String>,
+
+        /// Arguments for the eval itself
+        args: Vec<String>,
     },
 
     /// Run a tool using Docker.
@@ -50,6 +53,9 @@ enum Commands {
         /// The Docker image tag, or `latest` by default. For example: `2024-12-01`
         #[clap(short, long)]
         tag: Option<String>,
+
+        /// Arguments for the tool itself
+        args: Vec<String>,
     },
 
     /// Run a given tool on a given eval. For example:
@@ -535,17 +541,19 @@ struct Summary<'a> {
 /// Run the GradBench CLI, returning a `Result`.
 fn cli_result() -> Result<(), ExitCode> {
     match Cli::parse().command {
-        Commands::Eval { eval, tag } => {
+        Commands::Eval { eval, tag, args } => {
             let t = tag.as_deref().unwrap_or("latest");
             run(Command::new("docker")
                 .args(["run", "--rm", "--interactive"])
-                .arg(format!("ghcr.io/gradbench/eval-{eval}:{t}")))
+                .arg(format!("ghcr.io/gradbench/eval-{eval}:{t}"))
+                .args(args))
         }
-        Commands::Tool { tool, tag } => {
+        Commands::Tool { tool, tag, args } => {
             let t = tag.as_deref().unwrap_or("latest");
             run(Command::new("docker")
                 .args(["run", "--rm", "--interactive"])
-                .arg(format!("ghcr.io/gradbench/tool-{tool}:{t}")))
+                .arg(format!("ghcr.io/gradbench/tool-{tool}:{t}"))
+                .args(args))
         }
         Commands::Run { eval, tool, output } => {
             let (mut client, mut server) = match (


### PR DESCRIPTION
This feature was added in #127 but accidentally removed in #147.