### PR TITLE
Support multiple runs in C++-based tools.

### DIFF
--- a/cpp/adbench/io.cpp
+++ b/cpp/adbench/io.cpp
@@ -3,11 +3,12 @@
 #include "adbench/shared/GMMData.h"
 #include "adbench/shared/BAData.h"
 
-void read_HelloInput_json(const char* fname, HelloInput &input) {
+void read_HelloInput_json(const char* fname, HelloInput &input, int *runs) {
   using json = nlohmann::json;
   std::ifstream f(fname);
   json data = json::parse(f);
   input.x = data.get<double>();
+  *runs = 1;
 }
 
 void write_HelloOutput_objective_json(std::ostream& f, HelloOutput &output) {
@@ -20,7 +21,7 @@ void write_HelloOutput_jacobian_json(std::ostream& f, HelloOutput &output) {
   f << json(output.gradient);
 }
 
-void read_GMMInput_json(const char* fname, GMMInput &input) {
+void read_GMMInput_json(const char* fname, GMMInput &input, int *runs) {
   // Based on read_lstm_instance from ADBench.
   using json = nlohmann::json;
   std::ifstream f(fname);
@@ -43,6 +44,8 @@ void read_GMMInput_json(const char* fname, GMMInput &input) {
 
   input.wishart.gamma = data["gamma"].get<double>();
   input.wishart.m = data["m"].get<int>();
+
+  *runs = data["runs"];
 }
 
 void write_GMMOutput_objective_json(std::ostream& f, GMMOutput &output) {
@@ -56,7 +59,7 @@ void write_GMMOutput_jacobian_json(std::ostream& f, GMMOutput &output) {
 }
 
 
-void read_BAInput_json(const char* fname, BAInput &input) {
+void read_BAInput_json(const char* fname, BAInput &input, int *runs) {
   // Based on read_ba_instance from ADBench.
   using json = nlohmann::json;
   std::ifstream f(fname);
@@ -105,6 +108,8 @@ void read_BAInput_json(const char* fname, BAInput &input) {
     input.feats[i * 2 + 0] = feat[0];
     input.feats[i * 2 + 1] = feat[1];
   }
+
+  *runs = data["runs"];
 }
 
 void write_BAOutput_objective_json(std::ostream& f, BAOutput &output) {
@@ -137,7 +142,7 @@ void write_BAOutput_jacobian_json(std::ostream& f, BAOutput &output) {
   f << out;
 }
 
-void read_LSTMInput_json(const char* fname, LSTMInput &input) {
+void read_LSTMInput_json(const char* fname, LSTMInput &input, int *runs) {
   // Based on read_lstm_instance from ADBench.
   using json = nlohmann::json;
   std::ifstream f(fname);
@@ -167,6 +172,8 @@ void read_LSTMInput_json(const char* fname, LSTMInput &input) {
   for (auto it = sequence.begin(); it != sequence.end(); it++) {
     input.sequence.insert(input.sequence.end(), it->begin(), it->end());
   }
+
+  *runs = data["runs"];
 }
 
 void write_LSTMOutput_objective_json(std::ostream& f, LSTMOutput &output) {
@@ -190,7 +197,7 @@ void to_light_matrix(LightMatrix<double> &m,
   }
 }
 
-void read_HandInput_json(const char* fname, HandInput &input) {
+void read_HandInput_json(const char* fname, HandInput &input, int *runs) {
   // Based on read_hand_instance from ADBench.
   using json = nlohmann::json;
   std::ifstream f(fname);
@@ -255,6 +262,8 @@ void read_HandInput_json(const char* fname, HandInput &input) {
                     inverse_base_absolutes[i]);
     input.data.model.inverse_base_absolutes[i].transpose_in_place();
   }
+
+  *runs = data["runs"];
 }
 
 void write_HandOutput_objective_json(std::ostream& f, HandOutput &output) {

--- a/cpp/adbench/io.h
+++ b/cpp/adbench/io.h
@@ -7,22 +7,22 @@
 #include "adbench/shared/LSTMData.h"
 #include "adbench/shared/HTData.h"
 
-void read_HelloInput_json(const char* fname, HelloInput &input, int*);
+void read_HelloInput_json(const char* fname, HelloInput &input, int *runs);
 void write_HelloOutput_objective_json(std::ostream& f, HelloOutput &output);
 void write_HelloOutput_jacobian_json(std::ostream& f, HelloOutput &output);
 
-void read_GMMInput_json(const char* fname, GMMInput &input, int*);
+void read_GMMInput_json(const char* fname, GMMInput &input, int *runs);
 void write_GMMOutput_objective_json(std::ostream& f, GMMOutput &output);
 void write_GMMOutput_jacobian_json(std::ostream& f, GMMOutput &output);
 
-void read_BAInput_json(const char* fname, BAInput &input, int*);
+void read_BAInput_json(const char* fname, BAInput &input, int *runs);
 void write_BAOutput_objective_json(std::ostream& f, BAOutput &output);
 void write_BAOutput_jacobian_json(std::ostream& f, BAOutput &output);
 
-void read_LSTMInput_json(const char* fname, LSTMInput &input, int*);
+void read_LSTMInput_json(const char* fname, LSTMInput &input, int *runs);
 void write_LSTMOutput_objective_json(std::ostream& f, LSTMOutput &output);
 void write_LSTMOutput_jacobian_json(std::ostream& f, LSTMOutput &output);
 
-void read_HandInput_json(const char* fname, HandInput &input, int*);
+void read_HandInput_json(const char* fname, HandInput &input, int *runs);
 void write_HandOutput_objective_json(std::ostream& f, HandOutput &output);
 void write_HandOutput_jacobian_json(std::ostream& f, HandOutput &output);

--- a/cpp/adbench/io.h
+++ b/cpp/adbench/io.h
@@ -7,22 +7,22 @@
 #include "adbench/shared/LSTMData.h"
 #include "adbench/shared/HTData.h"
 
-void read_HelloInput_json(const char* fname, HelloInput &input);
+void read_HelloInput_json(const char* fname, HelloInput &input, int*);
 void write_HelloOutput_objective_json(std::ostream& f, HelloOutput &output);
 void write_HelloOutput_jacobian_json(std::ostream& f, HelloOutput &output);
 
-void read_GMMInput_json(const char* fname, GMMInput &input);
+void read_GMMInput_json(const char* fname, GMMInput &input, int*);
 void write_GMMOutput_objective_json(std::ostream& f, GMMOutput &output);
 void write_GMMOutput_jacobian_json(std::ostream& f, GMMOutput &output);
 
-void read_BAInput_json(const char* fname, BAInput &input);
+void read_BAInput_json(const char* fname, BAInput &input, int*);
 void write_BAOutput_objective_json(std::ostream& f, BAOutput &output);
 void write_BAOutput_jacobian_json(std::ostream& f, BAOutput &output);
 
-void read_LSTMInput_json(const char* fname, LSTMInput &input);
+void read_LSTMInput_json(const char* fname, LSTMInput &input, int*);
 void write_LSTMOutput_objective_json(std::ostream& f, LSTMOutput &output);
 void write_LSTMOutput_jacobian_json(std::ostream& f, LSTMOutput &output);
 
-void read_HandInput_json(const char* fname, HandInput &input);
+void read_HandInput_json(const char* fname, HandInput &input, int*);
 void write_HandOutput_objective_json(std::ostream& f, HandOutput &output);
 void write_HandOutput_jacobian_json(std::ostream& f, HandOutput &output);

--- a/tools/enzyme/run.py
+++ b/tools/enzyme/run.py
@@ -12,9 +12,10 @@ def resolve(module, name):
 def run(params):
     func = resolve(params["module"], params["function"])
     vals = params["input"]
-    ret, time = func(vals).stdout.split("\n")
-    timings = [{"name": "evaluate", "nanoseconds": int(time)}]
-    return {"output": json.loads(ret), "timings": timings}
+    ls = func(vals).stdout.splitlines()
+    output = ls[0]
+    timings = [{"name": "evaluate", "nanoseconds": int(time)} for time in ls[1:]]
+    return {"output": json.loads(output), "timings": timings}
 
 
 def main():

--- a/tools/finite/run.py
+++ b/tools/finite/run.py
@@ -12,9 +12,10 @@ def resolve(module, name):
 def run(params):
     func = resolve(params["module"], params["function"])
     vals = params["input"]
-    ret, time = func(vals).stdout.split("\n")
-    timings = [{"name": "evaluate", "nanoseconds": int(time)}]
-    return {"output": json.loads(ret), "timings": timings}
+    ls = func(vals).stdout.splitlines()
+    output = ls[0]
+    timings = [{"name": "evaluate", "nanoseconds": int(time)} for time in ls[1:]]
+    return {"output": json.loads(output), "timings": timings}
 
 
 def main():

--- a/tools/manual/run.py
+++ b/tools/manual/run.py
@@ -12,9 +12,10 @@ def resolve(module, name):
 def run(params):
     func = resolve(params["module"], params["function"])
     vals = params["input"]
-    ret, time = func(vals).stdout.split("\n")
-    timings = [{"name": "evaluate", "nanoseconds": int(time)}]
-    return {"output": json.loads(ret), "timings": timings}
+    ls = func(vals).stdout.splitlines()
+    output = ls[0]
+    timings = [{"name": "evaluate", "nanoseconds": int(time)} for time in ls[1:]]
+    return {"output": json.loads(output), "timings": timings}
 
 
 def main():

--- a/tools/tapenade/run.py
+++ b/tools/tapenade/run.py
@@ -3,8 +3,6 @@ import sys
 import time
 from importlib import import_module
 
-# NOTE: The current implementation for Tapenade only supports passing in individual scalar inputs.
-
 
 def resolve(module, name):
     functions = import_module(module)
@@ -14,9 +12,10 @@ def resolve(module, name):
 def run(params):
     func = resolve(params["module"], params["function"])
     vals = params["input"]
-    ret, time = func(vals).stdout.split("\n")
-    timings = [{"name": "evaluate", "nanoseconds": int(time)}]
-    return {"output": json.loads(ret), "timings": timings}
+    ls = func(vals).stdout.splitlines()
+    output = ls[0]
+    timings = [{"name": "evaluate", "nanoseconds": int(time)} for time in ls[1:]]
+    return {"output": json.loads(output), "timings": timings}
 
 
 def main():


### PR DESCRIPTION
Rather than extending the ADBench-defined input data structures with a "runs" field, I opted to make the JSON parsing functions (which are custom to GradBench) write to a separate "runs" variable. This was done solely to minimise code differences with ADBench.