### PR TITLE
Fix Enzyme, which was quietly broken in #167.

### DIFF
--- a/tools/enzyme/EnzymeHello.cpp
+++ b/tools/enzyme/EnzymeHello.cpp
@@ -23,6 +23,6 @@ extern double __enzyme_autodiff(void*, double);
 void EnzymeHello::calculate_jacobian(int times)
 {
     for (int i = 0; i < times; ++i) {
-      _output.gradient = __enzyme_autodiff((void*)hello_objective, _input.x);
+      _output.gradient = __enzyme_autodiff((void*)hello_objective<double>, _input.x);
     }
 }


### PR DESCRIPTION
This reveals a testing weakness: if a bug is introduced that makes 'define' messages fail, CI will not notice.