### PR TITLE
Remove Ionide from VS Code extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,7 +1,6 @@
 {
   "recommendations": [
     "esbenp.prettier-vscode",
-    "ionide.ionide-fsharp",
     "julialang.language-julia",
     "leanprover.lean",
     "ms-python.black-formatter",


### PR DESCRIPTION
No longer relevant as of #239.