### PR TITLE
Speed up Enzyme a bit.

### DIFF
--- a/cpp/adbench/shared/gmm.h
+++ b/cpp/adbench/shared/gmm.h
@@ -162,12 +162,12 @@ void Qtimesx(int d,
 
 template<typename T>
 void gmm_objective(int d, int k, int n,
-    const T* const alphas,
-    const T* const means,
-    const T* const icf,
-    const double* const x,
-    Wishart wishart,
-    T* err)
+                   const T* __restrict__ const alphas,
+                   const T* __restrict__ const means,
+                   const T* __restrict__ const icf,
+                   const double* __restrict__ const x,
+                   Wishart wishart,
+                   T* __restrict__ err)
 {
     const double CONSTANT = -n * d * 0.5 * log(2 * PI);
     int icf_sz = d * (d + 1) / 2;

--- a/tools/enzyme/EnzymeGMM.cpp
+++ b/tools/enzyme/EnzymeGMM.cpp
@@ -28,11 +28,6 @@ extern int enzyme_const;
 void __enzyme_autodiff(... ) noexcept;
 
 void EnzymeGMM::calculate_jacobian() {
-  _output.gradient.resize(_input.alphas.size()+
-                          _input.means.size()+
-                          _input.icf.size());
-
-
   double* d_alphas = _output.gradient.data();
   double* d_means = d_alphas + _input.alphas.size();
   double* d_icf = d_means + _input.means.size();

--- a/tools/enzyme/Makefile
+++ b/tools/enzyme/Makefile
@@ -1,7 +1,7 @@
 CXX=clang++-19
 LLD=lld-19
-CXXFLAGS=-std=c++17 -O3 -Wall -flto
-LDFLAGS=-fuse-ld=$(LLD) -O3 -flto -Wl,--load-pass-plugin=$(LLDENZYME) -lm
+CXXFLAGS=-std=c++17 -O3 -fno-math-errno -Wall -flto
+LDFLAGS=-fuse-ld=$(LLD) -O3 -fno-math-errno -flto -Wl,--load-pass-plugin=$(LLDENZYME) -lm
 
 LLDENZYME=/home/gradbench/enzyme-build/Enzyme/LLDEnzyme-19.so
 


### PR DESCRIPTION
This is by adding `__restrict__` to the GMM objective function (significant impact, may also help other tools) and telling the compiler not to worry about errno for math functions (much smaller impact).

Enzyme is still inexplicably slow for GMM.