### PR TITLE
Build all multi-platform images in a separate job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -212,6 +212,12 @@ jobs:
     needs:
       - cli
       - matrix
+      # We don't want this job to take up runners before the other jobs get a
+      # chance, so we give it the same dependencies as the `run` job; those jobs
+      # should then start first because their name comes lexicographically
+      # before this one.
+      - eval
+      - x86-tool
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -212,12 +212,7 @@ jobs:
     needs:
       - cli
       - matrix
-      # We don't want this job to take up runners before the other jobs get a
-      # chance, so we give it the same dependencies as the `run` job; those jobs
-      # should then start first because their name comes lexicographically
-      # before this one.
-      - eval
-      - x86-tool
+      - run # Not strictly necessary, but GitHub Actions has concurrency limits.
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,8 +107,7 @@ jobs:
     runs-on: ubuntu-22.04
     outputs:
       eval: ${{ steps.matrix.outputs.eval }}
-      fast: ${{ steps.matrix.outputs.fast }}
-      slow: ${{ steps.matrix.outputs.slow }}
+      tool: ${{ steps.matrix.outputs.tool }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -144,14 +143,79 @@ jobs:
           name: eval-${{ matrix.eval }}
           path: eval-${{ matrix.eval }}.tar
 
-  tool-fast:
+  x86-tool:
     needs:
       - cli
       - matrix
     strategy:
       fail-fast: false
       matrix:
-        tool: ${{ fromJSON(needs.matrix.outputs.fast) }}
+        tool: ${{ fromJSON(needs.matrix.outputs.tool) }}
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Increase disk space
+        uses: ./.github/actions/space
+      - name: Install CLI from artifact
+        uses: ./.github/actions/cli
+      - name: Build tool Docker image
+        run: gradbench repo build-tool ${{ matrix.tool }}
+      - name: Serialize tool Docker image
+        run: docker save --output x86-tool-${{ matrix.tool }}.tar ghcr.io/gradbench/tool-${{ matrix.tool }}
+      - name: Upload tool Docker image as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: x86-tool-${{ matrix.tool }}
+          path: x86-tool-${{ matrix.tool }}.tar
+
+  run:
+    needs:
+      - cli
+      - matrix
+      - eval
+      - x86-tool
+    strategy:
+      fail-fast: false
+      matrix:
+        eval: ${{ fromJSON(needs.matrix.outputs.eval) }}
+        tool: ${{ fromJSON(needs.matrix.outputs.tool) }}
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install CLI from artifact
+        uses: ./.github/actions/cli
+      - name: Download eval Docker image from artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: eval-${{ matrix.eval }}
+      - name: Download tool Docker image from artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: x86-tool-${{ matrix.tool }}
+      - name: Load eval Docker image
+        run: docker load --input eval-${{ matrix.eval }}.tar
+      - name: Load tool Docker image
+        run: docker load --input x86-tool-${{ matrix.tool }}.tar
+      - name: Run tool on eval
+        id: run
+        run: gradbench run --eval 'gradbench eval ${{ matrix.eval }}' --tool 'gradbench tool ${{ matrix.tool }}' --output log.jsonl
+      - name: Upload log as artifact
+        if: success() || steps.run.conclusion == 'failure'
+        uses: actions/upload-artifact@v4
+        with:
+          name: run-${{ matrix.eval }}-${{ matrix.tool }}
+          path: log.jsonl
+
+  tool:
+    needs:
+      - cli
+      - matrix
+    strategy:
+      fail-fast: false
+      matrix:
+        tool: ${{ fromJSON(needs.matrix.outputs.tool) }}
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
@@ -171,110 +235,3 @@ jobs:
         with:
           name: tool-${{ matrix.tool }}
           path: tool-${{ matrix.tool }}.tar
-
-  tool-slow:
-    needs:
-      - cli
-      - matrix
-    strategy:
-      fail-fast: false
-      matrix:
-        tool: ${{ fromJSON(needs.matrix.outputs.slow) }}
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Increase disk space
-        uses: ./.github/actions/space
-      - name: Setup multi-platform Docker
-        uses: ./.github/actions/docker
-      - name: Install CLI from artifact
-        uses: ./.github/actions/cli
-      - name: Build tool Docker image
-        # no cross-platform for slow-to-build tools since it's, y'know, too slow
-        run: gradbench repo build-tool ${{ matrix.tool }}
-      - name: Serialize tool Docker image
-        run: docker save --output tool-${{ matrix.tool }}.tar ghcr.io/gradbench/tool-${{ matrix.tool }}
-      - name: Upload tool Docker image as artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: tool-${{ matrix.tool }}
-          path: tool-${{ matrix.tool }}.tar
-
-  run-fast:
-    needs:
-      - cli
-      - matrix
-      - eval
-      - tool-fast
-    strategy:
-      fail-fast: false
-      matrix:
-        eval: ${{ fromJSON(needs.matrix.outputs.eval) }}
-        tool: ${{ fromJSON(needs.matrix.outputs.fast) }}
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Install CLI from artifact
-        uses: ./.github/actions/cli
-      - name: Download eval Docker image from artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: eval-${{ matrix.eval }}
-      - name: Download tool Docker image from artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: tool-${{ matrix.tool }}
-      - name: Load eval Docker image
-        run: docker load --input eval-${{ matrix.eval }}.tar
-      - name: Load tool Docker image
-        run: docker load --input tool-${{ matrix.tool }}.tar
-      - name: Run tool on eval
-        id: run
-        run: gradbench run --eval 'gradbench eval ${{ matrix.eval }}' --tool 'gradbench tool ${{ matrix.tool }}' --output log.jsonl
-      - name: Upload log as artifact
-        if: success() || steps.run.conclusion == 'failure'
-        uses: actions/upload-artifact@v4
-        with:
-          name: run-${{ matrix.eval }}-${{ matrix.tool }}
-          path: log.jsonl
-
-  run-slow:
-    needs:
-      - cli
-      - matrix
-      - eval
-      - tool-slow
-    strategy:
-      fail-fast: false
-      matrix:
-        eval: ${{ fromJSON(needs.matrix.outputs.eval) }}
-        tool: ${{ fromJSON(needs.matrix.outputs.slow) }}
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Install CLI from artifact
-        uses: ./.github/actions/cli
-      - name: Download eval Docker image from artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: eval-${{ matrix.eval }}
-      - name: Download tool Docker image from artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: tool-${{ matrix.tool }}
-      - name: Load eval Docker image
-        run: docker load --input eval-${{ matrix.eval }}.tar
-      - name: Load tool Docker image
-        run: docker load --input tool-${{ matrix.tool }}.tar
-      - name: Run tool on eval
-        id: run
-        run: gradbench run --eval 'gradbench eval ${{ matrix.eval }}' --tool 'gradbench tool ${{ matrix.tool }}' --output log.jsonl
-      - name: Upload log as artifact
-        if: success() || steps.run.conclusion == 'failure'
-        uses: actions/upload-artifact@v4
-        with:
-          name: run-${{ matrix.eval }}-${{ matrix.tool }}
-          path: log.jsonl

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -143,7 +143,7 @@ jobs:
           name: eval-${{ matrix.eval }}
           path: eval-${{ matrix.eval }}.tar
 
-  x86-tool:
+  tool:
     needs:
       - cli
       - matrix
@@ -174,7 +174,7 @@ jobs:
       - cli
       - matrix
       - eval
-      - x86-tool
+      - tool
     strategy:
       fail-fast: false
       matrix:
@@ -208,7 +208,8 @@ jobs:
           name: run-${{ matrix.eval }}-${{ matrix.tool }}
           path: log.jsonl
 
-  tool:
+  # This job's name must lexicographically come after `tool` so it runs later.
+  tool-cross:
     needs:
       - cli
       - matrix

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -184,6 +184,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Increase disk space
+        uses: ./.github/actions/space
       - name: Install CLI from artifact
         uses: ./.github/actions/cli
       - name: Download eval Docker image from artifact

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -143,7 +143,7 @@ jobs:
           name: eval-${{ matrix.eval }}
           path: eval-${{ matrix.eval }}.tar
 
-  tool:
+  x86-tool:
     needs:
       - cli
       - matrix
@@ -174,7 +174,7 @@ jobs:
       - cli
       - matrix
       - eval
-      - tool
+      - x86-tool
     strategy:
       fail-fast: false
       matrix:
@@ -208,8 +208,7 @@ jobs:
           name: run-${{ matrix.eval }}-${{ matrix.tool }}
           path: log.jsonl
 
-  # This job's name must lexicographically come after `tool` so it runs later.
-  tool-cross:
+  tool:
     needs:
       - cli
       - matrix

--- a/crates/gradbench/src/main.rs
+++ b/crates/gradbench/src/main.rs
@@ -1025,16 +1025,6 @@ fn cli_result() -> Result<(), ExitCode> {
                     tools.retain(|t| t != "diffsharp"); // Flaky.
                     tools.sort();
                     github_output("tool", &tools)?;
-                    // Specifically, this is the list of tools for which the ARM Docker image is
-                    // slow to build on x86 via QEMU. It doesn't mean that the tool itself is slow
-                    // to run, or even that the Docker image is slow to build natively.
-                    let slow = ["enzyme", "floretta", "scilean"];
-                    let fast: Vec<_> = tools
-                        .iter()
-                        .filter(|t| !slow.contains(&t.as_str()))
-                        .collect();
-                    github_output("fast", fast)?;
-                    github_output("slow", slow)?;
                     Ok(())
                 }
                 RepoCommands::Summarize { dir, date, commit } => {


### PR DESCRIPTION
This PR should make #227 not matter as much, while also giving us better CI signal on PRs like #224. Now there's just one `run` job which depends on a single `x86-tool` job, and the multi-platform images are built in a single `tool` job that depends on the `run` job to ensure that it runs after it and thus doesn't take up GitHub Actions runners while the `run` job is in progress.