### PR TITLE
Include commit SHA in nightly `summary.json`

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -189,7 +189,7 @@ jobs:
       - name: Create summary of logs in nightly outputs branch dir
         env:
           DATE: ${{ fromJSON(needs.matrix.outputs.date) }}
-        run: gradbench repo summarize --date "$DATE" run
+        run: gradbench repo summarize --date "$DATE" --commit ${{ github.sha }} run
       - name: Commit and push nightly outputs branch
         working-directory: run
         env:

--- a/crates/gradbench/src/cli.rs
+++ b/crates/gradbench/src/cli.rs
@@ -167,6 +167,10 @@ enum RepoCommands {
         /// The current date
         #[clap(long)]
         date: String,
+
+        /// The Git commit SHA from the `main` branch
+        #[clap(long)]
+        commit: String,
     },
 }
 
@@ -715,6 +719,9 @@ struct Summary<'a> {
     /// The current date.
     date: String,
 
+    /// The Git commit SHA from the `main` branch.
+    commit: String,
+
     /// The table of summary data.
     table: Vec<Row<'a>>,
 }
@@ -820,7 +827,7 @@ fn cli_result() -> Result<(), ExitCode> {
                     github_output("slow", slow)?;
                     Ok(())
                 }
-                RepoCommands::Summarize { dir, date } => {
+                RepoCommands::Summarize { dir, date, commit } => {
                     let mut table = vec![];
                     let mut evals = ls("evals")?;
                     evals.sort();
@@ -835,7 +842,11 @@ fn cli_result() -> Result<(), ExitCode> {
                         }
                         table.push(Row { eval, tools: row });
                     }
-                    let summary = Summary { date, table };
+                    let summary = Summary {
+                        date,
+                        commit,
+                        table,
+                    };
                     let output = dir.join("summary.json");
                     let file = fs::File::create(&output).map_err(|err| {
                         eprintln!("error creating summary file {output:?}: {err}");


### PR DESCRIPTION
I want the eval and tool names on the GradBench website to be links to the `README.md` files in this repo. By including the commit SHA in the `summary.json` for each nightly run, we can have those be permalinks which will be guaranteed valid.