### PR TITLE
Allow `"timings"` in the response to `"define"`

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ The session proceeds over a series of _rounds_, driven by the eval. In each roun
 
 2. `"kind": "define"` - the eval provides the name of a `"module"` which the tool will need in order to proceed further with this particular benchmark. This will allow the tool to respond saying whether or not it knows of and has an implementation for the module of that name.
 
-   - The tool responds with the `"id"` and either `"success": true` or `"success": false`. In the former case, the benchmark proceeds normally. In the latter case, the tool is indicating that it does not have an implementation for the requested module, and the eval should stop and not send any further messages.
+   - The tool responds with the `"id"` and either `"success": true` or `"success": false`. In the former case, the benchmark proceeds normally. In the latter case, the tool is indicating that it does not have an implementation for the requested module, and the eval should stop and not send any further messages. Optionally, the tool may also provide a list of `"timings"` for subtasks of preparing the requested module.
 
 3. `"kind": "evaluate"` - the eval again provides a `"module"` name, as well as the name of a `"function"` in that module. Currently there is no formal process for registering module names or specifying the functions available in those modules; those are specified informally via documentation in the evals themselves. An `"input"` to that function is also provided; the tool will be expected to evaluate that function at that input, and return the result. Optionally, the eval may also provide a short human-readable `"description"` of the input.
 
@@ -145,6 +145,7 @@ type Message = StartMessage | DefineMessage | EvaluateMessage | AnalysisMessage;
 
 interface DefineResponse extends Base {
   success: boolean;
+  timings?: Timing[];
 }
 
 interface EvaluateResponse extends Base {

--- a/crates/gradbench/src/cli.rs
+++ b/crates/gradbench/src/cli.rs
@@ -225,17 +225,6 @@ enum Message {
     },
 }
 
-/// A response from the tool to a `"start"` message.
-#[derive(Debug, Deserialize)]
-struct StartResponse {}
-
-/// A response from the tool to a `"define"` message.
-#[derive(Debug, Deserialize)]
-struct DefineResponse {
-    /// Whether the module was successfully defined.
-    success: bool,
-}
-
 /// Nanosecond timings from the tool.
 #[derive(Debug, Deserialize)]
 struct Timing {
@@ -246,10 +235,24 @@ struct Timing {
     nanoseconds: u128,
 }
 
+/// A response from the tool to a `"start"` message.
+#[derive(Debug, Deserialize)]
+struct StartResponse {}
+
+/// A response from the tool to a `"define"` message.
+#[derive(Debug, Deserialize)]
+struct DefineResponse {
+    /// Whether the module was successfully defined.
+    success: bool,
+
+    /// Subtask timings.
+    timings: Option<Vec<Timing>>,
+}
+
 /// A response from the tool to an `"evaluate"` message.
 #[derive(Debug, Deserialize)]
 struct EvaluateResponse {
-    /// More granular timings.
+    /// Subtask timings.
     timings: Option<Vec<Timing>>,
 }
 


### PR DESCRIPTION
Following up on #149 and #157.