### PR TITLE
Move Enzyme to the "slow" list

### DIFF
--- a/crates/gradbench/src/cli.rs
+++ b/crates/gradbench/src/cli.rs
@@ -663,7 +663,7 @@ fn cli_result() -> Result<(), ExitCode> {
                     let mut tools = ls("tools")?;
                     tools.sort();
                     github_output("tool", &tools)?;
-                    let slow = ["scilean"];
+                    let slow = ["enzyme", "scilean"];
                     let fast: Vec<_> = tools
                         .iter()
                         .filter(|t| !slow.contains(&t.as_str()))


### PR DESCRIPTION
Followup on #148 because building the Enzyme tool takes over half an hour; cf. #94.

Marking this for review instead of just merging it, because I'm not entirely convinced that this is the right thing to do: the downside is that we would then have to also wait for the two-hour SciLean build to finish before we can get Enzyme results.

One other possibility would be to split into more than two matrix jobs, to account for these different "tiers" of slowness. At that point, though, I would no longer consider it wise to maintain `.github/workflows/build.yml` by hand, so we'd want to autogenerate it. That would add more complexity to the repository, so I'm hesitant to go down that road, having previously worked on a similar CI system in the [PyTorch repository](https://github.com/pytorch/pytorch).