### PR TITLE
Check response.success after response.error

### DIFF
--- a/crates/gradbench/src/main.rs
+++ b/crates/gradbench/src/main.rs
@@ -1476,7 +1476,7 @@ mod tests {
         colored::control::set_override(false);
         let result = intermediary.run();
         write_goldenfile("define_error.txt", &intermediary.out);
-        assert_eq!(result, Err(BadOutcome::Undefined));
+        assert_eq!(result, Err(BadOutcome::Failure));
     }
 
     #[test]

--- a/crates/gradbench/src/main.rs
+++ b/crates/gradbench/src/main.rs
@@ -696,17 +696,18 @@ impl<
                     self.print_left(WIDTH_DESCRIPTION, "")?;
                     write!(self.out, " {}", nanostring(nanos).dimmed())?;
                     let response: DefineResponse = self.parse_response(&tool_line)?;
-                    if !response.success {
-                        undefined += 1;
-                    }
                     self.print_status(response.success)?;
                     line.end(&mut self.out)?;
                     if let Some(error) = response.error {
+                        failure += 1;
                         writeln!(self.out, "{}", error.red())?;
                         if response.success {
                             return Err(anyhow!("tool reported success but gave an error"));
                         }
+                    } else if !response.success {
+                        undefined += 1;
                     }
+
                 }
                 Message::Evaluate { .. } => {
                     write!(self.out, " {}", nanostring(nanos).dimmed())?;

--- a/crates/gradbench/src/main.rs
+++ b/crates/gradbench/src/main.rs
@@ -707,7 +707,6 @@ impl<
                     } else if !response.success {
                         undefined += 1;
                     }
-
                 }
                 Message::Evaluate { .. } => {
                     write!(self.out, " {}", nanostring(nanos).dimmed())?;


### PR DESCRIPTION
Also increment failure count on define failure.

Without this change, a tool responding with a failure to a 'define' message is counted as undefined, which means gradbench (in its default configuration) will not return a nonzero exit code. This is why kmeans is actually broken for enzyme/manual right now, without the PR having failed.