### PR TITLE
Better error messages on validation errors.

### DIFF
--- a/python/gradbench/comparison.py
+++ b/python/gradbench/comparison.py
@@ -26,7 +26,12 @@ def compare_json_objects(expected, actual, tolerance=1e-4, path=""):
     """
     mismatches = []
 
-    if isinstance(expected, dict) and isinstance(actual, dict):
+    if type(expected) != type(actual):
+        mismatches.append(
+            f"{path}: expected value of type {type(expected)}, got value of type {type(actual)}"
+        )
+
+    elif isinstance(expected, dict) and isinstance(actual, dict):
         all_keys = set(expected.keys()).union(set(actual.keys()))
         for key in all_keys:
             new_path = f"{path}.{key}" if path else key

--- a/python/gradbench/comparison.py
+++ b/python/gradbench/comparison.py
@@ -1,0 +1,64 @@
+import numpy as np
+
+
+# This definition is ported from ADBench's JacobianComparison.cs.
+def difference(x, y):
+    absX = np.abs(x)
+    absY = np.abs(y)
+    absdiff = np.abs(x - y)
+    normCoef = np.clip(absX + absY, a_min=1, a_max=None)
+    return absdiff / normCoef
+
+
+def compare_json_objects(expected, actual, tolerance=1e-4, path=""):
+    """Compare two Python objects corresponding to JSON objects and
+    report mismatches.
+
+    :param expected: The reference value.
+
+    :param actual: The obtained value.
+
+    :param path: Path within the nested structure (used for reporting mismatches)
+
+    :return: List of mismatches, each as a string describing the
+    location and nature of the mismatch
+
+    """
+    mismatches = []
+
+    if isinstance(expected, dict) and isinstance(actual, dict):
+        all_keys = set(expected.keys()).union(set(actual.keys()))
+        for key in all_keys:
+            new_path = f"{path}.{key}" if path else key
+            if key not in expected:
+                mismatches.append(f"Unexpected key '{new_path}'.")
+            elif key not in actual:
+                mismatches.append(f"Key '{new_path}' is missing.")
+            else:
+                mismatches.extend(
+                    compare_json_objects(
+                        expected[key], actual[key], tolerance, new_path
+                    )
+                )
+
+    elif isinstance(expected, list) and isinstance(actual, list):
+        expected_len = len(expected)
+        actual_len = len(actual)
+        if expected_len != actual_len:
+            mismatches.append(
+                f"{path}: Expected array of length {expected_len}, got array of length {actual_len}."
+            )
+        for i in range(expected_len):
+            mismatches.extend(
+                compare_json_objects(expected[i], actual[i], tolerance, f"{path}[{i}]")
+            )
+
+    elif isinstance(expected, float) and isinstance(actual, float):
+        if difference(np.array(actual), np.array(expected)) > tolerance:
+            mismatches.append(f"{path}: {expected} != {actual}")
+
+    else:
+        if expected != actual:
+            mismatches.append(f"{path}: {expected} != {actual}")
+
+    return mismatches

--- a/python/gradbench/evals/ht/run.py
+++ b/python/gradbench/evals/ht/run.py
@@ -5,15 +5,16 @@ from typing import Any
 import numpy as np
 
 import gradbench.pytorch.ht as golden
+from gradbench.comparison import compare_json_objects
 from gradbench.evals.ht import io
-from gradbench.evaluation import SingleModuleValidatedEvaluation, assertion
+from gradbench.evaluation import SingleModuleValidatedEvaluation, mismatch
 from gradbench.wrap_module import Functions
 
 
 def check(function: str, input: Any, output: Any) -> None:
     func: Functions = getattr(golden, function)
     expected = func.unwrap(func(func.prepare(input)))
-    assert np.all(np.isclose(expected, output))
+    return compare_json_objects(expected, output)
 
 
 def main():
@@ -22,7 +23,7 @@ def main():
     parser.add_argument("--max", type=int, default=2)
     args = parser.parse_args()
 
-    e = SingleModuleValidatedEvaluation(module="ht", validator=assertion(check))
+    e = SingleModuleValidatedEvaluation(module="ht", validator=mismatch(check))
     e.start()
     if e.define().success:
         data_root = Path("evals/ht/data")  # assumes cwd is set correctly

--- a/python/gradbench/evals/lstm/run.py
+++ b/python/gradbench/evals/lstm/run.py
@@ -5,15 +5,16 @@ from typing import Any
 import numpy as np
 
 import gradbench.pytorch.lstm as golden
+from gradbench.comparison import compare_json_objects
 from gradbench.evals.lstm import io
-from gradbench.evaluation import SingleModuleValidatedEvaluation, assertion
+from gradbench.evaluation import SingleModuleValidatedEvaluation, mismatch
 from gradbench.wrap_module import Functions
 
 
 def check(function: str, input: Any, output: Any) -> None:
     func: Functions = getattr(golden, function)
     expected = func.unwrap(func(func.prepare(input)))
-    assert np.all(np.isclose(expected, output))
+    return compare_json_objects(expected, output)
 
 
 def main():
@@ -22,7 +23,7 @@ def main():
     parser.add_argument("-c", nargs="+", type=int, default=[1024, 4096])
     args = parser.parse_args()
 
-    e = SingleModuleValidatedEvaluation(module="lstm", validator=assertion(check))
+    e = SingleModuleValidatedEvaluation(module="lstm", validator=mismatch(check))
     e.start()
     if e.define().success:
         data_root = Path("evals/lstm/data")  # assumes cwd is set correctly

--- a/python/gradbench/evaluation.py
+++ b/python/gradbench/evaluation.py
@@ -54,6 +54,20 @@ def assertion(check: Callable[[str, Any, Any], None]) -> Validator:
     return validator
 
 
+def mismatch(check: Callable[[str, Any, Any], None], max_mismatches=10) -> Validator:
+    def validator(function: str, input: Any, output: Any) -> Analysis:
+        mismatches = check(function, input, output)
+        if len(mismatches) == 0:
+            return Analysis(valid=True, message=None)
+        else:
+            shown_mismatches = mismatches[0:max_mismatches]
+            mismatches_str = "\n".join(shown_mismatches)
+            message = f"Found {len(mismatches)} mismatches, showing {len(shown_mismatches)}:\n{mismatches_str}"
+            return Analysis(valid=False, message=message)
+
+    return validator
+
+
 class SingleModuleValidatedEvaluation:
     module: str
     validator: Validator

--- a/python/gradbench/pytorch/lstm.py
+++ b/python/gradbench/pytorch/lstm.py
@@ -58,7 +58,7 @@ def prepare_input(input):
 
 
 def objective_output(output):
-    return output.detach().flatten().numpy().tolist()
+    return output.detach().flatten().numpy()[0]
 
 
 def jacobian_output(output):

--- a/python/gradbench/pytorch/lstm.py
+++ b/python/gradbench/pytorch/lstm.py
@@ -58,7 +58,7 @@ def prepare_input(input):
 
 
 def objective_output(output):
-    return output.detach().flatten().numpy()[0]
+    return float(output.detach().flatten().numpy()[0])
 
 
 def jacobian_output(output):

--- a/python/gradbench/tensorflow/ba.py
+++ b/python/gradbench/tensorflow/ba.py
@@ -144,7 +144,7 @@ class TensorflowBA(ITest):
 def objective_output(errors):
     try:
         r_err, w_err = errors
-        num_r = len(r_err.numpy().tolist()) / 2
+        num_r = len(r_err.numpy().tolist()) // 2
         num_w = len(w_err.numpy().tolist())
         return {
             "reproj_error": {"elements": r_err.numpy().tolist()[:2], "repeated": num_r},


### PR DESCRIPTION
This adds a new validator, gradbench.evaluation.mismatch, and a function, gradbench.comparison.compare_json_objects, that produces fairly human-friendly descriptions of mismatches between expected and actual results.

All ADBench-derived evals have been modified to use it.

I had to modify the pytorch implementation of lstm, which had a small bug where it returned a singleton list instead of a scalar (this was not detected by the previous validation).