### PR TITLE
Rename `cli::cli` to `cli::main` in `gradbench`

### DIFF
--- a/crates/gradbench/src/cli.rs
+++ b/crates/gradbench/src/cli.rs
@@ -892,7 +892,7 @@ fn cli_result() -> Result<(), ExitCode> {
 }
 
 /// Run the GradBench CLI.
-pub fn cli() -> ExitCode {
+pub fn main() -> ExitCode {
     match cli_result() {
         Ok(()) => ExitCode::SUCCESS,
         Err(code) => code,

--- a/crates/gradbench/src/main.rs
+++ b/crates/gradbench/src/main.rs
@@ -1,5 +1,5 @@
 mod cli;
 
 fn main() -> std::process::ExitCode {
-    cli::cli()
+    cli::main()
 }


### PR DESCRIPTION
Prerequisite for #219 to hopefully make GitHub recognize it as a rename.