### PR TITLE
Construct the ADBench wrapper objects in prepare_input method.

### DIFF
--- a/python/gradbench/pytorch/ba.py
+++ b/python/gradbench/pytorch/ba.py
@@ -122,10 +122,6 @@ class PyTorchBA(ITest):
             self.reproj_error = reproj_error.flatten()
 
 
-def evaluate_times(times):
-    return [{"name": "evaluate", "nanoseconds": time} for time in times]
-
-
 # Convert objective output to dictionary
 def objective_output(errors):
     r_err, w_err = errors
@@ -171,20 +167,18 @@ def prepare_input(input):
         camIdx = (camIdx + 1) % n
         ptIdx = (ptIdx + 1) % m
 
-    return BAInput(cams, X, w, obs, feats)
+    py = PyTorchBA()
+    py.prepare(BAInput(cams, X, w, obs, feats))
+    return py
 
 
 @wrap.multiple_runs(runs=lambda x: x["runs"], pre=prepare_input, post=objective_output)
-def objective(input):
-    py = PyTorchBA()
-    py.prepare(input)
+def objective(py):
     py.calculate_objective(1)
     return py.reproj_error, py.w_err
 
 
 @wrap.multiple_runs(runs=lambda x: x["runs"], pre=prepare_input, post=jacobian_output)
-def jacobian(input):
-    py = PyTorchBA()
-    py.prepare(input)
+def jacobian(py):
     py.calculate_jacobian(1)
     return py.jacobian

--- a/python/gradbench/pytorch/gmm.py
+++ b/python/gradbench/pytorch/gmm.py
@@ -77,21 +77,23 @@ class PyTorchGMM(ITest):
 
 
 def prepare_input(input):
-    return GMMInput(
-        input["alpha"],
-        input["means"],
-        input["icf"],
-        input["x"],
-        Wishart(input["gamma"], input["m"]),
+    py = PyTorchGMM()
+    py.prepare(
+        GMMInput(
+            input["alpha"],
+            input["means"],
+            input["icf"],
+            input["x"],
+            Wishart(input["gamma"], input["m"]),
+        )
     )
+    return py
 
 
 @wrap.multiple_runs(
     runs=lambda x: x["runs"], pre=prepare_input, post=lambda x: x.tolist()
 )
-def jacobian(input):
-    py = PyTorchGMM()
-    py.prepare(input)
+def jacobian(py):
     py.calculate_jacobian(1)
     return py.gradient
 
@@ -99,8 +101,6 @@ def jacobian(input):
 @wrap.multiple_runs(
     runs=lambda x: x["runs"], pre=prepare_input, post=lambda x: x.tolist()
 )
-def objective(input):
-    py = PyTorchGMM()
-    py.prepare(input)
+def objective(py):
     py.calculate_objective(1)
     return py.objective

--- a/python/gradbench/pytorch/ht.py
+++ b/python/gradbench/pytorch/ht.py
@@ -116,7 +116,9 @@ class PyTorchHand(ITest):
 
 
 def prepare_input(input):
-    return HandInput.from_dict(input)
+    py = PyTorchHand()
+    py.prepare(HandInput.from_dict(input))
+    return py
 
 
 def objective_output(output):
@@ -128,16 +130,12 @@ def jacobian_output(output):
 
 
 @wrap.multiple_runs(runs=lambda x: x["runs"], pre=prepare_input, post=objective_output)
-def objective(input):
-    py = PyTorchHand()
-    py.prepare(input)
+def objective(py):
     py.calculate_objective(1)
     return py.objective
 
 
 @wrap.multiple_runs(runs=lambda x: x["runs"], pre=prepare_input, post=jacobian_output)
-def jacobian(input):
-    py = PyTorchHand()
-    py.prepare(input)
+def jacobian(py):
     py.calculate_jacobian(1)
     return py.jacobian

--- a/python/gradbench/pytorch/lstm.py
+++ b/python/gradbench/pytorch/lstm.py
@@ -54,7 +54,9 @@ class PyTorchLSTM(ITest):
 
 
 def prepare_input(input):
-    return LSTMInput.from_dict(input)
+    py = PyTorchLSTM()
+    py.prepare(LSTMInput.from_dict(input))
+    return py
 
 
 def objective_output(output):
@@ -66,16 +68,12 @@ def jacobian_output(output):
 
 
 @wrap.multiple_runs(runs=lambda x: x["runs"], pre=prepare_input, post=objective_output)
-def objective(input):
-    py = PyTorchLSTM()
-    py.prepare(input)
+def objective(py):
     py.calculate_objective(1)
     return py.objective
 
 
 @wrap.multiple_runs(runs=lambda x: x["runs"], pre=prepare_input, post=jacobian_output)
-def jacobian(input):
-    py = PyTorchLSTM()
-    py.prepare(input)
+def jacobian(py):
     py.calculate_jacobian(1)
     return py.gradient

--- a/python/gradbench/tensorflow/ba.py
+++ b/python/gradbench/tensorflow/ba.py
@@ -191,20 +191,18 @@ def prepare_input(input):
         camIdx = (camIdx + 1) % n
         ptIdx = (ptIdx + 1) % m
 
-    return BAInput(cams, X, w, obs, feats)
+    py = TensorflowBA()
+    py.prepare(BAInput(cams, X, w, obs, feats))
+    return py
 
 
 @wrap.function(pre=prepare_input, post=objective_output)
-def objective(input):
-    py = TensorflowBA()
-    py.prepare(input)
+def objective(py):
     py.calculate_objective(1)
     return (py.reproj_error, py.w_err)
 
 
 @wrap.function(pre=prepare_input, post=jacobian_output)
-def jacobian(input):
-    py = TensorflowBA()
-    py.prepare(input)
+def jacobian(py):
     py.calculate_jacobian(1)
     return py.jacobian

--- a/python/gradbench/tensorflow/gmm.py
+++ b/python/gradbench/tensorflow/gmm.py
@@ -101,26 +101,26 @@ class TensorflowGMM(ITest):
 
 
 def prepare_input(input):
-    return GMMInput(
-        input["alpha"],
-        input["means"],
-        input["icf"],
-        input["x"],
-        Wishart(input["gamma"], input["m"]),
+    py = TensorflowGMM()
+    py.prepare(
+        GMMInput(
+            input["alpha"],
+            input["means"],
+            input["icf"],
+            input["x"],
+            Wishart(input["gamma"], input["m"]),
+        )
     )
+    return py
 
 
 @wrap.function(pre=prepare_input, post=lambda x: x.numpy().tolist())
-def jacobian(input):
-    py = TensorflowGMM()
-    py.prepare(input)
+def jacobian(py):
     py.calculate_jacobian(1)
     return py.gradient
 
 
 @wrap.function(pre=prepare_input, post=lambda x: x.numpy().tolist())
-def objective(input):
-    py = TensorflowGMM()
-    py.prepare(input)
+def objective(py):
     py.calculate_objective(1)
     return py.objective


### PR DESCRIPTION
Importantly, this moves the invocation of the "prepare" method out of the timing loop. Depending on the PyTorch backend, "prepare" might be very costly (e.g. copying data to a GPU), but is unrelated to AD.

A future addition could be to also return timing information for "prepare", in case anyone would find that interesting.