### PR TITLE
Add Nix setup with shell.nix

### DIFF
--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -1,0 +1,68 @@
+# shell.nix for use with Nix, in order to run Gradbench locally.
+#
+# May get out of sync with in particular pyproject.toml (I couldn't
+# figure out how to import it automatically), but hopefully it is not
+# too difficult to maintain.
+{ pkgs ? import <nixpkgs> {} }:
+let
+  my-python-packages = ps: with ps; [
+    (buildPythonPackage rec {
+      pname = "futhark-data";
+      version = "1.0.2";
+      src = fetchPypi {
+        inherit pname version;
+        sha256 = "sha256-FJOhVr65U3kP408BbA42jbGGD6x+tVh+TNhsYv8bUT0=";
+      };
+      doCheck = false;
+    })
+    (buildPythonPackage rec {
+      pname = "futhark-server";
+      version = "1.0.0";
+      src = fetchPypi {
+        inherit pname version;
+        sha256 = "sha256-I2+8BeEOPOV0fXtrXdz/eqCj8DFAJTbKmUKy43oiyjE=";
+      };
+      doCheck = false;
+    })
+    numpy
+    termcolor
+    black
+    isort
+    pytorch
+    jax
+    jaxlib
+    tensorflow
+    autograd
+    dataclasses-json
+    pydantic
+    matplotlib
+  ];
+  my-python = pkgs.python3.withPackages my-python-packages;
+  cppad = pkgs.callPackage ./cppad.nix {};
+  adept = pkgs.callPackage ./adept.nix {};
+  GRADBENCH_PATH = builtins.getEnv "PWD";
+in
+pkgs.stdenv.mkDerivation {
+  name = "gradbench";
+  buildInputs =
+    [my-python
+     pkgs.niv
+     pkgs.gh
+     pkgs.cargo
+     pkgs.rustc
+     pkgs.rustfmt
+     pkgs.futhark
+     pkgs.enzyme
+     pkgs.adolc
+     pkgs.pkg-config
+     pkgs.llvmPackages_19.lld
+     pkgs.llvmPackages_19.clang
+     adept
+     cppad
+    ];
+
+  # The following are environment variables used by various tools.
+  PYTHONPATH = "${GRADBENCH_PATH}/python/gradbench";
+  ENZYME_LIB = "${pkgs.enzyme}/lib";
+  LD_LIBRARY_PATH = "${pkgs.stdenv.cc.cc.lib}/lib";
+}

--- a/tools/enzyme/Dockerfile
+++ b/tools/enzyme/Dockerfile
@@ -21,6 +21,10 @@ RUN apt-get install -y \
 COPY python /home/gradbench/python
 ENV PYTHONPATH=/home/gradbench/python/gradbench
 
+# Set clang
+RUN update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-19 100
+RUN update-alternatives --install /usr/bin/lld lld /usr/bin/lld-19 100
+
 # Install Enzyme
 RUN wget https://github.com/EnzymeAD/Enzyme/archive/refs/tags/v${ENZYME_VER}.tar.gz
 RUN tar xvf v${ENZYME_VER}.tar.gz && rm -f v${ENZYME_VER}.tar.gz

--- a/tools/enzyme/Makefile
+++ b/tools/enzyme/Makefile
@@ -1,9 +1,10 @@
-CXX=clang++-19
-LLD=lld-19
+CXX=clang++
+LLD=lld
 CXXFLAGS=-std=c++17 -O3 -fno-math-errno -Wall -flto
 LDFLAGS=-fuse-ld=$(LLD) -O3 -fno-math-errno -flto -Wl,--load-pass-plugin=$(LLDENZYME) -lm
 
-LLDENZYME=/home/gradbench/enzyme-build/Enzyme/LLDEnzyme-19.so
+ENZYME_LIB?=/home/gradbench/enzyme-build/Enzyme/
+LLDENZYME=$(ENZYME_LIB)/LLDEnzyme-19.so
 
 UTIL_OBJECTS=../../cpp/adbench/shared/utils.o ../../cpp/adbench/io.o
 HELLO_OBJECTS=EnzymeHello.o run_hello.o


### PR DESCRIPTION
This is useful for people who don't want to run everything inside Docker, but still want some measure of a predictable environment.

Also slightly modifies Enzyme to make it run well both within Docker and Nix.

This shell.nix does not pin Nixpkgs, which is strictly speaking not ideal, but pinning would just add an extra maintenance burden. I'll add pinning if/when I regret not doing so in the first place, or when others also start using this shell.nix.