### PR TITLE
Support timeouts in intermediary.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,6 +79,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
+name = "bitflags"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+
+[[package]]
 name = "bumpalo"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -98,6 +104,12 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -185,6 +197,7 @@ dependencies = [
  "colored",
  "serde",
  "serde_json",
+ "timeout-readwrite",
 ]
 
 [[package]]
@@ -261,6 +274,18 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
 
 [[package]]
 name = "num-traits"
@@ -354,6 +379,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "timeout-readwrite"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f99014ef5f7ad8fb986e0885b612ac6bd74a87c8df9816c27de5dcc49029646"
+dependencies = [
+ "nix",
 ]
 
 [[package]]

--- a/crates/gradbench/Cargo.toml
+++ b/crates/gradbench/Cargo.toml
@@ -13,3 +13,4 @@ clap = { version = "4", features = ["derive"] }
 colored = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+timeout-readwrite = "0.4.0"


### PR DESCRIPTION
This does work, although it has the following deficiencies:

1. Timeouts are only supported for tool responses, not eval responses. This is probably not a significant problem.

2. Failures due to timeouts are not distinguishable from other failures. It can be expected that some tools will fail to complete on some datasets, and it would be nice if this did not cause CI to fail entirely, but simply show up on the graphs (once we get those). I think the solution here is to make the exit code depend on the reason for the termination. Alternatively, just don't treat timeouts as an error at all.

3. When run in the terminal, timeouts are somewhat noisy, because pipes get broken and the tool/eval scripts get upset about unexpected EOFs and SIGPIPEs and print out stack traces. Quite similar to what happens when a tool crashes, actually.