### PR TITLE
Make objective_hello a template function.

### DIFF
--- a/cpp/adbench/shared/hello.h
+++ b/cpp/adbench/shared/hello.h
@@ -1,5 +1,8 @@
 #pragma once
 
-double hello_objective(double x) {
+// Written as a template function to allow for overloading-based AD
+// tools.
+template<typename D>
+D hello_objective(D x) {
   return x * x;
 }


### PR DESCRIPTION
This is to ensure that it is usable with operator overloading-based AD tools, which is consistent with the other C++ objective functions.

Of course the 'hello' eval is so trivial that it takes less time to implement than to import, but I think it is useful to use it for demonstrating "best practice".