### PR TITLE
Make LSTM accept pointer instead of vector for state.

### DIFF
--- a/cpp/adbench/shared/lstm.h
+++ b/cpp/adbench/shared/lstm.h
@@ -190,14 +190,15 @@ void lstm_predict(int l, int b,
 template<typename T>
 void lstm_objective(int l, int c, int b, 
     const T* main_params, const T* extra_params,
-    std::vector<T> state, const T* sequence,
+    const T* state, const T* sequence,
     T* loss)
 {
     T total = 0.0;
     int count = 0;
     MainParams<T> main_params_wrap(main_params, b, l);
     ExtraParams<T> extra_params_wrap(extra_params, b);
-    State<T> state_wrap(state.data(), b, l);
+    std::vector<T> state_copy(state, state + l*2*b);
+    State<T> state_wrap(state_copy.data(), b, l);
     InputSequence<T> sequence_wrap(sequence, b, c);
     std::vector<T> ypred(b), ynorm(b);
     for (int t = 0; t < c - 1; ++t)

--- a/cpp/adbench/shared/lstm.h
+++ b/cpp/adbench/shared/lstm.h
@@ -197,7 +197,8 @@ void lstm_objective(int l, int c, int b,
     int count = 0;
     MainParams<T> main_params_wrap(main_params, b, l);
     ExtraParams<T> extra_params_wrap(extra_params, b);
-    std::vector<T> state_copy(state, state + l*2*b);
+    std::vector<T> state_copy(l*2*b);
+    std::copy(&state[0], &state[l*2*b], state_copy.data());
     State<T> state_wrap(state_copy.data(), b, l);
     InputSequence<T> sequence_wrap(sequence, b, c);
     std::vector<T> ypred(b), ynorm(b);

--- a/tools/adept/AdeptLSTM.cpp
+++ b/tools/adept/AdeptLSTM.cpp
@@ -22,7 +22,7 @@ void lstm_objective_J(int l, int c, int b,
   adouble aloss;
   lstm_objective(l, c, b,
                  amain_params.data(), aextra_params.data(),
-                 astate, asequence.data(),
+                 astate.data(), asequence.data(),
                  &aloss);
   aloss.set_gradient(1.); // only one J row here
   stack.reverse();
@@ -40,7 +40,6 @@ void lstm_objective_J(int l, int c, int b,
 void AdeptLSTM::prepare(LSTMInput&& input) {
   this->input = input;
   int Jcols = 8 * this->input.l * this->input.b + 3 * this->input.b;
-  state = std::vector<double>(this->input.state.size());
   result = { 0, std::vector<double>(Jcols) };
 }
 
@@ -51,14 +50,12 @@ LSTMOutput AdeptLSTM::output()
 
 void AdeptLSTM::calculate_objective(int times) {
   for (int i = 0; i < times; ++i) {
-    state = input.state;
-    lstm_objective(input.l, input.c, input.b, input.main_params.data(), input.extra_params.data(), state, input.sequence.data(), &result.objective);
+    lstm_objective(input.l, input.c, input.b, input.main_params.data(), input.extra_params.data(), input.state.data(), input.sequence.data(), &result.objective);
   }
 }
 
 void AdeptLSTM::calculate_jacobian(int times) {
   for (int i = 0; i < times; ++i) {
-    state = input.state;
     lstm_objective_J(input.l, input.c, input.b, input, &result.objective, result.gradient.data());
   }
 }

--- a/tools/adept/AdeptLSTM.h
+++ b/tools/adept/AdeptLSTM.h
@@ -9,7 +9,6 @@ class AdeptLSTM : public ITest<LSTMInput, LSTMOutput> {
 private:
   LSTMInput input;
   LSTMOutput result;
-  std::vector<double> state;
 
 public:
   virtual void prepare(LSTMInput&& input) override;

--- a/tools/finite/FiniteLSTM.cpp
+++ b/tools/finite/FiniteLSTM.cpp
@@ -12,7 +12,6 @@ void FiniteLSTM::prepare(LSTMInput&& input)
 {
     this->input = input;
     int Jcols = 8 * this->input.l * this->input.b + 3 * this->input.b;
-    state = std::vector<double>(this->input.state.size());
     result = { 0, std::vector<double>(Jcols) };
     engine.set_max_output_size(1);
 }
@@ -25,28 +24,21 @@ LSTMOutput FiniteLSTM::output()
 void FiniteLSTM::calculate_objective(int times)
 {
     for (int i = 0; i < times; ++i) {
-        state = input.state;
-        lstm_objective(input.l, input.c, input.b, input.main_params.data(), input.extra_params.data(), state, input.sequence.data(), &result.objective);
+        lstm_objective(input.l, input.c, input.b, input.main_params.data(), input.extra_params.data(), input.state.data(), input.sequence.data(), &result.objective);
     }
 }
 
 void FiniteLSTM::calculate_jacobian(int times)
 {
     for (int i = 0; i < times; ++i) {
-        state = input.state;
         engine.finite_differences([&](double* main_params_in, double* loss) {
             lstm_objective(input.l, input.c, input.b, main_params_in,
-                input.extra_params.data(), state, input.sequence.data(), loss);
+                           input.extra_params.data(), input.state.data(), input.sequence.data(), loss);
             }, input.main_params.data(), input.main_params.size(), 1, result.gradient.data());
 
         engine.finite_differences([&](double* extra_params_in, double* loss) {
             lstm_objective(input.l, input.c, input.b, input.main_params.data(),
-                extra_params_in, state, input.sequence.data(), loss);
+                           extra_params_in, input.state.data(), input.sequence.data(), loss);
             }, input.extra_params.data(), input.extra_params.size(), 1, &result.gradient.data()[2 * input.l * 4 * input.b]);
     }
-}
-
-extern "C" DLL_PUBLIC ITest<LSTMInput, LSTMOutput>*  get_lstm_test()
-{
-    return new FiniteLSTM();
 }

--- a/tools/finite/FiniteLSTM.h
+++ b/tools/finite/FiniteLSTM.h
@@ -15,7 +15,6 @@ class FiniteLSTM : public ITest<LSTMInput, LSTMOutput> {
 private:
     LSTMInput input;
     LSTMOutput result;
-    std::vector<double> state;
     FiniteDifferencesEngine<double> engine;
 
 public:

--- a/tools/manual/ManualLSTM.cpp
+++ b/tools/manual/ManualLSTM.cpp
@@ -13,7 +13,6 @@ void ManualLSTM::prepare(LSTMInput&& input)
 {
     this->input = input;
     int Jcols = 8 * this->input.l * this->input.b + 3 * this->input.b;
-    state = std::vector<double>(this->input.state.size());
     result = { 0, std::vector<double>(Jcols) };
 }
 
@@ -25,20 +24,13 @@ LSTMOutput ManualLSTM::output()
 void ManualLSTM::calculate_objective(int times)
 {
     for (int i = 0; i < times; ++i) {
-        state = input.state;
-        lstm_objective(input.l, input.c, input.b, input.main_params.data(), input.extra_params.data(), state, input.sequence.data(), &result.objective);
+      lstm_objective(input.l, input.c, input.b, input.main_params.data(), input.extra_params.data(), input.state.data(), input.sequence.data(), &result.objective);
     }
 }
 
 void ManualLSTM::calculate_jacobian(int times)
 {
     for (int i = 0; i < times; ++i) {
-        state = input.state;
-        lstm_objective_d(input.l, input.c, input.b, input.main_params.data(), input.extra_params.data(), state, input.sequence.data(), &result.objective, result.gradient.data());
+      lstm_objective_d(input.l, input.c, input.b, input.main_params.data(), input.extra_params.data(), input.state, input.sequence.data(), &result.objective, result.gradient.data());
     }
-}
-
-extern "C" DLL_PUBLIC ITest<LSTMInput, LSTMOutput>*  get_lstm_test()
-{
-    return new ManualLSTM();
 }


### PR DESCRIPTION
This is consistent with the other parameters (and other objective functions for that matter), and is necessary for Enzyme to easily accept the lstm_objective function.