### PR TITLE
Shorten redundant eval function names

### DIFF
--- a/python/gradbench/evals/ba/run.py
+++ b/python/gradbench/evals/ba/run.py
@@ -37,7 +37,7 @@ def check(function: str, input: Any, b: Any) -> None:
     func: Functions = getattr(golden, function)
     a = func.unwrap(func(func.prepare(input)))
     match function:
-        case "calculate_objectiveBA":
+        case "objective":
             assert (
                 np.all(
                     np.isclose(
@@ -48,7 +48,7 @@ def check(function: str, input: Any, b: Any) -> None:
                 and np.all(np.isclose(a["w_err"]["element"], b["w_err"]["element"]))
                 and a["w_err"]["repeated"] == b["w_err"]["repeated"]
             )
-        case "calculate_jacobianBA":
+        case "jacobian":
             assert a == b
 
 
@@ -67,16 +67,8 @@ def main():
             datafile = next((Path(__file__).parent / "data").glob(f"ba{i}_*.txt"), None)
             if datafile:
                 input = parse(datafile)
-                e.evaluate(
-                    function="calculate_objectiveBA",
-                    input=input,
-                    description=datafile.stem,
-                )
-                e.evaluate(
-                    function="calculate_jacobianBA",
-                    input=input,
-                    description=datafile.stem,
-                )
+                e.evaluate(function="objective", input=input, description=datafile.stem)
+                e.evaluate(function="jacobian", input=input, description=datafile.stem)
 
 
 if __name__ == "__main__":

--- a/python/gradbench/evals/gmm/run.py
+++ b/python/gradbench/evals/gmm/run.py
@@ -46,12 +46,12 @@ def main():
             for k in args.k:
                 input = data_gen.main(d, k, n)
                 e.evaluate(
-                    function="calculate_objectiveGMM",
+                    function="objective",
                     input=input | {"runs": args.runs},
                     description=f"{d}_{k}_{n}",
                 )
                 e.evaluate(
-                    function="calculate_jacobianGMM",
+                    function="jacobian",
                     input=input | {"runs": args.runs},
                     description=f"{d}_{k}_{n}",
                 )

--- a/python/gradbench/evals/ht/run.py
+++ b/python/gradbench/evals/ht/run.py
@@ -39,12 +39,8 @@ def main():
                 fn = next(data_dir.glob(f"hand{i}_*.txt"), None)
                 model_dir = data_dir / "model"
                 input = io.read_hand_instance(model_dir, fn, complicated).to_dict()
-                e.evaluate(
-                    function="calculate_objectiveHT", input=input, description=fn.stem
-                )
-                e.evaluate(
-                    function="calculate_jacobianHT", input=input, description=fn.stem
-                )
+                e.evaluate(function="objective", input=input, description=fn.stem)
+                e.evaluate(function="jacobian", input=input, description=fn.stem)
 
         evals(simple_small, False)
         evals(simple_big, False)

--- a/python/gradbench/evals/lstm/run.py
+++ b/python/gradbench/evals/lstm/run.py
@@ -31,12 +31,8 @@ def main():
             for c in args.c:
                 fn = next(data_root.glob(f"lstm_l{l}_c{1024}.txt"), None)
                 input = io.read_lstm_instance(fn).to_dict()
-                e.evaluate(
-                    function="calculate_objectiveLSTM", input=input, description=fn.stem
-                )
-                e.evaluate(
-                    function="calculate_jacobianLSTM", input=input, description=fn.stem
-                )
+                e.evaluate(function="objective", input=input, description=fn.stem)
+                e.evaluate(function="jacobian", input=input, description=fn.stem)
 
 
 if __name__ == "__main__":

--- a/python/gradbench/pytorch/ba.py
+++ b/python/gradbench/pytorch/ba.py
@@ -183,7 +183,7 @@ def prepare_input(input):
 
 
 @wrap(prepare_input, objective_output)
-def calculate_objectiveBA(input):
+def objective(input):
     py = PyTorchBA()
     py.prepare(input)
 
@@ -199,7 +199,7 @@ def calculate_objectiveBA(input):
 
 
 @wrap(prepare_input, jacobian_output)
-def calculate_jacobianBA(input):
+def jacobian(input):
     py = PyTorchBA()
     py.prepare(input)
 

--- a/python/gradbench/pytorch/gmm.py
+++ b/python/gradbench/pytorch/gmm.py
@@ -87,7 +87,7 @@ def prepare_input(input):
 
 
 @wrap(prepare_input, lambda x: x.tolist())
-def calculate_jacobianGMM(input):
+def jacobian(input):
     py = PyTorchGMM()
     py.prepare(input)
     py.calculate_jacobian(1)
@@ -95,7 +95,7 @@ def calculate_jacobianGMM(input):
 
 
 @wrap(prepare_input, lambda x: x.tolist())
-def calculate_objectiveGMM(input):
+def objective(input):
     py = PyTorchGMM()
     py.prepare(input)
     py.calculate_objective(1)

--- a/python/gradbench/pytorch/ht.py
+++ b/python/gradbench/pytorch/ht.py
@@ -128,7 +128,7 @@ def jacobian_output(output):
 
 
 @wrap(prepare_input, objective_output)
-def calculate_objectiveHT(input):
+def objective(input):
     py = PyTorchHand()
     py.prepare(input)
     py.calculate_objective(1)
@@ -136,7 +136,7 @@ def calculate_objectiveHT(input):
 
 
 @wrap(prepare_input, jacobian_output)
-def calculate_jacobianHT(input):
+def jacobian(input):
     py = PyTorchHand()
     py.prepare(input)
     py.calculate_jacobian(1)

--- a/python/gradbench/pytorch/lstm.py
+++ b/python/gradbench/pytorch/lstm.py
@@ -66,7 +66,7 @@ def jacobian_output(output):
 
 
 @wrap(prepare_input, objective_output)
-def calculate_objectiveLSTM(input):
+def objective(input):
     py = PyTorchLSTM()
     py.prepare(input)
     py.calculate_objective(1)
@@ -74,7 +74,7 @@ def calculate_objectiveLSTM(input):
 
 
 @wrap(prepare_input, jacobian_output)
-def calculate_jacobianLSTM(input):
+def jacobian(input):
     py = PyTorchLSTM()
     py.prepare(input)
     py.calculate_jacobian(1)

--- a/python/gradbench/tensorflow/ba.py
+++ b/python/gradbench/tensorflow/ba.py
@@ -189,7 +189,7 @@ def prepare_input(input):
 
 
 @wrap(prepare_input, objective_output)
-def calculate_objectiveBA(input):
+def objective(input):
     py = TensorflowBA()
     py.prepare(input)
     py.calculate_objective(1)
@@ -197,7 +197,7 @@ def calculate_objectiveBA(input):
 
 
 @wrap(prepare_input, jacobian_output)
-def calculate_jacobianBA(input):
+def jacobian(input):
     py = TensorflowBA()
     py.prepare(input)
     py.calculate_jacobian(1)

--- a/python/gradbench/tensorflow/gmm.py
+++ b/python/gradbench/tensorflow/gmm.py
@@ -111,7 +111,7 @@ def prepare_input(input):
 
 
 @wrap(prepare_input, lambda x: x.numpy().tolist())
-def calculate_jacobianGMM(input):
+def jacobian(input):
     py = TensorflowGMM()
     py.prepare(input)
     py.calculate_jacobian(1)
@@ -119,7 +119,7 @@ def calculate_jacobianGMM(input):
 
 
 @wrap(prepare_input, lambda x: x.numpy().tolist())
-def calculate_objectiveGMM(input):
+def objective(input):
     py = TensorflowGMM()
     py.prepare(input)
     py.calculate_objective(1)

--- a/tools/finite/ba.py
+++ b/tools/finite/ba.py
@@ -9,7 +9,7 @@ def compile():
     return True
 
 
-def calculate_objectiveBA(input):
+def objective(input):
     with tempfile.NamedTemporaryFile("w") as tmp:
         json.dump(input, tmp)
         tmp.flush()
@@ -18,7 +18,7 @@ def calculate_objectiveBA(input):
         )
 
 
-def calculate_jacobianBA(input):
+def jacobian(input):
     with tempfile.NamedTemporaryFile("w") as tmp:
         json.dump(input, tmp)
         tmp.flush()

--- a/tools/finite/gmm.py
+++ b/tools/finite/gmm.py
@@ -9,7 +9,7 @@ def compile():
     return True
 
 
-def calculate_objectiveGMM(input):
+def objective(input):
     with tempfile.NamedTemporaryFile("w") as tmp:
         json.dump(input, tmp)
         tmp.flush()
@@ -18,7 +18,7 @@ def calculate_objectiveGMM(input):
         )
 
 
-def calculate_jacobianGMM(input):
+def jacobian(input):
     with tempfile.NamedTemporaryFile("w") as tmp:
         json.dump(input, tmp)
         tmp.flush()

--- a/tools/finite/ht.py
+++ b/tools/finite/ht.py
@@ -9,7 +9,7 @@ def compile():
     return True
 
 
-def calculate_objectiveHT(input):
+def objective(input):
     with tempfile.NamedTemporaryFile("w") as tmp:
         json.dump(input, tmp)
         tmp.flush()
@@ -18,7 +18,7 @@ def calculate_objectiveHT(input):
         )
 
 
-def calculate_jacobianHT(input):
+def jacobian(input):
     with tempfile.NamedTemporaryFile("w") as tmp:
         json.dump(input, tmp)
         tmp.flush()

--- a/tools/finite/lstm.py
+++ b/tools/finite/lstm.py
@@ -9,7 +9,7 @@ def compile():
     return True
 
 
-def calculate_objectiveLSTM(input):
+def objective(input):
     with tempfile.NamedTemporaryFile("w") as tmp:
         json.dump(input, tmp)
         tmp.flush()
@@ -18,7 +18,7 @@ def calculate_objectiveLSTM(input):
         )
 
 
-def calculate_jacobianLSTM(input):
+def jacobian(input):
     with tempfile.NamedTemporaryFile("w") as tmp:
         json.dump(input, tmp)
         tmp.flush()

--- a/tools/futhark/ba.py
+++ b/tools/futhark/ba.py
@@ -32,7 +32,7 @@ def prepare(server, input):
     server.put_value("feats", feats)
 
 
-def calculate_objectiveBA(server, input):
+def objective(server, input):
     runs = 1
     (r_err, w_err), times = futhark_utils.run(
         server,
@@ -52,7 +52,7 @@ def calculate_objectiveBA(server, input):
     )
 
 
-def calculate_jacobianBA(server, input):
+def jacobian(server, input):
     runs = 1
     (rows, cols, vals), times = futhark_utils.run(
         server,

--- a/tools/futhark/gmm.py
+++ b/tools/futhark/gmm.py
@@ -15,7 +15,7 @@ def prepare(server, input):
     server.put_value("m", np.int64(input["m"]))
 
 
-def calculate_objectiveGMM(server, input):
+def objective(server, input):
     runs = input["runs"]
     (o,), times = futhark_utils.run(
         server,
@@ -27,7 +27,7 @@ def calculate_objectiveGMM(server, input):
     return (o, times)
 
 
-def calculate_jacobianGMM(server, input):
+def jacobian(server, input):
     runs = input["runs"]
     (o1, o2, o3), times = futhark_utils.run(
         server,

--- a/tools/futhark/ht.py
+++ b/tools/futhark/ht.py
@@ -21,7 +21,7 @@ def prepare(server, input):
     server.put_value("us", input.us.flatten())
 
 
-def calculate_objectiveHT(server, input):
+def objective(server, input):
     runs = 1
     (obj,), times = futhark_utils.run(
         server,
@@ -45,7 +45,7 @@ def calculate_objectiveHT(server, input):
     return (obj.flatten().tolist(), times)
 
 
-def calculate_jacobianHT(server, input):
+def jacobian(server, input):
     runs = 1
     (J,), times = futhark_utils.run(
         server,

--- a/tools/futhark/lstm.py
+++ b/tools/futhark/lstm.py
@@ -14,7 +14,7 @@ def prepare(server, input):
     server.put_value("sequence", input.sequence)
 
 
-def calculate_objectiveLSTM(server, input):
+def objective(server, input):
     runs = 1
     (obj,), times = futhark_utils.run(
         server,
@@ -26,7 +26,7 @@ def calculate_objectiveLSTM(server, input):
     return (obj, times)
 
 
-def calculate_jacobianLSTM(server, input):
+def jacobian(server, input):
     runs = 1
     (J,), times = futhark_utils.run(
         server,

--- a/tools/manual/ba.py
+++ b/tools/manual/ba.py
@@ -9,7 +9,7 @@ def compile():
     return True
 
 
-def calculate_objectiveBA(input):
+def objective(input):
     with tempfile.NamedTemporaryFile("w") as tmp:
         json.dump(input, tmp)
         tmp.flush()
@@ -18,7 +18,7 @@ def calculate_objectiveBA(input):
         )
 
 
-def calculate_jacobianBA(input):
+def jacobian(input):
     with tempfile.NamedTemporaryFile("w") as tmp:
         json.dump(input, tmp)
         tmp.flush()

--- a/tools/manual/gmm.py
+++ b/tools/manual/gmm.py
@@ -9,7 +9,7 @@ def compile():
     return True
 
 
-def calculate_objectiveGMM(input):
+def objective(input):
     with tempfile.NamedTemporaryFile("w") as tmp:
         json.dump(input, tmp)
         tmp.flush()
@@ -18,7 +18,7 @@ def calculate_objectiveGMM(input):
         )
 
 
-def calculate_jacobianGMM(input):
+def jacobian(input):
     with tempfile.NamedTemporaryFile("w") as tmp:
         json.dump(input, tmp)
         tmp.flush()

--- a/tools/manual/ht.py
+++ b/tools/manual/ht.py
@@ -9,7 +9,7 @@ def compile():
     return True
 
 
-def calculate_objectiveHT(input):
+def objective(input):
     with tempfile.NamedTemporaryFile("w") as tmp:
         json.dump(input, tmp)
         tmp.flush()
@@ -18,7 +18,7 @@ def calculate_objectiveHT(input):
         )
 
 
-def calculate_jacobianHT(input):
+def jacobian(input):
     with tempfile.NamedTemporaryFile("w") as tmp:
         json.dump(input, tmp)
         tmp.flush()

--- a/tools/manual/lstm.py
+++ b/tools/manual/lstm.py
@@ -9,7 +9,7 @@ def compile():
     return True
 
 
-def calculate_objectiveLSTM(input):
+def objective(input):
     with tempfile.NamedTemporaryFile("w") as tmp:
         json.dump(input, tmp)
         tmp.flush()
@@ -18,7 +18,7 @@ def calculate_objectiveLSTM(input):
         )
 
 
-def calculate_jacobianLSTM(input):
+def jacobian(input):
     with tempfile.NamedTemporaryFile("w") as tmp:
         json.dump(input, tmp)
         tmp.flush()

--- a/tools/tapenade/ba.py
+++ b/tools/tapenade/ba.py
@@ -9,7 +9,7 @@ def compile():
     return True
 
 
-def calculate_objectiveBA(input):
+def objective(input):
     with tempfile.NamedTemporaryFile("w") as tmp:
         json.dump(input, tmp)
         tmp.flush()
@@ -18,7 +18,7 @@ def calculate_objectiveBA(input):
         )
 
 
-def calculate_jacobianBA(input):
+def jacobian(input):
     with tempfile.NamedTemporaryFile("w") as tmp:
         json.dump(input, tmp)
         tmp.flush()

--- a/tools/tapenade/gmm.py
+++ b/tools/tapenade/gmm.py
@@ -9,7 +9,7 @@ def compile():
     return True
 
 
-def calculate_objectiveGMM(input):
+def objective(input):
     with tempfile.NamedTemporaryFile("w") as tmp:
         json.dump(input, tmp)
         tmp.flush()
@@ -18,7 +18,7 @@ def calculate_objectiveGMM(input):
         )
 
 
-def calculate_jacobianGMM(input):
+def jacobian(input):
     with tempfile.NamedTemporaryFile("w") as tmp:
         json.dump(input, tmp)
         tmp.flush()

--- a/tools/tapenade/ht.py
+++ b/tools/tapenade/ht.py
@@ -9,7 +9,7 @@ def compile():
     return True
 
 
-def calculate_objectiveHT(input):
+def objective(input):
     with tempfile.NamedTemporaryFile("w") as tmp:
         json.dump(input, tmp)
         tmp.flush()
@@ -18,7 +18,7 @@ def calculate_objectiveHT(input):
         )
 
 
-def calculate_jacobianHT(input):
+def jacobian(input):
     with tempfile.NamedTemporaryFile("w") as tmp:
         json.dump(input, tmp)
         tmp.flush()

--- a/tools/tapenade/lstm.py
+++ b/tools/tapenade/lstm.py
@@ -9,7 +9,7 @@ def compile():
     return True
 
 
-def calculate_objectiveLSTM(input):
+def objective(input):
     with tempfile.NamedTemporaryFile("w") as tmp:
         json.dump(input, tmp)
         tmp.flush()
@@ -18,7 +18,7 @@ def calculate_objectiveLSTM(input):
         )
 
 
-def calculate_jacobianLSTM(input):
+def jacobian(input):
     with tempfile.NamedTemporaryFile("w") as tmp:
         json.dump(input, tmp)
         tmp.flush()


### PR DESCRIPTION
This replaces the `calculate_(objective|jacobian)[A-Z]+` names of our four ADBench evals with just `objective` and `jacobian`, since the rest of the name is redundant given the name of the containing module.