### PR TITLE
Make `gradbench run` output nicer

### DIFF
--- a/crates/gradbench/src/cli.rs
+++ b/crates/gradbench/src/cli.rs
@@ -455,7 +455,7 @@ fn intermediary(o: &mut impl Write, eval: &mut Child, tool: &mut Child) -> anyho
                     if first {
                         print!(" =");
                     } else {
-                        print!(",");
+                        print!(" +");
                     }
                     first = false;
                     print_nanoseconds(ns);


### PR DESCRIPTION
This PR improves the output of `gradbench run`. For example:

```sh
./gradbench run --eval './gradbench eval ht' --tool './gradbench tool pytorch'
```

Before:

```
[   0] Ready.
[   1] Defining module "ht"... success.
[   2] Eval objective                 hand1_t26_c100    11420000 ns (evaluate) ✓
[   4] Eval jacobian                  hand1_t26_c100  2842243293 ns (evaluate) ✓
[   6] Eval objective                 hand2_t26_c192     6060250 ns (evaluate) ✓
[   8] Eval jacobian                  hand2_t26_c192  6466435920 ns (evaluate) ✓
[  10] Eval objective                 hand1_t26_c100    25684750 ns (evaluate) ✓
[  12] Eval jacobian                  hand1_t26_c100  10651882380 ns (evaluate) ✓
[  14] Eval objective                 hand2_t26_c192    13700583 ns (evaluate) ✓
[  16] Eval jacobian                  hand2_t26_c192  32497048849 ns (evaluate) ✓
[  18] Eval objective                 hand1_t26_c100     7760250 ns (evaluate) ✓
[  20] Eval jacobian                  hand1_t26_c100  5191854836 ns (evaluate) ✓
[  22] Eval objective                 hand2_t26_c192    10942666 ns (evaluate) ✓
[  24] Eval jacobian                  hand2_t26_c192  15612818798 ns (evaluate) ✓
[  26] Eval objective                 hand1_t26_c100    19441125 ns (evaluate) ✓
[  28] Eval jacobian                  hand1_t26_c100  25456236220 ns (evaluate) ✓
[  30] Eval objective                 hand2_t26_c192    19411458 ns (evaluate) ✓
[  32] Eval jacobian                  hand2_t26_c192  87290425248 ns (evaluate) ✓
```

After:

```
  [0] start
  [1] def   ht                                    758ms ✓
  [2] eval  ht::objective   hand1_t26_c100         18ms =        12ms evaluate ✓
  [4] eval  ht::jacobian    hand1_t26_c100      2.730 s =     2.724 s evaluate ✓
  [6] eval  ht::objective   hand2_t26_c192         15ms =         5ms evaluate ✓
  [8] eval  ht::jacobian    hand2_t26_c192      6.881 s =     6.873 s evaluate ✓
 [10] eval  ht::objective   hand1_t26_c100         66ms =        20ms evaluate ✓
 [12] eval  ht::jacobian    hand1_t26_c100     10.800 s =    10.734 s evaluate ✓
 [14] eval  ht::objective   hand2_t26_c192         62ms =        22ms evaluate ✓
 [16] eval  ht::jacobian    hand2_t26_c192     32.546 s =    32.506 s evaluate ✓
 [18] eval  ht::objective   hand1_t26_c100         15ms =         7ms evaluate ✓
 [20] eval  ht::jacobian    hand1_t26_c100      5.026 s =     5.019 s evaluate ✓
 [22] eval  ht::objective   hand2_t26_c192         16ms =        11ms evaluate ✓
 [24] eval  ht::jacobian    hand2_t26_c192     15.243 s =    15.235 s evaluate ✓
 [26] eval  ht::objective   hand1_t26_c100         66ms =        25ms evaluate ✓
 [28] eval  ht::jacobian    hand1_t26_c100     25.334 s =    25.269 s evaluate ✓
 [30] eval  ht::objective   hand2_t26_c192         59ms =        19ms evaluate ✓
 [32] eval  ht::jacobian    hand2_t26_c192   1:26.819   =  1:26.778   evaluate ✓
```