### PR TITLE
Clean up the Adept tool.

### DIFF
--- a/tools/adept/Dockerfile
+++ b/tools/adept/Dockerfile
@@ -20,8 +20,11 @@ RUN curl -O http://www.met.reading.ac.uk/clouds/adept/adept-2.1.1.tar.gz
 RUN tar xvf adept-2.1.1.tar.gz
 RUN cd adept-2.1.1 && curl -O https://cvs.savannah.gnu.org/viewvc/*checkout*/config/config/config.guess
 RUN cd adept-2.1.1 && curl -O https://cvs.savannah.gnu.org/viewvc/*checkout*/config/config/config.sub
-RUN cd adept-2.1.1 && ./configure && make
-ENV ADEPT_DIR=/home/gradbench/adept-2.1.1
+RUN cd adept-2.1.1 && ./configure
+RUN make -C adept-2.1.1
+RUN make -C adept-2.1.1 install
+ENV LIBRARY_PATH=/usr/local/lib
+ENV LD_LIBRARY_PATH=/usr/local/lib
 
 COPY cpp /home/gradbench/cpp
 

--- a/tools/adept/Makefile
+++ b/tools/adept/Makefile
@@ -1,14 +1,7 @@
-# The ADEPT_DIR default is set such that you can download adept into
-# this directory for easy testing, but is overridden by an environment
-# variable in the Dockerfile.
-ADEPT_DIR?=adept-2.1.1
-ADEPT_INCLUDE_DIR=$(ADEPT_DIR)/include
-ADEPT_LIB_DIR=$(ADEPT_DIR)/adept/.libs/
-
 CXX?=c++
 CC?=cc
-CFLAGS=-std=c++17 -O2 -Wall -I$(ADEPT_INCLUDE_DIR) -fopenmp
-LDFLAGS=-lm $(ADEPT_LIB_DIR)/libadept.a -fopenmp
+CFLAGS=-std=c++17 -O2 -Wall -fopenmp
+LDFLAGS=-lm -ladept -fopenmp
 
 UTIL_OBJECTS=../../cpp/adbench/shared/utils.o ../../cpp/adbench/io.o
 HELLO_OBJECTS=AdeptHello.o run_hello.o


### PR DESCRIPTION
No user-visible change, but much easier to run outside of Docker, as you no longer have to set bespoke environment variables.