### PR TITLE
Modify evals and tools to handle closed pipes gracefully.

### DIFF
--- a/python/gradbench/cpp_run.py
+++ b/python/gradbench/cpp_run.py
@@ -32,17 +32,20 @@ def run(params):
 
 
 def main():
-    for line in sys.stdin:
-        message = json.loads(line)
-        response = {}
-        if message["kind"] == "evaluate":
-            response = run(message)
-        elif message["kind"] == "define":
-            try:
-                functions = import_module(message["module"])
-                func = getattr(functions, "compile")
-                success = func()  # compiles C code
-                response["success"] = success
-            except:
-                response["success"] = False
-        print(json.dumps({"id": message["id"]} | response), flush=True)
+    try:
+        for line in sys.stdin:
+            message = json.loads(line)
+            response = {}
+            if message["kind"] == "evaluate":
+                response = run(message)
+            elif message["kind"] == "define":
+                try:
+                    functions = import_module(message["module"])
+                    func = getattr(functions, "compile")
+                    success = func()  # compiles C code
+                    response["success"] = success
+                except:
+                    response["success"] = False
+            print(json.dumps({"id": message["id"]} | response), flush=True)
+    except (EOFError, BrokenPipeError):
+        pass

--- a/python/gradbench/evals/gmm/run.py
+++ b/python/gradbench/evals/gmm/run.py
@@ -49,4 +49,7 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except (EOFError, BrokenPipeError):
+        pass

--- a/python/gradbench/evals/hello/run.py
+++ b/python/gradbench/evals/hello/run.py
@@ -25,4 +25,7 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except (EOFError, BrokenPipeError):
+        pass

--- a/python/gradbench/evals/ht/run.py
+++ b/python/gradbench/evals/ht/run.py
@@ -59,4 +59,7 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except (EOFError, BrokenPipeError):
+        pass

--- a/python/gradbench/evals/lstm/run.py
+++ b/python/gradbench/evals/lstm/run.py
@@ -46,4 +46,7 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except (EOFError, BrokenPipeError):
+        pass

--- a/python/gradbench/evaluation.py
+++ b/python/gradbench/evaluation.py
@@ -84,7 +84,10 @@ class SingleModuleValidatedEvaluation:
         print(flush=True)
         if message["kind"] == "end":
             return
-        response = json.loads(sys.stdin.readline())
+        l = sys.stdin.readline()
+        if l == "":
+            raise EOFError
+        response = json.loads(l)
         if response["id"] != self.id:
             raise ValueError(f"expected message ID {self.id}, got {response['id']}")
         self.id += 1

--- a/tools/futhark/run.py
+++ b/tools/futhark/run.py
@@ -59,4 +59,7 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except (EOFError, BrokenPipeError):
+        pass


### PR DESCRIPTION
Previously, if the stdin/stdout pipes were closed unexpectedly by the intermediary (usually because of an error somewhere), we'd get loud stack traces and nonzero exit codes. This has two problems:

* It obscures the first error (the one that causes the intermediary to close the pipes) because the followup error is just as verbose.

* It makes timeouts (#178) much more verbose, because they inherently depend on unexpectedly shutting down the tool and/or eval.

I think it is correct design for debuggability that the stderrs of tool/eval are not in any way impeded, but it comes with an obligation not to needlessly litter them. It is very unlikely that the change in this PR will suppress a true bug.