### PR TITLE
Silence "unused result" warnings in input reading code.

### DIFF
--- a/cpp/adbench/shared/utils.cpp
+++ b/cpp/adbench/shared/utils.cpp
@@ -25,6 +25,9 @@
 
 #include "defs.h"
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-result"
+
 using std::cin;
 using std::cout;
 using std::endl;
@@ -664,3 +667,5 @@ double timer(int nruns, double limit, std::function<void()> func) {
     else
         return 0;
 }
+
+#pragma GCC diagnostic pop


### PR DESCRIPTION
A more honourable solution is to rewrite the ADBench input reading code to detect errors properly, but it's not like we're actually using these functions anyway.