### PR TITLE
Make the CLI work on Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,6 +84,16 @@ jobs:
           name: cli
           path: target/release/gradbench
 
+  windows:
+    runs-on: windows-2022
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Build CLI
+        run: cargo build --release
+      - name: Run CLI
+        run: ./gradbench.ps1 help
+
   matrix:
     needs: cli
     runs-on: ubuntu-22.04

--- a/gradbench.ps1
+++ b/gradbench.ps1
@@ -1,0 +1,1 @@
+cargo run --quiet --release -- $args


### PR DESCRIPTION
This PR tweaks the CLI a bit so it works correctly on Windows, adds a `gradbench.ps1` counterpart to the `gradbench` shell script, and adds a CI check that the latter at least supports the `help` subcommand.