### PR TITLE
Simplify C++ infrastructure.

### DIFF
--- a/cpp/adbench/shared/ITest.h
+++ b/cpp/adbench/shared/ITest.h
@@ -2,40 +2,33 @@
 // Licensed under the MIT license.
 
 // https://github.com/microsoft/ADBench/blob/38cb7931303a830c3700ca36ba9520868327ac87/src/cpp/shared/ITest.h
+//
+// Changes made:
+//
+//   - removed 'times' parameter from calculate_objective/calculate_jacobian.
+//   - changed 'prepare' method into a constructor.
+//   - added a 'prepare_jacobian' method.
+//   - added _input/_output fields.
 
 #pragma once
 
-#if defined _WIN32 || defined __CYGWIN__
-    #ifdef __GNUC__
-        #define DLL_PUBLIC __attribute__ ((dllexport))
-    #else
-        #define DLL_PUBLIC __declspec(dllexport) // Note: actually gcc seems to also supports this syntax.
-    #endif
-#else
-  #if __GNUC__ >= 4
-    #define DLL_PUBLIC __attribute__ ((visibility ("default")))
-  #else
-    #define DLL_PUBLIC
-  #endif
-#endif
-
-#include <ostream>
-
 template <typename Input, typename Output>
 class ITest {
+protected:
+  Input& _input;
+  Output _output;
 public:
-    // This function must be called before any other function.
-    virtual void prepare(Input&& input) = 0;
-    // calculate function
-    virtual void calculate_objective(int times) = 0;
-    virtual void calculate_jacobian(int times) = 0;
-    virtual Output output() = 0;
-    virtual ~ITest() = 0;
+  // This function must be called before any other function.
+  ITest(Input& input) : _input(input) {}
+  // This function must be called before calculate_jacobian.
+  virtual void prepare_jacobian() { };
+  // calculate function
+  virtual void calculate_objective() = 0;
+  virtual void calculate_jacobian() = 0;
+  Output output() { return _output; };
+  virtual ~ITest() = default;
 };
-
-template <typename Input, typename Output>
-ITest<Input, Output>::~ITest() = default;
 
 // Factory function that creates instances of the GMMTester object.
 // Should be declared in each module.
-// extern "C" DLL_PUBLIC ITest<Input,Output>* GetGMMTester();
+

--- a/cpp/adbench/shared/lstm.h
+++ b/cpp/adbench/shared/lstm.h
@@ -4,7 +4,6 @@
 // https://github.com/microsoft/ADBench/blob/38cb7931303a830c3700ca36ba9520868327ac87/src/cpp/shared/lstm.h
 
 #pragma once
-#pragma warning (disable : 4996) // fopen
 
 #include <vector>
 #include <cmath>

--- a/cpp/adbench/shared/utils.cpp
+++ b/cpp/adbench/shared/utils.cpp
@@ -2,10 +2,10 @@
 // Licensed under the MIT license.
 
 // https://github.com/microsoft/ADBench/blob/38cb7931303a830c3700ca36ba9520868327ac87/src/cpp/shared/utils.cpp
+//
+// Changes made: silenced some warnings.
 
 #include "utils.h"
-
-#pragma warning (disable : 4996) // fopen
 
 #include <iostream>
 #include <string>

--- a/tools/adept/AdeptBA.cpp
+++ b/tools/adept/AdeptBA.cpp
@@ -56,10 +56,7 @@ void compute_ba_J(int n, int m, int p,
   }
 }
 
-// This function must be called before any other function.
-void AdeptBA::prepare(BAInput&& input)
-{
-  _input = input;
+AdeptBA::AdeptBA(BAInput& input) : ITest(input) {
   _output = {
     std::vector<double>(2 * _input.p),
     std::vector<double>(_input.p),
@@ -69,26 +66,15 @@ void AdeptBA::prepare(BAInput&& input)
   _reproj_err_d = std::vector<double>(2 * n_new_cols);
 }
 
-BAOutput AdeptBA::output()
-{
-  return _output;
+void AdeptBA::calculate_objective() {
+  ba_objective(_input.n, _input.m, _input.p, _input.cams.data(), _input.X.data(), _input.w.data(),
+               _input.obs.data(), _input.feats.data(), _output.reproj_err.data(), _output.w_err.data());
 }
 
-void AdeptBA::calculate_objective(int times)
-{
-  for (int i = 0; i < times; ++i) {
-    ba_objective(_input.n, _input.m, _input.p, _input.cams.data(), _input.X.data(), _input.w.data(),
-                 _input.obs.data(), _input.feats.data(), _output.reproj_err.data(), _output.w_err.data());
-  }
-}
-
-void AdeptBA::calculate_jacobian(int times)
-{
-  for (int i = 0; i < times; ++i) {
-    _output.J.clear();
-    compute_ba_J(_input.n, _input.m, _input.p,
-                 _input.cams.data(), _input.X.data(), _input.w.data(),
-                 _input.obs.data(), _input.feats.data(), _output.reproj_err.data(), _output.w_err.data(),
-                 &_output.J);
-  }
+void AdeptBA::calculate_jacobian() {
+  _output.J.clear();
+  compute_ba_J(_input.n, _input.m, _input.p,
+               _input.cams.data(), _input.X.data(), _input.w.data(),
+               _input.obs.data(), _input.feats.data(), _output.reproj_err.data(), _output.w_err.data(),
+               &_output.J);
 }

--- a/tools/adept/AdeptBA.h
+++ b/tools/adept/AdeptBA.h
@@ -7,16 +7,11 @@
 
 class AdeptBA : public ITest<BAInput, BAOutput> {
 private:
-  BAInput _input;
-  BAOutput _output;
   std::vector<double> _reproj_err_d;
 
 public:
-  virtual void prepare(BAInput&& input) override;
+  AdeptBA(BAInput&);
 
-  virtual void calculate_objective(int times) override;
-  virtual void calculate_jacobian(int times) override;
-  virtual BAOutput output() override;
-
-  ~AdeptBA() {}
+  virtual void calculate_objective() override;
+  virtual void calculate_jacobian() override;
 };

--- a/tools/adept/AdeptGMM.cpp
+++ b/tools/adept/AdeptGMM.cpp
@@ -39,30 +39,16 @@ void compute_gmm_J(const GMMInput &input, GMMOutput &output) {
   delete[] aicf;
 }
 
-// This function must be called before any other function.
-void AdeptGMM::prepare(GMMInput&& input)
-{
-  _input = input;
+AdeptGMM::AdeptGMM(GMMInput& input) : ITest(input) {
   int Jcols = (_input.k * (_input.d + 1) * (_input.d + 2)) / 2;
   _output = { 0,  std::vector<double>(Jcols) };
 }
 
-GMMOutput AdeptGMM::output()
-{
-  return _output;
+void AdeptGMM::calculate_objective() {
+  gmm_objective(_input.d, _input.k, _input.n, _input.alphas.data(), _input.means.data(),
+                _input.icf.data(), _input.x.data(), _input.wishart, &_output.objective);
 }
 
-void AdeptGMM::calculate_objective(int times)
-{
-  for (int i = 0; i < times; ++i) {
-    gmm_objective(_input.d, _input.k, _input.n, _input.alphas.data(), _input.means.data(),
-                  _input.icf.data(), _input.x.data(), _input.wishart, &_output.objective);
-  }
-}
-
-void AdeptGMM::calculate_jacobian(int times)
-{
-  for (int i = 0; i < times; ++i) {
+void AdeptGMM::calculate_jacobian() {
     compute_gmm_J(_input, _output);
-  }
 }

--- a/tools/adept/AdeptGMM.h
+++ b/tools/adept/AdeptGMM.h
@@ -6,15 +6,9 @@
 #include <vector>
 
 class AdeptGMM : public ITest<GMMInput, GMMOutput> {
-  GMMInput _input;
-  GMMOutput _output;
-
 public:
-  void prepare(GMMInput&& input) override;
+  AdeptGMM(GMMInput&);
 
-  void calculate_objective(int times) override;
-  void calculate_jacobian(int times) override;
-  GMMOutput output() override;
-
-  ~AdeptGMM() = default;
+  void calculate_objective() override;
+  void calculate_jacobian() override;
 };

--- a/tools/adept/AdeptHT.cpp
+++ b/tools/adept/AdeptHT.cpp
@@ -62,7 +62,7 @@ void compute_hand_complicated_J(const vector<double>& theta, const vector<double
 }
 
 void compute_hand_simple_J(const vector<double>& theta, const HandDataLightMatrix* data,
-                             vector<double> *perr, vector<double> *pJ) {
+                           vector<double> *perr, vector<double> *pJ) {
   auto &err = *perr;
   auto &J = *pJ;
   adept::Stack stack;
@@ -79,47 +79,32 @@ void compute_hand_simple_J(const vector<double>& theta, const HandDataLightMatri
   adept::get_values(aerr.data(), err.size(), err.data());
 }
 
-// This function must be called before any other function.
-void AdeptHand::prepare(HandInput&& input)
-{
-  _input = input;
+AdeptHand::AdeptHand(HandInput& input) : ITest(input) {
   _complicated = _input.us.size() != 0;
   int err_size = 3 * _input.data.correspondences.size();
   int ncols = (_complicated ? 2 : 0) + _input.theta.size();
   _output = { std::vector<double>(err_size), ncols, err_size, std::vector<double>(err_size * ncols) };
 }
 
-HandOutput AdeptHand::output()
-{
-  return _output;
-}
-
-void AdeptHand::calculate_objective(int times) {
+void AdeptHand::calculate_objective() {
   if (_complicated) {
-    for (int i = 0; i < times; ++i) {
-      hand_objective(_input.theta.data(), _input.us.data(), &_input.data, _output.objective.data());
-    }
-  }
-  else {
-    for (int i = 0; i < times; ++i) {
-      hand_objective(_input.theta.data(), &_input.data, _output.objective.data());
-    }
+    hand_objective(_input.theta.data(), _input.us.data(), &_input.data, _output.objective.data());
+  } else {
+    hand_objective(_input.theta.data(), &_input.data, _output.objective.data());
   }
 }
 
-void AdeptHand::calculate_jacobian(int times) {
-  for (int i = 0; i < times; ++i) {
-    if (_input.us.size() == 0) {
-      compute_hand_simple_J(_input.theta,
-                            &_input.data,
-                            &_output.objective,
-                            &_output.jacobian);
-    } else {
-      compute_hand_complicated_J(_input.theta,
-                                 _input.us,
-                                 &_input.data,
-                                 &_output.objective,
-                                 &_output.jacobian);
-    }
+void AdeptHand::calculate_jacobian() {
+  if (_input.us.size() == 0) {
+    compute_hand_simple_J(_input.theta,
+                          &_input.data,
+                          &_output.objective,
+                          &_output.jacobian);
+  } else {
+    compute_hand_complicated_J(_input.theta,
+                               _input.us,
+                               &_input.data,
+                               &_output.objective,
+                               &_output.jacobian);
   }
 }

--- a/tools/adept/AdeptHT.h
+++ b/tools/adept/AdeptHT.h
@@ -4,16 +4,11 @@
 #include "adbench/shared/HTData.h"
 
 class AdeptHand : public ITest<HandInput, HandOutput> {
-  HandInput _input;
-  HandOutput _output;
   bool _complicated = false;
 
 public:
-  void prepare(HandInput&& input) override;
+  AdeptHand(HandInput&);
 
-  void calculate_objective(int times) override;
-  void calculate_jacobian(int times) override;
-  HandOutput output() override;
-
-  ~AdeptHand() = default;
+  void calculate_objective() override;
+  void calculate_jacobian() override;
 };

--- a/tools/adept/AdeptHello.cpp
+++ b/tools/adept/AdeptHello.cpp
@@ -2,37 +2,23 @@
 #include "adbench/shared/hello.h"
 #include "adept.h"
 
-void AdeptHello::prepare(HelloInput&& input)
-{
-    _input = input;
+AdeptHello::AdeptHello(HelloInput& input) : ITest(input) {}
+
+void AdeptHello::calculate_objective() {
+  _output.objective = hello_objective(_input.x);
 }
 
-HelloOutput AdeptHello::output()
-{
-    return _output;
-}
-
-void AdeptHello::calculate_objective(int times)
-{
-    for (int i = 0; i < times; ++i) {
-      _output.objective = hello_objective(_input.x);
-    }
-}
-
-void AdeptHello::calculate_jacobian(int times)
-{
+void AdeptHello::calculate_jacobian() {
   using adept::adouble;
   using adept::Real;
   adept::Stack s;
   adouble x = _input.x;
 
-  for (int i = 0; i < times; ++i) {
-    s.new_recording();
-    adouble y = hello_objective<adouble>(x);
-    y.set_gradient(1.0);
-    s.reverse();
-    s.independent(&x, 1);
-    s.dependent(y);
-    s.jacobian(&_output.gradient);
-  }
+  s.new_recording();
+  adouble y = hello_objective<adouble>(x);
+  y.set_gradient(1.0);
+  s.reverse();
+  s.independent(&x, 1);
+  s.dependent(y);
+  s.jacobian(&_output.gradient);
 }

--- a/tools/adept/AdeptHello.h
+++ b/tools/adept/AdeptHello.h
@@ -6,16 +6,9 @@
 #include <vector>
 
 class AdeptHello : public ITest<HelloInput, HelloOutput> {
-private:
-    HelloInput _input;
-    HelloOutput _output;
-
 public:
-    virtual void prepare(HelloInput&& input) override;
+    AdeptHello(HelloInput&);
 
-    virtual void calculate_objective(int times) override;
-    virtual void calculate_jacobian(int times) override;
-    virtual HelloOutput output() override;
-
-    ~AdeptHello() {}
+    virtual void calculate_objective() override;
+    virtual void calculate_jacobian() override;
 };

--- a/tools/adept/AdeptLSTM.cpp
+++ b/tools/adept/AdeptLSTM.cpp
@@ -37,25 +37,15 @@ void lstm_objective_J(int l, int c, int b,
 }
 
 
-void AdeptLSTM::prepare(LSTMInput&& input) {
-  this->input = input;
-  int Jcols = 8 * this->input.l * this->input.b + 3 * this->input.b;
-  result = { 0, std::vector<double>(Jcols) };
+AdeptLSTM::AdeptLSTM(LSTMInput& input) : ITest(input) {
+  int Jcols = 8 * _input.l * _input.b + 3 * _input.b;
+  _output = { 0, std::vector<double>(Jcols) };
 }
 
-LSTMOutput AdeptLSTM::output()
-{
-  return result;
+void AdeptLSTM::calculate_objective() {
+  lstm_objective(_input.l, _input.c, _input.b, _input.main_params.data(), _input.extra_params.data(), _input.state.data(), _input.sequence.data(), &_output.objective);
 }
 
-void AdeptLSTM::calculate_objective(int times) {
-  for (int i = 0; i < times; ++i) {
-    lstm_objective(input.l, input.c, input.b, input.main_params.data(), input.extra_params.data(), input.state.data(), input.sequence.data(), &result.objective);
-  }
-}
-
-void AdeptLSTM::calculate_jacobian(int times) {
-  for (int i = 0; i < times; ++i) {
-    lstm_objective_J(input.l, input.c, input.b, input, &result.objective, result.gradient.data());
-  }
+void AdeptLSTM::calculate_jacobian() {
+  lstm_objective_J(_input.l, _input.c, _input.b, _input, &_output.objective, _output.gradient.data());
 }

--- a/tools/adept/AdeptLSTM.h
+++ b/tools/adept/AdeptLSTM.h
@@ -6,16 +6,9 @@
 #include <vector>
 
 class AdeptLSTM : public ITest<LSTMInput, LSTMOutput> {
-private:
-  LSTMInput input;
-  LSTMOutput result;
-
 public:
-  virtual void prepare(LSTMInput&& input) override;
+  AdeptLSTM(LSTMInput&);
 
-  virtual void calculate_objective(int times) override;
-  virtual void calculate_jacobian(int times) override;
-  virtual LSTMOutput output() override;
-
-  ~AdeptLSTM() {}
+  virtual void calculate_objective() override;
+  virtual void calculate_jacobian() override;
 };

--- a/tools/adol-c/AdolCBA.cpp
+++ b/tools/adol-c/AdolCBA.cpp
@@ -106,30 +106,19 @@ void compute_ba_J(int n, int m, int p,
   }
 }
 
-
-// This function must be called before any other function.
-void AdolCBA::prepare(BAInput&& input) {
-  _input = input;
+AdolCBA::AdolCBA(BAInput& input) : ITest(input) {
   _output = { std::vector<double>(2 * _input.p), std::vector<double>(_input.p), BASparseMat(_input.n, _input.m, _input.p) };
   int n_new_cols = BA_NCAMPARAMS + 3 + 1;
   _reproj_err_d = std::vector<double>(2 * n_new_cols);
 }
 
-BAOutput AdolCBA::output() {
-  return _output;
+void AdolCBA::calculate_objective() {
+  ba_objective(_input.n, _input.m, _input.p, _input.cams.data(), _input.X.data(), _input.w.data(),
+               _input.obs.data(), _input.feats.data(), _output.reproj_err.data(), _output.w_err.data());
 }
 
-void AdolCBA::calculate_objective(int times) {
-  for (int i = 0; i < times; ++i) {
-    ba_objective(_input.n, _input.m, _input.p, _input.cams.data(), _input.X.data(), _input.w.data(),
-                 _input.obs.data(), _input.feats.data(), _output.reproj_err.data(), _output.w_err.data());
-  }
-}
-
-void AdolCBA::calculate_jacobian(int times) {
-  for (int i = 0; i < times; ++i) {
-    compute_ba_J(_input.n, _input.m, _input.p, _input.cams.data(), _input.X.data(), _input.w.data(),
-                 _input.obs.data(), _input.feats.data(), _output.reproj_err.data(), _output.w_err.data(),
-                 &_output.J);
-  }
+void AdolCBA::calculate_jacobian() {
+  compute_ba_J(_input.n, _input.m, _input.p, _input.cams.data(), _input.X.data(), _input.w.data(),
+               _input.obs.data(), _input.feats.data(), _output.reproj_err.data(), _output.w_err.data(),
+               &_output.J);
 }

--- a/tools/adol-c/AdolCBA.h
+++ b/tools/adol-c/AdolCBA.h
@@ -7,16 +7,11 @@
 
 class AdolCBA : public ITest<BAInput, BAOutput> {
 private:
-  BAInput _input;
-  BAOutput _output;
   std::vector<double> _reproj_err_d;
 
 public:
-  virtual void prepare(BAInput&& input) override;
+  AdolCBA(BAInput&);
 
-  virtual void calculate_objective(int times) override;
-  virtual void calculate_jacobian(int times) override;
-  virtual BAOutput output() override;
-
-  ~AdolCBA() {}
+  virtual void calculate_objective() override;
+  virtual void calculate_jacobian() override;
 };

--- a/tools/adol-c/AdolCGMM.h
+++ b/tools/adol-c/AdolCGMM.h
@@ -6,15 +6,10 @@
 #include <vector>
 
 class AdolCGMM : public ITest<GMMInput, GMMOutput> {
-  GMMInput _input;
-  GMMOutput _output;
-
 public:
-  void prepare(GMMInput&& input) override;
+  AdolCGMM(GMMInput&);
 
-  void calculate_objective(int times) override;
-  void calculate_jacobian(int times) override;
-  GMMOutput output() override;
-
-  ~AdolCGMM() = default;
+  void prepare_jacobian() override;
+  void calculate_objective() override;
+  void calculate_jacobian() override;
 };

--- a/tools/adol-c/AdolCHT.cpp
+++ b/tools/adol-c/AdolCHT.cpp
@@ -223,8 +223,7 @@ void compute_hand_simple_J(vector<double>& theta,
   delete[] J_tmp;
 }
 
-void AdolCHand::prepare(HandInput&& input) {
-  _input = input;
+AdolCHand::AdolCHand(HandInput& input) : ITest(input) {
   _complicated = _input.us.size() != 0;
   int err_size = 3 * _input.data.correspondences.size();
   int ncols = (_complicated ? 2 : 0) + _input.theta.size();
@@ -236,28 +235,18 @@ void AdolCHand::prepare(HandInput&& input) {
   };
 }
 
-HandOutput AdolCHand::output() {
-  return _output;
-}
-
-void AdolCHand::calculate_objective(int times) {
+void AdolCHand::calculate_objective() {
   if (_complicated) {
-    for (int i = 0; i < times; ++i) {
-      hand_objective(_input.theta.data(), _input.us.data(), _input.data, _output.objective.data());
-    }
+    hand_objective(_input.theta.data(), _input.us.data(), &_input.data, _output.objective.data());
   } else {
-    for (int i = 0; i < times; ++i) {
-      hand_objective(_input.theta.data(), _input.data, _output.objective.data());
-    }
+    hand_objective(_input.theta.data(), &_input.data, _output.objective.data());
   }
 }
 
-void AdolCHand::calculate_jacobian(int times) {
-  for (int i = 0; i < times; ++i) {
-    if (_complicated) {
-      compute_hand_complicated_J(_input.theta, _input.us, _input.data, &_output.objective, &_output.jacobian);
-    } else {
-      compute_hand_simple_J(_input.theta, _input.data, &_output.objective, &_output.jacobian);
-    }
+void AdolCHand::calculate_jacobian() {
+  if (_complicated) {
+    compute_hand_complicated_J(_input.theta, _input.us, _input.data, &_output.objective, &_output.jacobian);
+  } else {
+    compute_hand_simple_J(_input.theta, _input.data, &_output.objective, &_output.jacobian);
   }
 }

--- a/tools/adol-c/AdolCHT.h
+++ b/tools/adol-c/AdolCHT.h
@@ -4,16 +4,11 @@
 #include "adbench/shared/HTData.h"
 
 class AdolCHand : public ITest<HandInput, HandOutput> {
-  HandInput _input;
-  HandOutput _output;
   bool _complicated = false;
 
 public:
-  void prepare(HandInput&& input) override;
+  AdolCHand(HandInput&);
 
-  void calculate_objective(int times) override;
-  void calculate_jacobian(int times) override;
-  HandOutput output() override;
-
-  ~AdolCHand() = default;
+  void calculate_objective() override;
+  void calculate_jacobian() override;
 };

--- a/tools/adol-c/AdolCHello.cpp
+++ b/tools/adol-c/AdolCHello.cpp
@@ -7,9 +7,7 @@
 
 static const int tapeTag = 1;
 
-void AdolCHello::prepare(HelloInput&& input) {
-  _input = input;
-
+AdolCHello::AdolCHello(HelloInput& input) : ITest(input) {
   // Construct tape.
   adouble ax;
   trace_on(tapeTag);
@@ -18,19 +16,11 @@ void AdolCHello::prepare(HelloInput&& input) {
   trace_off();
 }
 
-HelloOutput AdolCHello::output() {
-  return _output;
+void AdolCHello::calculate_objective() {
+  _output.objective = hello_objective(_input.x);
 }
 
-void AdolCHello::calculate_objective(int times) {
-  for (int i = 0; i < times; ++i) {
-    _output.objective = hello_objective(_input.x);
-  }
-}
-
-void AdolCHello::calculate_jacobian(int times) {
-  for (int i = 0; i < times; ++i) {
-    double in = _input.x;
-    gradient(tapeTag, 1, &in, &_output.gradient);
-  }
+void AdolCHello::calculate_jacobian() {
+  double in = _input.x;
+  gradient(tapeTag, 1, &in, &_output.gradient);
 }

--- a/tools/adol-c/AdolCHello.h
+++ b/tools/adol-c/AdolCHello.h
@@ -6,16 +6,9 @@
 #include <vector>
 
 class AdolCHello : public ITest<HelloInput, HelloOutput> {
-private:
-  HelloInput _input;
-  HelloOutput _output;
-
 public:
-  virtual void prepare(HelloInput&& input) override;
+  AdolCHello(HelloInput& input);
 
-  virtual void calculate_objective(int times) override;
-  virtual void calculate_jacobian(int times) override;
-  virtual HelloOutput output() override;
-
-  ~AdolCHello() {}
+  virtual void calculate_objective() override;
+  virtual void calculate_jacobian() override;
 };

--- a/tools/adol-c/AdolCLSTM.cpp
+++ b/tools/adol-c/AdolCLSTM.cpp
@@ -11,72 +11,64 @@
 
 static const int tapeTag = 1;
 
-void AdolCLSTM::prepare(LSTMInput&& input) {
-  this->input = input;
-  int Jcols = 8 * this->input.l * this->input.b + 3 * this->input.b;
-  result = { 0, std::vector<double>(Jcols) };
+AdolCLSTM::AdolCLSTM(LSTMInput& input) : ITest(input) {
+  int Jcols = 8 * _input.l * _input.b + 3 * _input.b;
+  _output = { 0, std::vector<double>(Jcols) };
+}
 
-  // Construct tape.
-
+void AdolCLSTM::prepare_jacobian() {
   trace_on(tapeTag);
 
-  std::vector<adouble> amain_params(input.main_params.size());
-  std::vector<adouble> aextra_params(input.extra_params.size());
-  std::vector<adouble> astate(input.state.size());
-  std::vector<adouble> asequence(input.sequence.size());
+  std::vector<adouble> amain_params(_input.main_params.size());
+  std::vector<adouble> aextra_params(_input.extra_params.size());
+  std::vector<adouble> astate(_input.state.size());
+  std::vector<adouble> asequence(_input.sequence.size());
   adouble aobjective;
 
-  for (size_t i = 0; i < input.main_params.size(); i++) {
-    amain_params[i] <<= input.main_params[i];
+  for (size_t i = 0; i < _input.main_params.size(); i++) {
+    amain_params[i] <<= _input.main_params[i];
   }
 
-  for (size_t i = 0; i < input.extra_params.size(); i++) {
-    aextra_params[i] <<= input.extra_params[i];
+  for (size_t i = 0; i < _input.extra_params.size(); i++) {
+    aextra_params[i] <<= _input.extra_params[i];
   }
 
-  for (size_t i = 0; i < input.state.size(); i++) {
-    astate[i] = input.state[i];
+  for (size_t i = 0; i < _input.state.size(); i++) {
+    astate[i] = _input.state[i];
   }
 
-  for (size_t i = 0; i < input.sequence.size(); i++) {
-    asequence[i] = input.sequence[i];
+  for (size_t i = 0; i < _input.sequence.size(); i++) {
+    asequence[i] = _input.sequence[i];
   }
 
-  lstm_objective(input.l, input.c, input.b,
+  lstm_objective(_input.l, _input.c, _input.b,
                  amain_params.data(), aextra_params.data(),
                  astate.data(), asequence.data(),
                  &aobjective);
 
-  aobjective >>= result.objective;
+  aobjective >>= _output.objective;
 
   trace_off();
+
 }
 
-LSTMOutput AdolCLSTM::output() {
-  return result;
+void AdolCLSTM::calculate_objective() {
+  lstm_objective(_input.l, _input.c, _input.b,
+                 _input.main_params.data(), _input.extra_params.data(),
+                 _input.state.data(), _input.sequence.data(),
+                 &_output.objective);
 }
 
-void AdolCLSTM::calculate_objective(int times) {
-  for (int i = 0; i < times; ++i) {
-    lstm_objective(input.l, input.c, input.b,
-                   input.main_params.data(), input.extra_params.data(),
-                   input.state.data(), input.sequence.data(),
-                   &result.objective);
-  }
-}
+void AdolCLSTM::calculate_jacobian() {
+  int Jcols = _input.main_params.size() + _input.extra_params.size();
 
-void AdolCLSTM::calculate_jacobian(int times) {
-  int Jcols = input.main_params.size() + input.extra_params.size();
-
-  for (int i = 0; i < times; ++i) {
-    double *in = new double[Jcols];
-    memcpy(in,
-           input.main_params.data(),
-           input.main_params.size() * sizeof(double));
-    memcpy(in + input.main_params.size(),
-           input.extra_params.data(),
-           input.extra_params.size() * sizeof(double));
-    gradient(tapeTag, Jcols, in, result.gradient.data());
-    delete[] in;
-  }
+  double *in = new double[Jcols];
+  memcpy(in,
+         _input.main_params.data(),
+         _input.main_params.size() * sizeof(double));
+  memcpy(in + _input.main_params.size(),
+         _input.extra_params.data(),
+         _input.extra_params.size() * sizeof(double));
+  gradient(tapeTag, Jcols, in, _output.gradient.data());
+  delete[] in;
 }

--- a/tools/adol-c/AdolCLSTM.h
+++ b/tools/adol-c/AdolCLSTM.h
@@ -4,16 +4,10 @@
 #include "adbench/shared/LSTMData.h"
 
 class AdolCLSTM : public ITest<LSTMInput, LSTMOutput> {
-private:
-  LSTMInput input;
-  LSTMOutput result;
-
 public:
-  virtual void prepare(LSTMInput&& input) override;
+  AdolCLSTM(LSTMInput& input);
 
-  virtual void calculate_objective(int times) override;
-  virtual void calculate_jacobian(int times) override;
-  virtual LSTMOutput output() override;
-
-  ~AdolCLSTM() {}
+  void prepare_jacobian() override;
+  void calculate_objective() override;
+  void calculate_jacobian() override;
 };

--- a/tools/adol-c/Dockerfile
+++ b/tools/adol-c/Dockerfile
@@ -13,10 +13,6 @@ RUN apt-get update && apt-get install -y \
 COPY python /home/gradbench/python
 ENV PYTHONPATH=/home/gradbench/python/gradbench
 
-COPY cpp /home/gradbench/cpp
-
-RUN make -C cpp
-
 # Install ADOL-C
 RUN wget https://github.com/coin-or/ADOL-C/archive/refs/tags/releases/2.7.2.tar.gz
 RUN tar xvf 2.7.2.tar.gz
@@ -25,6 +21,8 @@ RUN cd ADOL-C-releases-2.7.2 && ./configure --enable-sparse --prefix=/usr/local
 RUN cd ADOL-C-releases-2.7.2 && make install
 ENV LIBRARY_PATH=/usr/local/lib64
 ENV LD_LIBRARY_PATH=/usr/local/lib64
+
+COPY cpp /home/gradbench/cpp
 
 COPY tools/adol-c/ /home/gradbench/tools/adol-c
 

--- a/tools/cppad/CppADGMM.cpp
+++ b/tools/cppad/CppADGMM.cpp
@@ -4,8 +4,7 @@
 
 typedef CppAD::AD<double> ADdouble;
 
-void CppADGMM::prepare(GMMInput&& input) {
-  _input = input;
+CppADGMM::CppADGMM(GMMInput& input) : ITest(input) {
   int Jcols = (_input.k * (_input.d + 1) * (_input.d + 2)) / 2;
   _output = { 0,  std::vector<double>(Jcols) };
 
@@ -34,20 +33,12 @@ void CppADGMM::prepare(GMMInput&& input) {
   _tape->optimize();
 }
 
-GMMOutput CppADGMM::output() {
-  return _output;
+void CppADGMM::calculate_objective() {
+  gmm_objective(_input.d, _input.k, _input.n,
+                _input.alphas.data(), _input.means.data(), _input.icf.data(),
+                _input.x.data(), _input.wishart, &_output.objective);
 }
 
-void CppADGMM::calculate_objective(int times) {
-  for (int i = 0; i < times; ++i) {
-    gmm_objective(_input.d, _input.k, _input.n,
-                  _input.alphas.data(), _input.means.data(), _input.icf.data(),
-                  _input.x.data(), _input.wishart, &_output.objective);
-  }
-}
-
-void CppADGMM::calculate_jacobian(int times) {
-  for (int i = 0; i < times; ++i) {
-    _output.gradient = _tape->Jacobian(_input_flat);
-  }
+void CppADGMM::calculate_jacobian() {
+  _output.gradient = _tape->Jacobian(_input_flat);
 }

--- a/tools/cppad/CppADGMM.h
+++ b/tools/cppad/CppADGMM.h
@@ -5,18 +5,12 @@
 #include <cppad/cppad.hpp>
 
 class CppADGMM : public ITest<GMMInput, GMMOutput> {
-  GMMInput _input;
-  GMMOutput _output;
-
   std::vector<double> _input_flat;
   CppAD::ADFun<double> *_tape;
 
 public:
-  void prepare(GMMInput&& input) override;
+  CppADGMM(GMMInput&);
 
-  void calculate_objective(int times) override;
-  void calculate_jacobian(int times) override;
-  GMMOutput output() override;
-
-  ~CppADGMM() = default;
+  void calculate_objective() override;
+  void calculate_jacobian() override;
 };

--- a/tools/cppad/CppADHello.cpp
+++ b/tools/cppad/CppADHello.cpp
@@ -4,10 +4,7 @@
 
 typedef CppAD::AD<double> ADdouble;
 
-void CppADHello::prepare(HelloInput&& input)
-{
-  _input = input;
-
+CppADHello::CppADHello(HelloInput& input) : ITest(input) {
   std::vector<ADdouble> X(1);
   std::vector<ADdouble> Y(1);
   X[0] = _input.x;
@@ -17,26 +14,15 @@ void CppADHello::prepare(HelloInput&& input)
   _tape = new CppAD::ADFun<double>(X, Y);
 }
 
-HelloOutput CppADHello::output()
-{
-    return _output;
+void CppADHello::calculate_objective() {
+  _output.objective = hello_objective(_input.x);
 }
 
-void CppADHello::calculate_objective(int times)
-{
-    for (int i = 0; i < times; ++i) {
-      _output.objective = hello_objective(_input.x);
-    }
-}
-
-void CppADHello::calculate_jacobian(int times)
-{
+void CppADHello::calculate_jacobian() {
   std::vector<double> dx(1);
   dx[0] = 1;
   std::vector<double> dy(1);
 
-  for (int i = 0; i < times; ++i) {
-    dy = _tape->Forward(1, dx);
-    _output.gradient = dy[0];
-  }
+  dy = _tape->Forward(1, dx);
+  _output.gradient = dy[0];
 }

--- a/tools/cppad/CppADHello.h
+++ b/tools/cppad/CppADHello.h
@@ -6,16 +6,11 @@
 
 class CppADHello : public ITest<HelloInput, HelloOutput> {
 private:
-  HelloInput _input;
-  HelloOutput _output;
   CppAD::ADFun<double> *_tape;
 
 public:
-  virtual void prepare(HelloInput&& input) override;
+  CppADHello(HelloInput&);
 
-  virtual void calculate_objective(int times) override;
-  virtual void calculate_jacobian(int times) override;
-  virtual HelloOutput output() override;
-
-  ~CppADHello() = default;
+  virtual void calculate_objective() override;
+  virtual void calculate_jacobian() override;
 };

--- a/tools/cppad/CppADLSTM.cpp
+++ b/tools/cppad/CppADLSTM.cpp
@@ -4,8 +4,7 @@
 
 typedef CppAD::AD<double> ADdouble;
 
-void CppADLSTM::prepare(LSTMInput&& input) {
-  _input = input;
+CppADLSTM::CppADLSTM(LSTMInput& input) : ITest(input) {
   int Jcols = 8 * _input.l * _input.b + 3 * _input.b;
   _output = { 0,  std::vector<double>(Jcols) };
 
@@ -36,21 +35,13 @@ void CppADLSTM::prepare(LSTMInput&& input) {
   _tape->optimize();
 }
 
-LSTMOutput CppADLSTM::output() {
-  return _output;
+void CppADLSTM::calculate_objective() {
+  lstm_objective(_input.l, _input.c, _input.b,
+                 _input.main_params.data(), _input.extra_params.data(),
+                 _input.state.data(), _input.sequence.data(),
+                 &_output.objective);
 }
 
-void CppADLSTM::calculate_objective(int times) {
-  for (int i = 0; i < times; ++i) {
-    lstm_objective(_input.l, _input.c, _input.b,
-                   _input.main_params.data(), _input.extra_params.data(),
-                   _input.state.data(), _input.sequence.data(),
-                   &_output.objective);
-  }
-}
-
-void CppADLSTM::calculate_jacobian(int times) {
-  for (int i = 0; i < times; ++i) {
-    _output.gradient = _tape->Jacobian(_input_flat);
-  }
+void CppADLSTM::calculate_jacobian() {
+  _output.gradient = _tape->Jacobian(_input_flat);
 }

--- a/tools/cppad/CppADLSTM.h
+++ b/tools/cppad/CppADLSTM.h
@@ -5,18 +5,12 @@
 #include <cppad/cppad.hpp>
 
 class CppADLSTM : public ITest<LSTMInput, LSTMOutput> {
-  LSTMInput _input;
-  LSTMOutput _output;
-
   std::vector<double> _input_flat;
   CppAD::ADFun<double> *_tape;
 
 public:
-  void prepare(LSTMInput&& input) override;
+  CppADLSTM(LSTMInput&);
 
-  void calculate_objective(int times) override;
-  void calculate_jacobian(int times) override;
-  LSTMOutput output() override;
-
-  ~CppADLSTM() = default;
+  void calculate_objective() override;
+  void calculate_jacobian() override;
 };

--- a/tools/enzyme/EnzymeBA.cpp
+++ b/tools/enzyme/EnzymeBA.cpp
@@ -2,8 +2,7 @@
 #include "adbench/shared/ba.h"
 #include <algorithm>
 
-void EnzymeBA::prepare(BAInput&& input) {
-  _input = input;
+EnzymeBA::EnzymeBA(BAInput& input) : ITest(input) {
   _output = {
     std::vector<double>(2 * _input.p),
     std::vector<double>(_input.p),
@@ -13,17 +12,11 @@ void EnzymeBA::prepare(BAInput&& input) {
   _reproj_err_d = std::vector<double>(2 * n_new_cols);
 }
 
-BAOutput EnzymeBA::output() {
-  return _output;
-}
-
-void EnzymeBA::calculate_objective(int times) {
-  for (int i = 0; i < times; ++i) {
-    ba_objective(_input.n, _input.m, _input.p,
-                 _input.cams.data(), _input.X.data(), _input.w.data(),
-                 _input.obs.data(), _input.feats.data(),
-                 _output.reproj_err.data(), _output.w_err.data());
-  }
+void EnzymeBA::calculate_objective() {
+  ba_objective(_input.n, _input.m, _input.p,
+               _input.cams.data(), _input.X.data(), _input.w.data(),
+               _input.obs.data(), _input.feats.data(),
+               _output.reproj_err.data(), _output.w_err.data());
 }
 
 extern int enzyme_dup;
@@ -109,13 +102,11 @@ void compute_ba_J(int n, int m, int p,
   }
 }
 
-void EnzymeBA::calculate_jacobian(int times) {
-  for (int i = 0; i < times; ++i) {
-    _output.J.clear();
-    compute_ba_J(_input.n, _input.m, _input.p,
-                 _input.cams.data(), _input.X.data(), _input.w.data(),
-                 _input.obs.data(), _input.feats.data(),
-                 _output.reproj_err.data(), _output.w_err.data(),
-                 &_output.J);
-  }
+void EnzymeBA::calculate_jacobian() {
+  _output.J.clear();
+  compute_ba_J(_input.n, _input.m, _input.p,
+               _input.cams.data(), _input.X.data(), _input.w.data(),
+               _input.obs.data(), _input.feats.data(),
+               _output.reproj_err.data(), _output.w_err.data(),
+               &_output.J);
 }

--- a/tools/enzyme/EnzymeBA.h
+++ b/tools/enzyme/EnzymeBA.h
@@ -7,16 +7,11 @@
 
 class EnzymeBA : public ITest<BAInput, BAOutput> {
 private:
-  BAInput _input;
-  BAOutput _output;
   std::vector<double> _reproj_err_d;
 
 public:
-  virtual void prepare(BAInput&& input) override;
+  EnzymeBA(BAInput& input);
 
-  virtual void calculate_objective(int times) override;
-  virtual void calculate_jacobian(int times) override;
-  virtual BAOutput output() override;
-
-  ~EnzymeBA() {}
+  virtual void calculate_objective() override;
+  virtual void calculate_jacobian() override;
 };

--- a/tools/enzyme/EnzymeGMM.cpp
+++ b/tools/enzyme/EnzymeGMM.cpp
@@ -2,30 +2,23 @@
 #include "adbench/shared/gmm.h"
 #include <algorithm>
 
-void EnzymeGMM::prepare(GMMInput&& input) {
-  _input = input;
+EnzymeGMM::EnzymeGMM(GMMInput& input) : ITest(input) {
   int Jcols = (_input.k * (_input.d + 1) * (_input.d + 2)) / 2;
   _output = { 0,  std::vector<double>(Jcols) };
 }
 
-GMMOutput EnzymeGMM::output() {
-  return _output;
-}
+void EnzymeGMM::calculate_objective() {
+  gmm_objective(_input.d,
+                _input.k,
+                _input.n,
 
-void EnzymeGMM::calculate_objective(int times) {
-  for (int i = 0; i < times; ++i) {
-    gmm_objective(_input.d,
-                  _input.k,
-                  _input.n,
+                _input.alphas.data(),
+                _input.means.data(),
+                _input.icf.data(),
 
-                  _input.alphas.data(),
-                  _input.means.data(),
-                  _input.icf.data(),
-
-                  _input.x.data(),
-                  _input.wishart,
-                  &_output.objective);
-  }
+                _input.x.data(),
+                _input.wishart,
+                &_output.objective);
 }
 
 extern int enzyme_dup;
@@ -34,7 +27,7 @@ extern int enzyme_out;
 extern int enzyme_const;
 void __enzyme_autodiff(... ) noexcept;
 
-void EnzymeGMM::calculate_jacobian(int times) {
+void EnzymeGMM::calculate_jacobian() {
   _output.gradient.resize(_input.alphas.size()+
                           _input.means.size()+
                           _input.icf.size());
@@ -44,23 +37,21 @@ void EnzymeGMM::calculate_jacobian(int times) {
   double* d_means = d_alphas + _input.alphas.size();
   double* d_icf = d_means + _input.means.size();
 
-  for (int i = 0; i < times; ++i) {
-    std::fill(_output.gradient.begin(), _output.gradient.end(), 0);
-    double d_err = 1;
-    __enzyme_autodiff
-      (gmm_objective<double>,
-       enzyme_const, _input.d,
-       enzyme_const, _input.k,
-       enzyme_const, _input.n,
+  std::fill(_output.gradient.begin(), _output.gradient.end(), 0);
+  double d_err = 1;
+  __enzyme_autodiff
+    (gmm_objective<double>,
+     enzyme_const, _input.d,
+     enzyme_const, _input.k,
+     enzyme_const, _input.n,
 
-       enzyme_dup, _input.alphas.data(), d_alphas,
+     enzyme_dup, _input.alphas.data(), d_alphas,
 
-       enzyme_dup, _input.means.data(), d_means,
+     enzyme_dup, _input.means.data(), d_means,
 
-       enzyme_dup, _input.icf.data(), d_icf,
+     enzyme_dup, _input.icf.data(), d_icf,
 
-       enzyme_const, _input.x.data(),
-       enzyme_const, _input.wishart,
-       enzyme_dupnoneed, &_output.objective, &d_err);
-  }
+     enzyme_const, _input.x.data(),
+     enzyme_const, _input.wishart,
+     enzyme_dupnoneed, &_output.objective, &d_err);
 }

--- a/tools/enzyme/EnzymeGMM.h
+++ b/tools/enzyme/EnzymeGMM.h
@@ -6,16 +6,9 @@
 #include <vector>
 
 class EnzymeGMM : public ITest<GMMInput, GMMOutput> {
-  GMMInput _input;
-  GMMOutput _output;
-
  public:
-  // This function must be called before any other function.
-  void prepare(GMMInput&& input) override;
+  EnzymeGMM(GMMInput& input);
 
-  void calculate_objective(int times) override;
-  void calculate_jacobian(int times) override;
-  GMMOutput output() override;
-
-  ~EnzymeGMM() = default;
+  void calculate_objective() override;
+  void calculate_jacobian() override;
 };

--- a/tools/enzyme/EnzymeHT.cpp
+++ b/tools/enzyme/EnzymeHT.cpp
@@ -2,33 +2,20 @@
 
 #include "adbench/shared/ht_light_matrix.h"
 
-void EnzymeHand::prepare(HandInput&& input)
-{
-  _input = input;
+EnzymeHand::EnzymeHand(HandInput& input) : ITest(input) {
   _complicated = _input.us.size() != 0;
   int err_size = 3 * _input.data.correspondences.size();
   int ncols = (_complicated ? 2 : 0) + _input.theta.size();
   _output = { std::vector<double>(err_size), ncols, err_size, std::vector<double>(err_size * ncols) };
 }
 
-HandOutput EnzymeHand::output()
-{
-  return _output;
-}
-
-void EnzymeHand::calculate_objective(int times) {
+void EnzymeHand::calculate_objective() {
   if (_complicated) {
-    for (int i = 0; i < times; ++i) {
-      hand_objective(_input.theta.data(), _input.us.data(), &_input.data, _output.objective.data());
-    }
-  }
-  else {
-    for (int i = 0; i < times; ++i) {
-      hand_objective(_input.theta.data(), &_input.data, _output.objective.data());
-    }
+    hand_objective(_input.theta.data(), _input.us.data(), &_input.data, _output.objective.data());
+  } else {
+    hand_objective(_input.theta.data(), &_input.data, _output.objective.data());
   }
 }
-
 
 extern int enzyme_dup;
 extern int enzyme_dupnoneed;
@@ -119,19 +106,17 @@ void compute_hand_simple_J(const vector<double>& theta, const HandDataLightMatri
   }
 }
 
-void EnzymeHand::calculate_jacobian(int times) {
-  for (int i = 0; i < times; ++i) {
-    if (_input.us.size() == 0) {
-      compute_hand_simple_J(_input.theta,
-                            _input.data,
-                            &_output.objective,
-                            &_output.jacobian);
-    } else {
-      compute_hand_complicated_J(_input.theta,
-                                 _input.us,
-                                 _input.data,
-                                 &_output.objective,
-                                 &_output.jacobian);
-    }
+void EnzymeHand::calculate_jacobian() {
+  if (_input.us.size() == 0) {
+    compute_hand_simple_J(_input.theta,
+                          _input.data,
+                          &_output.objective,
+                          &_output.jacobian);
+  } else {
+    compute_hand_complicated_J(_input.theta,
+                               _input.us,
+                               _input.data,
+                               &_output.objective,
+                               &_output.jacobian);
   }
 }

--- a/tools/enzyme/EnzymeHT.h
+++ b/tools/enzyme/EnzymeHT.h
@@ -4,16 +4,11 @@
 #include "adbench/shared/HTData.h"
 
 class EnzymeHand : public ITest<HandInput, HandOutput> {
-  HandInput _input;
-  HandOutput _output;
   bool _complicated = false;
 
 public:
-  void prepare(HandInput&& input) override;
+  EnzymeHand(HandInput& input);
 
-  void calculate_objective(int times) override;
-  void calculate_jacobian(int times) override;
-  HandOutput output() override;
-
-  ~EnzymeHand() = default;
+  void calculate_objective() override;
+  void calculate_jacobian() override;
 };

--- a/tools/enzyme/EnzymeHello.cpp
+++ b/tools/enzyme/EnzymeHello.cpp
@@ -1,28 +1,14 @@
 #include "EnzymeHello.h"
 #include "adbench/shared/hello.h"
 
-void EnzymeHello::prepare(HelloInput&& input)
-{
-    _input = input;
-}
+EnzymeHello::EnzymeHello(HelloInput& input) : ITest(input) {}
 
-HelloOutput EnzymeHello::output()
-{
-    return _output;
-}
-
-void EnzymeHello::calculate_objective(int times)
-{
-    for (int i = 0; i < times; ++i) {
-      _output.objective = hello_objective(_input.x);
-    }
+void EnzymeHello::calculate_objective() {
+  _output.objective = hello_objective(_input.x);
 }
 
 extern double __enzyme_autodiff(void*, double);
 
-void EnzymeHello::calculate_jacobian(int times)
-{
-    for (int i = 0; i < times; ++i) {
-      _output.gradient = __enzyme_autodiff((void*)hello_objective<double>, _input.x);
-    }
+void EnzymeHello::calculate_jacobian() {
+  _output.gradient = __enzyme_autodiff((void*)hello_objective<double>, _input.x);
 }

--- a/tools/enzyme/EnzymeHello.h
+++ b/tools/enzyme/EnzymeHello.h
@@ -11,11 +11,8 @@ private:
     HelloOutput _output;
 
 public:
-    virtual void prepare(HelloInput&& input) override;
+    EnzymeHello(HelloInput& input);
 
-    virtual void calculate_objective(int times) override;
-    virtual void calculate_jacobian(int times) override;
-    virtual HelloOutput output() override;
-
-    ~EnzymeHello() {}
+    virtual void calculate_objective() override;
+    virtual void calculate_jacobian() override;
 };

--- a/tools/enzyme/EnzymeHello.h
+++ b/tools/enzyme/EnzymeHello.h
@@ -6,13 +6,9 @@
 #include <vector>
 
 class EnzymeHello : public ITest<HelloInput, HelloOutput> {
-private:
-    HelloInput _input;
-    HelloOutput _output;
-
 public:
-    EnzymeHello(HelloInput& input);
+  EnzymeHello(HelloInput& input);
 
-    virtual void calculate_objective() override;
-    virtual void calculate_jacobian() override;
+  virtual void calculate_objective() override;
+  virtual void calculate_jacobian() override;
 };

--- a/tools/enzyme/EnzymeLSTM.h
+++ b/tools/enzyme/EnzymeLSTM.h
@@ -6,16 +6,9 @@
 #include <vector>
 
 class EnzymeLSTM : public ITest<LSTMInput, LSTMOutput> {
-private:
-  LSTMInput input;
-  LSTMOutput result;
-
 public:
-  virtual void prepare(LSTMInput&& input) override;
+  EnzymeLSTM(LSTMInput& input);
 
-  virtual void calculate_objective(int times) override;
-  virtual void calculate_jacobian(int times) override;
-  virtual LSTMOutput output() override;
-
-  ~EnzymeLSTM() {}
+  virtual void calculate_objective() override;
+  virtual void calculate_jacobian() override;
 };

--- a/tools/finite/FiniteBA.cpp
+++ b/tools/finite/FiniteBA.cpp
@@ -3,74 +3,56 @@
 
 // https://github.com/microsoft/ADBench/blob/38cb7931303a830c3700ca36ba9520868327ac87/src/cpp/modules/finite/FiniteBA.cpp
 
-// FiniteBA.cpp : Defines the exported functions for the DLL.
 #include "FiniteBA.h"
 #include "adbench/shared/ba.h"
 #include "finite.h"
 
-// This function must be called before any other function.
-void FiniteBA::prepare(BAInput&& input)
-{
-    this->input = input;
-    result = { std::vector<double>(2 * this->input.p), std::vector<double>(this->input.p), BASparseMat(this->input.n, this->input.m, this->input.p) };
-    int n_new_cols = BA_NCAMPARAMS + 3 + 1;
-    reproj_err_d = std::vector<double>(2 * n_new_cols);
-    engine.set_max_output_size(2);
+FiniteBA::FiniteBA(BAInput& input) : ITest(input) {
+  _output = {
+    std::vector<double>(2 * _input.p),
+    std::vector<double>(_input.p),
+    BASparseMat(_input.n, _input.m, _input.p)
+  };
+  int n_new_cols = BA_NCAMPARAMS + 3 + 1;
+  reproj_err_d = std::vector<double>(2 * n_new_cols);
+  engine.set_max_output_size(2);
 }
 
-BAOutput FiniteBA::output()
-{
-    return result;
+void FiniteBA::calculate_objective() {
+  ba_objective(_input.n, _input.m, _input.p, _input.cams.data(), _input.X.data(), _input.w.data(),
+               _input.obs.data(), _input.feats.data(), _output.reproj_err.data(), _output.w_err.data());
 }
 
-void FiniteBA::calculate_objective(int times)
-{
-    for (int i = 0; i < times; ++i) {
-        ba_objective(input.n, input.m, input.p, input.cams.data(), input.X.data(), input.w.data(),
-            input.obs.data(), input.feats.data(), result.reproj_err.data(), result.w_err.data());
-    }
-}
+void FiniteBA::calculate_jacobian() {
+  _output.J.clear();
+  for (int j = 0; j < _input.p; ++j) {
+    std::fill(reproj_err_d.begin(), reproj_err_d.end(), (double)0);
 
-void FiniteBA::calculate_jacobian(int times)
-{
-    for (int i = 0; i < times; ++i) {
-        result.J.clear();
-        for (int j = 0; j < input.p; ++j)
-        {
-            std::fill(reproj_err_d.begin(), reproj_err_d.end(), (double)0);
+    int camIdx = _input.obs[2 * j + 0];
+    int ptIdx = _input.obs[2 * j + 1];
 
-            int camIdx = input.obs[2 * j + 0];
-            int ptIdx = input.obs[2 * j + 1];
+    engine.finite_differences([&](double* cam_in, double* reproj_err) {
+      computeReprojError(cam_in, &_input.X[ptIdx * 3], &_input.w[j], &_input.feats[2 * j], reproj_err);
+    }, &_input.cams[camIdx * BA_NCAMPARAMS], BA_NCAMPARAMS, 2, reproj_err_d.data());
 
-            engine.finite_differences([&](double* cam_in, double* reproj_err) {
-                computeReprojError(cam_in, &input.X[ptIdx * 3], &input.w[j], &input.feats[2 * j], reproj_err);
-                }, &input.cams[camIdx * BA_NCAMPARAMS], BA_NCAMPARAMS, 2, reproj_err_d.data());
+    engine.finite_differences([&](double* X_in, double* reproj_err) {
+      computeReprojError(&_input.cams[camIdx * BA_NCAMPARAMS], X_in, &_input.w[j], &_input.feats[2 * j], reproj_err);
+    }, &_input.X[ptIdx * 3], 3, 2, &reproj_err_d.data()[2 * BA_NCAMPARAMS]);
 
-            engine.finite_differences([&](double* X_in, double* reproj_err) {
-                computeReprojError(&input.cams[camIdx * BA_NCAMPARAMS], X_in, &input.w[j], &input.feats[2 * j], reproj_err);
-                }, &input.X[ptIdx * 3], 3, 2, &reproj_err_d.data()[2 * BA_NCAMPARAMS]);
+    engine.finite_differences([&](double* w_in, double* reproj_err) {
+      computeReprojError(&_input.cams[camIdx * BA_NCAMPARAMS], &_input.X[ptIdx * 3], w_in, &_input.feats[2 * j], reproj_err);
+    }, &_input.w[j], 1, 2, &reproj_err_d.data()[2 * (BA_NCAMPARAMS + 3)]);
 
-            engine.finite_differences([&](double* w_in, double* reproj_err) {
-                computeReprojError(&input.cams[camIdx * BA_NCAMPARAMS], &input.X[ptIdx * 3], w_in, &input.feats[2 * j], reproj_err);
-                }, &input.w[j], 1, 2, &reproj_err_d.data()[2 * (BA_NCAMPARAMS + 3)]);
+    _output.J.insert_reproj_err_block(j, camIdx, ptIdx, reproj_err_d.data());
+  }
 
-            result.J.insert_reproj_err_block(j, camIdx, ptIdx, reproj_err_d.data());
-        }
+  double w_d;
 
-        double w_d;
+  for (int j = 0; j < _input.p; ++j) {
+    engine.finite_differences([&](double* w_in, double* w_er) {
+      computeZachWeightError(w_in, w_er);
+    }, &_input.w[j], 1, 1, &w_d);
 
-        for (int j = 0; j < input.p; ++j)
-        {
-            engine.finite_differences([&](double* w_in, double* w_er) {
-                computeZachWeightError(w_in, w_er);
-                }, &input.w[j], 1, 1, &w_d);
-
-            result.J.insert_w_err_block(j, w_d);
-        }
-    }
-}
-
-extern "C" DLL_PUBLIC ITest<BAInput, BAOutput>* get_ba_test()
-{
-    return new FiniteBA();
+    _output.J.insert_w_err_block(j, w_d);
+  }
 }

--- a/tools/finite/FiniteBA.h
+++ b/tools/finite/FiniteBA.h
@@ -13,18 +13,12 @@
 
 class FiniteBA : public ITest<BAInput, BAOutput> {
 private:
-    BAInput input;
-    BAOutput result;
-    std::vector<double> reproj_err_d;
-    FiniteDifferencesEngine<double> engine;
+  std::vector<double> reproj_err_d;
+  FiniteDifferencesEngine<double> engine;
 
 public:
-    // This function must be called before any other function.
-    virtual void prepare(BAInput&& input) override;
+  FiniteBA(BAInput&);
 
-    virtual void calculate_objective(int times) override;
-    virtual void calculate_jacobian(int times) override;
-    virtual BAOutput output() override;
-
-    ~FiniteBA() = default;
+  virtual void calculate_objective() override;
+  virtual void calculate_jacobian() override;
 };

--- a/tools/finite/FiniteGMM.cpp
+++ b/tools/finite/FiniteGMM.cpp
@@ -3,51 +3,31 @@
 
 // https://github.com/microsoft/ADBench/blob/38cb7931303a830c3700ca36ba9520868327ac87/src/cpp/modules/finite/FiniteGMM.cpp
 
-// FiniteGMM.cpp : Defines the exported functions for the DLL.
 #include "FiniteGMM.h"
 #include "adbench/shared/gmm.h"
 #include "finite.h"
 
-// This function must be called before any other function.
-void FiniteGMM::prepare(GMMInput&& input)
-{
-    this->input = input;
-    int Jcols = (this->input.k * (this->input.d + 1) * (this->input.d + 2)) / 2;
-    result = { 0,  std::vector<double>(Jcols) };
-    engine.set_max_output_size(1);
+FiniteGMM::FiniteGMM(GMMInput& input) : ITest(input) {
+  int Jcols = (_input.k * (_input.d + 1) * (_input.d + 2)) / 2;
+  _output = { 0,  std::vector<double>(Jcols) };
+  engine.set_max_output_size(1);
 }
 
-GMMOutput FiniteGMM::output()
-{
-    return result;
+void FiniteGMM::calculate_objective() {
+  gmm_objective(_input.d, _input.k, _input.n, _input.alphas.data(), _input.means.data(),
+                _input.icf.data(), _input.x.data(), _input.wishart, &_output.objective);
 }
 
-void FiniteGMM::calculate_objective(int times)
-{
-    for (int i = 0; i < times; ++i) {
-        gmm_objective(input.d, input.k, input.n, input.alphas.data(), input.means.data(),
-            input.icf.data(), input.x.data(), input.wishart, &result.objective);
-    }
-}
+void FiniteGMM::calculate_jacobian() {
+  engine.finite_differences([&](double* alphas_in, double* err) {
+    gmm_objective(_input.d, _input.k, _input.n, alphas_in, _input.means.data(), _input.icf.data(), _input.x.data(), _input.wishart, err);
+  }, _input.alphas.data(), _input.alphas.size(), 1, _output.gradient.data());
 
-void FiniteGMM::calculate_jacobian(int times)
-{
-    for (int i = 0; i < times; ++i) {
-        engine.finite_differences([&](double* alphas_in, double* err) {
-            gmm_objective(input.d, input.k, input.n, alphas_in, input.means.data(), input.icf.data(), input.x.data(), input.wishart, err);
-            }, input.alphas.data(), input.alphas.size(), 1, result.gradient.data());
+  engine.finite_differences([&](double* means_in, double* err) {
+    gmm_objective(_input.d, _input.k, _input.n, _input.alphas.data(), means_in, _input.icf.data(), _input.x.data(), _input.wishart, err);
+  }, _input.means.data(), _input.means.size(), 1, &_output.gradient.data()[_input.k]);
 
-        engine.finite_differences([&](double* means_in, double* err) {
-            gmm_objective(input.d, input.k, input.n, input.alphas.data(), means_in, input.icf.data(), input.x.data(), input.wishart, err);
-            }, input.means.data(), input.means.size(), 1, &result.gradient.data()[input.k]);
-
-        engine.finite_differences([&](double* icf_in, double* err) {
-            gmm_objective(input.d, input.k, input.n, input.alphas.data(), input.means.data(), icf_in, input.x.data(), input.wishart, err);
-            }, input.icf.data(), input.icf.size(), 1, &result.gradient.data()[input.k + input.d * input.k]);
-    }
-}
-
-extern "C" DLL_PUBLIC ITest<GMMInput, GMMOutput>* get_gmm_test()
-{
-    return new FiniteGMM();
+  engine.finite_differences([&](double* icf_in, double* err) {
+    gmm_objective(_input.d, _input.k, _input.n, _input.alphas.data(), _input.means.data(), icf_in, _input.x.data(), _input.wishart, err);
+  }, _input.icf.data(), _input.icf.size(), 1, &_output.gradient.data()[_input.k + _input.d * _input.k]);
 }

--- a/tools/finite/FiniteGMM.h
+++ b/tools/finite/FiniteGMM.h
@@ -10,17 +10,11 @@
 #include "finite.h"
 
 class FiniteGMM : public ITest<GMMInput, GMMOutput> {
-    GMMInput input;
-    GMMOutput result;
-    FiniteDifferencesEngine<double> engine;
+  FiniteDifferencesEngine<double> engine;
 
 public:
-    // This function must be called before any other function.
-    void prepare(GMMInput&& input) override;
+  FiniteGMM(GMMInput&);
 
-    void calculate_objective(int times) override;
-    void calculate_jacobian(int times) override;
-    GMMOutput output() override;
-
-    ~FiniteGMM() = default;
+  void calculate_objective() override;
+  void calculate_jacobian() override;
 };

--- a/tools/finite/FiniteHT.cpp
+++ b/tools/finite/FiniteHT.cpp
@@ -10,73 +10,45 @@
 #include "adbench/shared/ht_light_matrix.h"
 #include "finite.h"
 
-// This function must be called before any other function.
-void FiniteHand::prepare(HandInput&& input)
-{
-    this->input = input;
-    complicated = this->input.us.size() != 0;
-    int err_size = 3 * this->input.data.correspondences.size();
-    int ncols = (complicated ? 2 : 0) + this->input.theta.size();
-    result = { std::vector<double>(err_size), ncols, err_size, std::vector<double>(err_size * ncols) };
-    engine.set_max_output_size(err_size);
-    if (complicated)
-        jacobian_by_us = std::vector<double>(2 * err_size);
+FiniteHand::FiniteHand(HandInput& input) : ITest(input) {
+  complicated = _input.us.size() != 0;
+  int err_size = 3 * _input.data.correspondences.size();
+  int ncols = (complicated ? 2 : 0) + _input.theta.size();
+  _output = { std::vector<double>(err_size), ncols, err_size, std::vector<double>(err_size * ncols) };
+  engine.set_max_output_size(err_size);
+  if (complicated)
+    jacobian_by_us = std::vector<double>(2 * err_size);
 }
 
-HandOutput FiniteHand::output()
-{
-    return result;
+void FiniteHand::calculate_objective() {
+  if (complicated) {
+    hand_objective(_input.theta.data(), _input.us.data(), &_input.data, _output.objective.data());
+  }
+  else {
+    hand_objective(_input.theta.data(), &_input.data, _output.objective.data());
+  }
 }
 
-void FiniteHand::calculate_objective(int times)
-{
-    if (complicated)
-    {
-        for (int i = 0; i < times; ++i) {
-            hand_objective(input.theta.data(), input.us.data(), &input.data, result.objective.data());
-        }
-    }
-    else
-    {
-        for (int i = 0; i < times; ++i) {
-            hand_objective(input.theta.data(), &input.data, result.objective.data());
-        }
-    }
-}
+void FiniteHand::calculate_jacobian() {
+  if (complicated) {
+    engine.finite_differences([&](double* theta_in, double* err) {
+      hand_objective(theta_in, _input.us.data(), &_input.data, err);
+    }, _input.theta.data(), _input.theta.size(), _output.objective.size(), &_output.jacobian.data()[6 * _input.data.correspondences.size()]);
 
-void FiniteHand::calculate_jacobian(int times)
-{
-    if (complicated)
-    {
-        for (int i = 0; i < times; ++i) {
-            engine.finite_differences([&](double* theta_in, double* err) {
-                hand_objective(theta_in, input.us.data(), &input.data, err);
-                }, input.theta.data(), input.theta.size(), result.objective.size(), &result.jacobian.data()[6 * input.data.correspondences.size()]);
+    for (unsigned int j = 0; j < _input.us.size() / 2; ++j) {
+      engine.finite_differences([&](double* us_in, double* err) {
+        // us_in points into the middle of __input.us.data()
+        hand_objective(_input.theta.data(), _input.us.data(), &_input.data, err);
+      }, &_input.us.data()[j * 2], 2, _output.objective.size(), jacobian_by_us.data());
 
-            for (unsigned int j = 0; j < input.us.size() / 2; ++j) {
-                engine.finite_differences([&](double* us_in, double* err) {
-                    // us_in points into the middle of _input.us.data()
-                    hand_objective(input.theta.data(), input.us.data(), &input.data, err);
-                    }, &input.us.data()[j * 2], 2, result.objective.size(), jacobian_by_us.data());
-
-                for (int k = 0; k < 3; ++k) {
-                    result.jacobian[j * 3 + k] = jacobian_by_us[j * 3 + k];
-                    result.jacobian[j * 3 + k + result.objective.size()] = jacobian_by_us[j * 3 + k + result.objective.size()];
-                }
-            }
-        }
+      for (int k = 0; k < 3; ++k) {
+        _output.jacobian[j * 3 + k] = jacobian_by_us[j * 3 + k];
+        _output.jacobian[j * 3 + k + _output.objective.size()] = jacobian_by_us[j * 3 + k + _output.objective.size()];
+      }
     }
-    else
-    {
-        for (int i = 0; i < times; ++i) {
-            engine.finite_differences([&](double* theta_in, double* err) {
-                hand_objective(theta_in, &input.data, err);
-                }, input.theta.data(), input.theta.size(), result.objective.size(), result.jacobian.data());
-        }
-    }
-}
-
-extern "C" DLL_PUBLIC ITest<HandInput, HandOutput>* get_hand_test()
-{
-    return new FiniteHand();
+  } else {
+    engine.finite_differences([&](double* theta_in, double* err) {
+      hand_objective(theta_in, &_input.data, err);
+    }, _input.theta.data(), _input.theta.size(), _output.objective.size(), _output.jacobian.data());
+  }
 }

--- a/tools/finite/FiniteHT.h
+++ b/tools/finite/FiniteHT.h
@@ -10,19 +10,13 @@
 #include "finite.h"
 
 class FiniteHand : public ITest<HandInput, HandOutput> {
-    HandInput input;
-    HandOutput result;
     bool complicated = false;
     std::vector<double> jacobian_by_us;
     FiniteDifferencesEngine<double> engine;
 
 public:
-    // This function must be called before any other function.
-    void prepare(HandInput&& input) override;
+    FiniteHand(HandInput& input);
 
-    void calculate_objective(int times) override;
-    void calculate_jacobian(int times) override;
-    HandOutput output() override;
-
-    ~FiniteHand() = default;
+    void calculate_objective() override;
+    void calculate_jacobian() override;
 };

--- a/tools/finite/FiniteHello.cpp
+++ b/tools/finite/FiniteHello.cpp
@@ -2,29 +2,16 @@
 #include "adbench/shared/hello.h"
 #include "finite.h"
 
-void FiniteHello::prepare(HelloInput&& input)
-{
-    _input = input;
-    engine.set_max_output_size(1);
+FiniteHello::FiniteHello(HelloInput& input) : ITest(input) {
+  engine.set_max_output_size(1);
 }
 
-HelloOutput FiniteHello::output()
-{
-    return _output;
+void FiniteHello::calculate_objective() {
+  _output.objective = hello_objective(_input.x);
 }
 
-void FiniteHello::calculate_objective(int times)
-{
-    for (int i = 0; i < times; ++i) {
-      _output.objective = hello_objective(_input.x);
-    }
-}
-
-void FiniteHello::calculate_jacobian(int times)
-{
-  for (int i = 0; i < times; ++i) {
-    engine.finite_differences([&](double* x, double *out) {
-      *out = hello_objective(*x);
-    }, &_input.x, 1, 1, &_output.gradient);
-  }
+void FiniteHello::calculate_jacobian() {
+  engine.finite_differences([&](double* x, double *out) {
+    *out = hello_objective(*x);
+  }, &_input.x, 1, 1, &_output.gradient);
 }

--- a/tools/finite/FiniteHello.h
+++ b/tools/finite/FiniteHello.h
@@ -8,17 +8,11 @@
 
 class FiniteHello : public ITest<HelloInput, HelloOutput> {
 private:
-    HelloInput _input;
-    HelloOutput _output;
     FiniteDifferencesEngine<double> engine;
 
 public:
-    // This function must be called before any other function.
-    virtual void prepare(HelloInput&& input) override;
+    FiniteHello(HelloInput& input);
 
-    virtual void calculate_objective(int times) override;
-    virtual void calculate_jacobian(int times) override;
-    virtual HelloOutput output() override;
-
-    ~FiniteHello() = default;
+    virtual void calculate_objective() override;
+    virtual void calculate_jacobian() override;
 };

--- a/tools/finite/FiniteLSTM.cpp
+++ b/tools/finite/FiniteLSTM.cpp
@@ -7,38 +7,24 @@
 #include "adbench/shared/lstm.h"
 #include "finite.h"
 
-// This function must be called before any other function.
-void FiniteLSTM::prepare(LSTMInput&& input)
-{
-    this->input = input;
-    int Jcols = 8 * this->input.l * this->input.b + 3 * this->input.b;
-    result = { 0, std::vector<double>(Jcols) };
-    engine.set_max_output_size(1);
+FiniteLSTM::FiniteLSTM(LSTMInput& input) : ITest(input) {
+  int Jcols = 8 * _input.l * _input.b + 3 * _input.b;
+  _output = { 0, std::vector<double>(Jcols) };
+  engine.set_max_output_size(1);
 }
 
-LSTMOutput FiniteLSTM::output()
-{
-    return result;
+void FiniteLSTM::calculate_objective() {
+  lstm_objective(_input.l, _input.c, _input.b, _input.main_params.data(), _input.extra_params.data(), _input.state.data(), _input.sequence.data(), &_output.objective);
 }
 
-void FiniteLSTM::calculate_objective(int times)
-{
-    for (int i = 0; i < times; ++i) {
-        lstm_objective(input.l, input.c, input.b, input.main_params.data(), input.extra_params.data(), input.state.data(), input.sequence.data(), &result.objective);
-    }
-}
+void FiniteLSTM::calculate_jacobian() {
+  engine.finite_differences([&](double* main_params_in, double* loss) {
+    lstm_objective(_input.l, _input.c, _input.b, main_params_in,
+                   _input.extra_params.data(), _input.state.data(), _input.sequence.data(), loss);
+  }, _input.main_params.data(), _input.main_params.size(), 1, _output.gradient.data());
 
-void FiniteLSTM::calculate_jacobian(int times)
-{
-    for (int i = 0; i < times; ++i) {
-        engine.finite_differences([&](double* main_params_in, double* loss) {
-            lstm_objective(input.l, input.c, input.b, main_params_in,
-                           input.extra_params.data(), input.state.data(), input.sequence.data(), loss);
-            }, input.main_params.data(), input.main_params.size(), 1, result.gradient.data());
-
-        engine.finite_differences([&](double* extra_params_in, double* loss) {
-            lstm_objective(input.l, input.c, input.b, input.main_params.data(),
-                           extra_params_in, input.state.data(), input.sequence.data(), loss);
-            }, input.extra_params.data(), input.extra_params.size(), 1, &result.gradient.data()[2 * input.l * 4 * input.b]);
-    }
+  engine.finite_differences([&](double* extra_params_in, double* loss) {
+    lstm_objective(_input.l, _input.c, _input.b, _input.main_params.data(),
+                   extra_params_in, _input.state.data(), _input.sequence.data(), loss);
+  }, _input.extra_params.data(), _input.extra_params.size(), 1, &_output.gradient.data()[2 * _input.l * 4 * _input.b]);
 }

--- a/tools/finite/FiniteLSTM.h
+++ b/tools/finite/FiniteLSTM.h
@@ -13,17 +13,11 @@
 
 class FiniteLSTM : public ITest<LSTMInput, LSTMOutput> {
 private:
-    LSTMInput input;
-    LSTMOutput result;
     FiniteDifferencesEngine<double> engine;
 
 public:
-    // This function must be called before any other function.
-    virtual void prepare(LSTMInput&& input) override;
+    FiniteLSTM(LSTMInput&);
 
-    virtual void calculate_objective(int times) override;
-    virtual void calculate_jacobian(int times) override;
-    virtual LSTMOutput output() override;
-
-    ~FiniteLSTM() {}
+    virtual void calculate_objective() override;
+    virtual void calculate_jacobian() override;
 };

--- a/tools/manual/ManualBA.cpp
+++ b/tools/manual/ManualBA.cpp
@@ -8,60 +8,41 @@
 #include "adbench/shared/ba.h"
 #include "ba_d.h"
 
-// This function must be called before any other function.
-void ManualBA::prepare(BAInput&& input)
-{
-    _input = input;
-    _output = { std::vector<double>(2 * _input.p), std::vector<double>(_input.p), BASparseMat(_input.n, _input.m, _input.p) };
-    int n_new_cols = BA_NCAMPARAMS + 3 + 1;
-    _reproj_err_d = std::vector<double>(2 * n_new_cols);
+ManualBA::ManualBA(BAInput& input) : ITest(input) {
+  _output = { std::vector<double>(2 * _input.p), std::vector<double>(_input.p), BASparseMat(_input.n, _input.m, _input.p) };
+  int n_new_cols = BA_NCAMPARAMS + 3 + 1;
+  _reproj_err_d = std::vector<double>(2 * n_new_cols);
 }
 
-BAOutput ManualBA::output()
-{
-    return _output;
+void ManualBA::calculate_objective() {
+  ba_objective(_input.n, _input.m, _input.p, _input.cams.data(), _input.X.data(), _input.w.data(),
+               _input.obs.data(), _input.feats.data(), _output.reproj_err.data(), _output.w_err.data());
 }
 
-void ManualBA::calculate_objective(int times)
-{
-    for (int i = 0; i < times; ++i) {
-        ba_objective(_input.n, _input.m, _input.p, _input.cams.data(), _input.X.data(), _input.w.data(),
-            _input.obs.data(), _input.feats.data(), _output.reproj_err.data(), _output.w_err.data());
+void ManualBA::calculate_jacobian() {
+  _output.J.clear();
+  for (int i = 0; i < _input.p; i++)
+    {
+      std::fill(_reproj_err_d.begin(), _reproj_err_d.end(), (double)0);
+
+      int camIdx = _input.obs[2 * i + 0];
+      int ptIdx = _input.obs[2 * i + 1];
+      compute_reproj_error_d(
+                             &_input.cams[BA_NCAMPARAMS * camIdx],
+                             &_input.X[ptIdx * 3],
+                             _input.w[i],
+                             _input.feats[2 * i + 0], _input.feats[2 * i + 1],
+                             &_output.reproj_err[2 * i],
+                             _reproj_err_d.data());
+
+      _output.J.insert_reproj_err_block(i, camIdx, ptIdx, _reproj_err_d.data());
     }
-}
 
-void ManualBA::calculate_jacobian(int times)
-{
-    for (int i = 0; i < times; ++i) {
-        _output.J.clear();
-        for (int i = 0; i < _input.p; i++)
-        {
-            std::fill(_reproj_err_d.begin(), _reproj_err_d.end(), (double)0);
+  for (int i = 0; i < _input.p; i++)
+    {
+      double w_d = 0;
+      compute_zach_weight_error_d(_input.w[i], &_output.w_err[i], &w_d);
 
-            int camIdx = _input.obs[2 * i + 0];
-            int ptIdx = _input.obs[2 * i + 1];
-            compute_reproj_error_d(
-                &_input.cams[BA_NCAMPARAMS * camIdx],
-                &_input.X[ptIdx * 3],
-                _input.w[i],
-                _input.feats[2 * i + 0], _input.feats[2 * i + 1],
-                &_output.reproj_err[2 * i],
-                _reproj_err_d.data());
-
-            _output.J.insert_reproj_err_block(i, camIdx, ptIdx, _reproj_err_d.data());
-        }
-
-        for (int i = 0; i < _input.p; i++)
-        {
-            double w_d = 0;
-            compute_zach_weight_error_d(_input.w[i], &_output.w_err[i], &w_d);
-
-            _output.J.insert_w_err_block(i, w_d);
-        }
+      _output.J.insert_w_err_block(i, w_d);
     }
-}
-
-extern "C" DLL_PUBLIC ITest<BAInput, BAOutput>* get_ba_test()
-{
-    return new ManualBA();
 }

--- a/tools/manual/ManualBA.h
+++ b/tools/manual/ManualBA.h
@@ -13,17 +13,11 @@
 
 class ManualBA : public ITest<BAInput, BAOutput> {
 private:
-    BAInput _input;
-    BAOutput _output;
     std::vector<double> _reproj_err_d;
 
 public:
-    // This function must be called before any other function.
-    virtual void prepare(BAInput&& input) override;
+    ManualBA(BAInput&);
 
-    virtual void calculate_objective(int times) override;
-    virtual void calculate_jacobian(int times) override;
-    virtual BAOutput output() override;
-
-    ~ManualBA() {}
+    virtual void calculate_objective() override;
+    virtual void calculate_jacobian() override;
 };

--- a/tools/manual/ManualGMM.cpp
+++ b/tools/manual/ManualGMM.cpp
@@ -3,43 +3,23 @@
 
 // https://github.com/microsoft/ADBench/blob/38cb7931303a830c3700ca36ba9520868327ac87/src/cpp/modules/manual/ManualGMM.cpp
 
-// ManualGMM.cpp : Defines the exported functions for the DLL.
 #include "ManualGMM.h"
 #include "adbench/shared/gmm.h"
 #include "gmm_d.h"
 
 #include <iostream>
 
-// This function must be called before any other function.
-void ManualGMM::prepare(GMMInput&& input)
-{
-    _input = input;
-    int Jcols = (_input.k * (_input.d + 1) * (_input.d + 2)) / 2;
-    _output = { 0,  std::vector<double>(Jcols) };
+ManualGMM::ManualGMM(GMMInput& input) : ITest(input) {
+  int Jcols = (_input.k * (_input.d + 1) * (_input.d + 2)) / 2;
+  _output = { 0,  std::vector<double>(Jcols) };
 }
 
-GMMOutput ManualGMM::output()
-{
-    return _output;
+void ManualGMM::calculate_objective() {
+  gmm_objective(_input.d, _input.k, _input.n, _input.alphas.data(), _input.means.data(),
+                _input.icf.data(), _input.x.data(), _input.wishart, &_output.objective);
 }
 
-void ManualGMM::calculate_objective(int times)
-{
-    for (int i = 0; i < times; ++i) {
-        gmm_objective(_input.d, _input.k, _input.n, _input.alphas.data(), _input.means.data(),
-            _input.icf.data(), _input.x.data(), _input.wishart, &_output.objective);
-    }
-}
-
-void ManualGMM::calculate_jacobian(int times)
-{
-    for (int i = 0; i < times; ++i) {
-        gmm_objective_d(_input.d, _input.k, _input.n, _input.alphas.data(), _input.means.data(),
-            _input.icf.data(), _input.x.data(), _input.wishart, &_output.objective, _output.gradient.data());
-    }
-}
-
-extern "C" DLL_PUBLIC ITest<GMMInput, GMMOutput>* get_gmm_test()
-{
-    return new ManualGMM();
+void ManualGMM::calculate_jacobian() {
+  gmm_objective_d(_input.d, _input.k, _input.n, _input.alphas.data(), _input.means.data(),
+                  _input.icf.data(), _input.x.data(), _input.wishart, &_output.objective, _output.gradient.data());
 }

--- a/tools/manual/ManualGMM.h
+++ b/tools/manual/ManualGMM.h
@@ -12,16 +12,9 @@
 #include <vector>
 
 class ManualGMM : public ITest<GMMInput, GMMOutput> {
-    GMMInput _input;
-    GMMOutput _output;
-
 public:
-    // This function must be called before any other function.
-    void prepare(GMMInput&& input) override;
+    ManualGMM(GMMInput& input);
 
-    void calculate_objective(int times) override;
-    void calculate_jacobian(int times) override;
-    GMMOutput output() override; 
-
-    ~ManualGMM() = default;
+    void calculate_objective() override;
+    void calculate_jacobian() override;
 };

--- a/tools/manual/ManualHT.cpp
+++ b/tools/manual/ManualHT.cpp
@@ -3,55 +3,31 @@
 
 // https://github.com/microsoft/ADBench/blob/38cb7931303a830c3700ca36ba9520868327ac87/src/cpp/modules/manual/ManualHand.cpp
 
-// ManualHand.cpp : Defines the exported functions for the DLL.
 #include "ManualHT.h"
 
 #include "adbench/shared/ht_light_matrix.h"
 #include "ht_d.h"
 
-// This function must be called before any other function.
-void ManualHand::prepare(HandInput&& input)
-{
-    _input = input;
-    _complicated = _input.us.size() != 0;
-    int err_size = 3 * _input.data.correspondences.size();
-    int ncols = (_complicated ? 2 : 0) + _input.theta.size();
-    _output = { std::vector<double>(err_size), ncols, err_size, std::vector<double>(err_size * ncols) };
+ManualHand::ManualHand(HandInput& input) : ITest(input) {
+  _complicated = _input.us.size() != 0;
+  int err_size = 3 * _input.data.correspondences.size();
+  int ncols = (_complicated ? 2 : 0) + _input.theta.size();
+  _output = { std::vector<double>(err_size), ncols, err_size, std::vector<double>(err_size * ncols) };
 }
 
-HandOutput ManualHand::output()
-{
-    return _output;
+void ManualHand::calculate_objective() {
+  if (_complicated) {
+    hand_objective(_input.theta.data(), _input.us.data(), &_input.data, _output.objective.data());
+  } else {
+    hand_objective(_input.theta.data(), &_input.data, _output.objective.data());
+  }
 }
 
-void ManualHand::calculate_objective(int times)
-{
-    if (_complicated)
-    {
-        for (int i = 0; i < times; ++i) {
-            hand_objective(_input.theta.data(), _input.us.data(), &_input.data, _output.objective.data());
-        }
-    }
-    else
-    {
-        for (int i = 0; i < times; ++i) {
-            hand_objective(_input.theta.data(), &_input.data, _output.objective.data());
-        }
-    }
-}
-
-void ManualHand::calculate_jacobian(int times)
-{
-    if (_complicated)
-    {
-        for (int i = 0; i < times; ++i) {
-            hand_objective_d(_input.theta.data(), _input.us.data(), _input.data, _output.objective.data(), _output.jacobian.data());
-        }
-    }
-    else
-    {
-        for (int i = 0; i < times; ++i) {
-            hand_objective_d(_input.theta.data(), _input.data, _output.objective.data(), _output.jacobian.data());
-        }
-    }
+void ManualHand::calculate_jacobian() {
+  if (_complicated) {
+    hand_objective_d(_input.theta.data(), _input.us.data(), _input.data, _output.objective.data(), _output.jacobian.data());
+  }
+  else {
+    hand_objective_d(_input.theta.data(), _input.data, _output.objective.data(), _output.jacobian.data());
+  }
 }

--- a/tools/manual/ManualHT.h
+++ b/tools/manual/ManualHT.h
@@ -3,24 +3,17 @@
 
 // https://github.com/microsoft/ADBench/blob/38cb7931303a830c3700ca36ba9520868327ac87/src/cpp/modules/manual/ManualHand.h
 
-// ManualHand.h - Contains declarations of GMM tester functions
 #pragma once
 
 #include "adbench/shared/ITest.h"
 #include "adbench/shared/HTData.h"
 
 class ManualHand : public ITest<HandInput, HandOutput> {
-    HandInput _input;
-    HandOutput _output;
-    bool _complicated = false;
+  bool _complicated = false;
 
 public:
-    // This function must be called before any other function.
-    void prepare(HandInput&& input) override;
+  ManualHand(HandInput& input);
 
-    void calculate_objective(int times) override;
-    void calculate_jacobian(int times) override;
-    HandOutput output() override;
-
-    ~ManualHand() = default;
+  void calculate_objective() override;
+  void calculate_jacobian() override;
 };

--- a/tools/manual/ManualHello.cpp
+++ b/tools/manual/ManualHello.cpp
@@ -2,31 +2,13 @@
 #include "adbench/shared/hello.h"
 #include "hello_d.h"
 
-void ManualHello::prepare(HelloInput&& input)
-{
-    _input = input;
+ManualHello::ManualHello(HelloInput& input) : ITest(input) {}
+
+void ManualHello::calculate_objective() {
+
+  _output.objective = hello_objective(_input.x);
 }
 
-HelloOutput ManualHello::output()
-{
-    return _output;
-}
-
-void ManualHello::calculate_objective(int times)
-{
-    for (int i = 0; i < times; ++i) {
-      _output.objective = hello_objective(_input.x);
-    }
-}
-
-void ManualHello::calculate_jacobian(int times)
-{
-    for (int i = 0; i < times; ++i) {
-      _output.gradient = hello_objective_d(_input.x);
-    }
-}
-
-extern "C" DLL_PUBLIC ITest<HelloInput, HelloOutput>* get_ba_test()
-{
-    return new ManualHello();
+void ManualHello::calculate_jacobian() {
+  _output.gradient = hello_objective_d(_input.x);
 }

--- a/tools/manual/ManualHello.h
+++ b/tools/manual/ManualHello.h
@@ -6,16 +6,9 @@
 #include <vector>
 
 class ManualHello : public ITest<HelloInput, HelloOutput> {
-private:
-    HelloInput _input;
-    HelloOutput _output;
-
 public:
-    virtual void prepare(HelloInput&& input) override;
+    ManualHello(HelloInput&);
 
-    virtual void calculate_objective(int times) override;
-    virtual void calculate_jacobian(int times) override;
-    virtual HelloOutput output() override;
-
-    ~ManualHello() {}
+    virtual void calculate_objective() override;
+    virtual void calculate_jacobian() override;
 };

--- a/tools/manual/ManualLSTM.cpp
+++ b/tools/manual/ManualLSTM.cpp
@@ -8,29 +8,21 @@
 #include "adbench/shared/lstm.h"
 #include "lstm_d.h"
 
-// This function must be called before any other function.
-void ManualLSTM::prepare(LSTMInput&& input)
-{
-    this->input = input;
-    int Jcols = 8 * this->input.l * this->input.b + 3 * this->input.b;
-    result = { 0, std::vector<double>(Jcols) };
+ManualLSTM::ManualLSTM(LSTMInput& input) : ITest(input) {
+  int Jcols = 8 * _input.l * _input.b + 3 * _input.b;
+  _output = { 0, std::vector<double>(Jcols) };
 }
 
-LSTMOutput ManualLSTM::output()
-{
-    return result;
+void ManualLSTM::calculate_objective() {
+  lstm_objective(_input.l, _input.c, _input.b,
+                 _input.main_params.data(), _input.extra_params.data(),
+                 _input.state.data(), _input.sequence.data(),
+                 &_output.objective);
 }
 
-void ManualLSTM::calculate_objective(int times)
-{
-    for (int i = 0; i < times; ++i) {
-      lstm_objective(input.l, input.c, input.b, input.main_params.data(), input.extra_params.data(), input.state.data(), input.sequence.data(), &result.objective);
-    }
-}
-
-void ManualLSTM::calculate_jacobian(int times)
-{
-    for (int i = 0; i < times; ++i) {
-      lstm_objective_d(input.l, input.c, input.b, input.main_params.data(), input.extra_params.data(), input.state, input.sequence.data(), &result.objective, result.gradient.data());
-    }
+void ManualLSTM::calculate_jacobian() {
+  lstm_objective_d(_input.l, _input.c, _input.b,
+                   _input.main_params.data(), _input.extra_params.data(),
+                   _input.state, _input.sequence.data(),
+                   &_output.objective, _output.gradient.data());
 }

--- a/tools/manual/ManualLSTM.h
+++ b/tools/manual/ManualLSTM.h
@@ -3,7 +3,6 @@
 
 // https://github.com/microsoft/ADBench/blob/38cb7931303a830c3700ca36ba9520868327ac87/src/cpp/modules/manual/ManualLSTM.h
 
-// ManualLSTM.h - Contains declarations of LSTM tester functions
 #pragma once
 
 #include "adbench/shared/ITest.h"
@@ -13,17 +12,11 @@
 
 class ManualLSTM : public ITest<LSTMInput, LSTMOutput> {
 private:
-    LSTMInput input;
-    LSTMOutput result;
     std::vector<double> state;
 
 public:
-    // This function must be called before any other function.
-    virtual void prepare(LSTMInput&& input) override;
+    ManualLSTM(LSTMInput&);
 
-    virtual void calculate_objective(int times) override;
-    virtual void calculate_jacobian(int times) override;
-    virtual LSTMOutput output() override;
-
-    ~ManualLSTM() {}
+    virtual void calculate_objective() override;
+    virtual void calculate_jacobian() override;
 };

--- a/tools/tapenade/TapenadeBA.cpp
+++ b/tools/tapenade/TapenadeBA.cpp
@@ -5,58 +5,36 @@
 
 #include "TapenadeBA.h"
 
-// This function must be called before any other function.
-void TapenadeBA::prepare(BAInput&& input)
-{
-    this->input = input;
-    result = {
-        std::vector<double>(2 * this->input.p),
-        std::vector<double>(this->input.p),
-        BASparseMat(this->input.n, this->input.m, this->input.p)
-    };
+TapenadeBA::TapenadeBA(BAInput& input) : ITest(input) {
+  _input = input;
+  _output = {
+    std::vector<double>(2 * _input.p),
+    std::vector<double>(_input.p),
+    BASparseMat(_input.n, _input.m, _input.p)
+  };
 
-    reproj_err_d = std::vector<double>(2 * (BA_NCAMPARAMS + 3 + 1));
-    reproj_err_d_row = std::vector<double>(BA_NCAMPARAMS + 3 + 1);
+  reproj_err_d = std::vector<double>(2 * (BA_NCAMPARAMS + 3 + 1));
+  reproj_err_d_row = std::vector<double>(BA_NCAMPARAMS + 3 + 1);
 }
 
-
-
-BAOutput TapenadeBA::output()
-{
-    return result;
+void TapenadeBA::calculate_objective() {
+  ba_objective(_input.n,
+               _input.m,
+               _input.p,
+               _input.cams.data(),
+               _input.X.data(),
+               _input.w.data(),
+               _input.obs.data(),
+               _input.feats.data(),
+               _output.reproj_err.data(),
+               _output.w_err.data()
+               );
 }
 
-
-
-void TapenadeBA::calculate_objective(int times)
-{
-    for (int i = 0; i < times; i++)
-    {
-        ba_objective(
-            input.n,
-            input.m,
-            input.p,
-            input.cams.data(),
-            input.X.data(),
-            input.w.data(),
-            input.obs.data(),
-            input.feats.data(),
-            result.reproj_err.data(),
-            result.w_err.data()
-        );
-    }
-}
-
-
-
-void TapenadeBA::calculate_jacobian(int times)
-{
-    for (int i = 0; i < times; i++)
-    {
-        result.J.clear();
-        calculate_reproj_error_jacobian_part();
-        calculate_weight_error_jacobian_part();
-    }
+void TapenadeBA::calculate_jacobian() {
+  _output.J.clear();
+  calculate_reproj_error_jacobian_part();
+  calculate_weight_error_jacobian_part();
 }
 
 
@@ -66,29 +44,29 @@ void TapenadeBA::calculate_reproj_error_jacobian_part()
     double errb[2];     // stores dY
                         // (i-th element equals to 1.0 for calculating i-th jacobian row)
 
-    double err[2];      // stores fictive result
+    double err[2];      // stores fictive _output
                         // (Tapenade doesn't calculate an original function in reverse mode)
 
     double* cam_gradient_part = reproj_err_d_row.data();
     double* x_gradient_part = reproj_err_d_row.data() + BA_NCAMPARAMS;
     double* weight_gradient_part = reproj_err_d_row.data() + BA_NCAMPARAMS + 3;
 
-    for (int i = 0; i < input.p; i++)
+    for (int i = 0; i < _input.p; i++)
     {
-        int camIdx = input.obs[2 * i + 0];
-        int ptIdx = input.obs[2 * i + 1];
+        int camIdx = _input.obs[2 * i + 0];
+        int ptIdx = _input.obs[2 * i + 1];
 
         // calculate first row
         errb[0] = 1.0;
         errb[1] = 0.0;
         compute_reproj_error_b(
-            &input.cams[camIdx * BA_NCAMPARAMS],
+            &_input.cams[camIdx * BA_NCAMPARAMS],
             cam_gradient_part,
-            &input.X[ptIdx * 3],
+            &_input.X[ptIdx * 3],
             x_gradient_part,
-            &input.w[i],
+            &_input.w[i],
             weight_gradient_part,
-            &input.feats[i * 2],
+            &_input.feats[i * 2],
             err,
             errb
         );
@@ -103,13 +81,13 @@ void TapenadeBA::calculate_reproj_error_jacobian_part()
         errb[0] = 0.0;
         errb[1] = 1.0;
         compute_reproj_error_b(
-            &input.cams[camIdx * BA_NCAMPARAMS],
+            &_input.cams[camIdx * BA_NCAMPARAMS],
             cam_gradient_part,
-            &input.X[ptIdx * 3],
+            &_input.X[ptIdx * 3],
             x_gradient_part,
-            &input.w[i],
+            &_input.w[i],
             weight_gradient_part,
-            &input.feats[i * 2],
+            &_input.feats[i * 2],
             err,
             errb
         );
@@ -120,7 +98,7 @@ void TapenadeBA::calculate_reproj_error_jacobian_part()
             reproj_err_d[2 * j + 1] = reproj_err_d_row[j];
         }
 
-        result.J.insert_reproj_err_block(i, camIdx, ptIdx, reproj_err_d.data());
+        _output.J.insert_reproj_err_block(i, camIdx, ptIdx, reproj_err_d.data());
     }
 }
 
@@ -128,24 +106,17 @@ void TapenadeBA::calculate_reproj_error_jacobian_part()
 
 void TapenadeBA::calculate_weight_error_jacobian_part()
 {
-    for (int j = 0; j < input.p; j++)
+    for (int j = 0; j < _input.p; j++)
     {
         double wb;              // stores calculated derivative
 
-        double err = 0.0;       // stores fictive result
+        double err = 0.0;       // stores fictive _output
                                 // (Tapenade doesn't calculate an original function in reverse mode)
 
         double errb = 1.0;      // stores dY
                                 // (equals to 1.0 for derivative calculation)
 
-        compute_zach_weight_error_b(&input.w[j], &wb, &err, &errb);
-        result.J.insert_w_err_block(j, wb);
+        compute_zach_weight_error_b(&_input.w[j], &wb, &err, &errb);
+        _output.J.insert_w_err_block(j, wb);
     }
-}
-
-
-
-extern "C" DLL_PUBLIC ITest<BAInput, BAOutput>* get_ba_test()
-{
-    return new TapenadeBA();
 }

--- a/tools/tapenade/TapenadeBA.h
+++ b/tools/tapenade/TapenadeBA.h
@@ -17,8 +17,6 @@
 class TapenadeBA : public ITest<BAInput, BAOutput>
 {
 private:
-    BAInput input;
-    BAOutput result;
     std::vector<double> state;
 
     // buffer for reprojection error jacobian part holding (column-major)
@@ -28,14 +26,10 @@ private:
     std::vector<double> reproj_err_d_row;
 
 public:
-    // This function must be called before any other function.
-    virtual void prepare(BAInput&& input) override;
+    TapenadeBA(BAInput& input);
 
-    virtual void calculate_objective(int times) override;
-    virtual void calculate_jacobian(int times) override;
-    virtual BAOutput output() override;
-
-    ~TapenadeBA() {}
+    virtual void calculate_objective() override;
+    virtual void calculate_jacobian() override;
 
 private:
     void calculate_weight_error_jacobian_part();

--- a/tools/tapenade/TapenadeGMM.h
+++ b/tools/tapenade/TapenadeGMM.h
@@ -20,18 +20,12 @@
 class TapenadeGMM : public ITest<GMMInput, GMMOutput>
 {
 private:
-    GMMInput input;
-    GMMOutput result;
     std::vector<double> state;
 
 public:
-    // This function must be called before any other function.
-    virtual void prepare(GMMInput&& input) override;
+    TapenadeGMM(GMMInput&);
 
-    virtual void calculate_objective(int times) override;
-    virtual void calculate_jacobian(int times) override;
-    virtual GMMOutput output() override;
-
-    ~TapenadeGMM() {}
+    virtual void calculate_objective() override;
+    virtual void calculate_jacobian() override;
 };
 

--- a/tools/tapenade/TapenadeHT.h
+++ b/tools/tapenade/TapenadeHT.h
@@ -33,8 +33,6 @@ struct HandObjectiveData
 
 class TapenadeHand : public ITest<HandInput, HandOutput> {
     HandObjectiveData* objective_input = nullptr;
-    HandInput input;
-    HandOutput result;
     bool complicated = false;
 
     std::vector<double> theta_d;                // buffer for theta differentiation directions
@@ -46,14 +44,12 @@ class TapenadeHand : public ITest<HandInput, HandOutput> {
     std::vector<double> us_jacobian_column;     // buffer for holding jacobian column while differentiating by us
 
 public:
-    // This function must be called before any other function.
-    void prepare(HandInput&& input) override;
+    TapenadeHand(HandInput& input);
 
-    void calculate_objective(int times) override;
-    void calculate_jacobian(int times) override;
-    HandOutput output() override;
+    void calculate_objective() override;
+    void calculate_jacobian() override;
 
-    ~TapenadeHand() { free_objective_input(); }
+    virtual ~TapenadeHand() { free_objective_input(); }
 
 private:
     HandObjectiveData* convert_to_hand_objective_data(const HandInput& input);

--- a/tools/tapenade/TapenadeLSTM.h
+++ b/tools/tapenade/TapenadeLSTM.h
@@ -21,13 +21,9 @@ private:
     std::vector<double> state;
 
 public:
-    // This function must be called before any other function.
-    virtual void prepare(LSTMInput&& input) override;
+    TapenadeLSTM(LSTMInput&);
 
-    virtual void calculate_objective(int times) override;
-    virtual void calculate_jacobian(int times) override;
-    virtual LSTMOutput output() override;
-
-    ~TapenadeLSTM() {}
+    virtual void calculate_objective() override;
+    virtual void calculate_jacobian() override;
 };
 


### PR DESCRIPTION
Resolves #199. This looks like a large change, but it is actually not significant. It simplifies the IData class to remove some ADBench-isms that are unnecessary in Gradbench. The overall impact is less boilerplate in tool implementations. In particular:

* calculate_objective/jacobian no longer accept a 'times' parameter - this is done in the main function instead.

* The 'prepare' method has been replaced by a constructor.

* A 'prepare_jacobian' method has been introduced for those tools where it makes sense to measure the work done before computing the jacobian.