### PR TITLE
Delete `crates/gradbench/src/main.rs`

### DIFF
--- a/crates/gradbench/src/main.rs
+++ b/crates/gradbench/src/main.rs
@@ -1,5 +1,0 @@
-mod cli;
-
-fn main() -> std::process::ExitCode {
-    cli::main()
-}


### PR DESCRIPTION
Trying again to achieve the same goal as #220. This will break the build on `main`, but hopefully the `git blame` gains in the future will be worth it.