### PR TITLE
List tool before eval in `run` matrix

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -134,8 +134,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        eval: ${{ fromJSON(needs.matrix.outputs.eval) }}
         tool: ${{ fromJSON(needs.matrix.outputs.tool) }}
+        eval: ${{ fromJSON(needs.matrix.outputs.eval) }}
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout

--- a/crates/gradbench/src/main.rs
+++ b/crates/gradbench/src/main.rs
@@ -965,11 +965,11 @@ fn github_output(name: &str, value: impl Serialize) -> Result<(), ExitCode> {
 /// A single entry in the `run` matrix for GitHub Actions.
 #[derive(Serialize)]
 struct RunEntry<'a> {
-    /// The name of the eval.
-    eval: &'a str,
-
     /// The name of the tool.
     tool: &'a str,
+
+    /// The name of the eval.
+    eval: &'a str,
 
     /// The expected outcome of the run.
     outcome: &'static str,
@@ -1162,8 +1162,8 @@ fn cli_result() -> Result<(), ExitCode> {
                         let supported: HashSet<&str> = evals_list.lines().collect();
                         for eval in &evals {
                             run.push(RunEntry {
-                                eval,
                                 tool,
+                                eval,
                                 outcome: if supported.contains(eval.as_str()) {
                                     "success"
                                 } else {


### PR DESCRIPTION
Following up on #247 to make the list of jobs a bit easier to read.