### PR TITLE
Put `tools/futhark/lib` in `.dockerignore`

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+tools/futhark/lib


### PR DESCRIPTION
Before this change, I couldn't build the Futhark Docker image locally; for instance, on commit cc5d4b224d96900eaa25539464637951f975539f:

```
$ ./gradbench repo build-tool futhark
[+] Building 16.9s (15/16)                                                                                                           docker:desktop-linux
 => [internal] load build definition from Dockerfile                                                                                                 0.0s
 => => transferring dockerfile: 789B                                                                                                                 0.0s
 => [internal] load metadata for docker.io/library/python:3.11-slim                                                                                  0.4s
 => [internal] load .dockerignore                                                                                                                    0.0s
 => => transferring context: 2B                                                                                                                      0.0s
 => [ 1/11] FROM docker.io/library/python:3.11-slim@sha256:42420f737ba91d509fc60d5ed65ed0492678a90c561e1fa08786ae8ba8b52eda                          0.0s
 => => resolve docker.io/library/python:3.11-slim@sha256:42420f737ba91d509fc60d5ed65ed0492678a90c561e1fa08786ae8ba8b52eda                            0.0s
 => [internal] load build context                                                                                                                    0.0s
 => => transferring context: 11.46kB                                                                                                                 0.0s
 => [ 5/11] ADD https://futhark-lang.org/releases/futhark-0.25.23-linux-x86_64.tar.xz futhark-0.25.23-linux-x86_64.tar.xz                           14.4s
 => CACHED [ 2/11] RUN apt update                                                                                                                    0.0s
 => CACHED [ 3/11] RUN apt install -y xz-utils build-essential git                                                                                   0.0s
 => CACHED [ 4/11] RUN pip install futhark-data futhark-server dataclasses-json                                                                      0.0s
 => CACHED [ 5/11] ADD https://futhark-lang.org/releases/futhark-0.25.23-linux-x86_64.tar.xz futhark-0.25.23-linux-x86_64.tar.xz                     0.0s
 => CACHED [ 6/11] RUN tar xvf futhark-0.25.23-linux-x86_64.tar.xz                                                                                   0.0s
 => CACHED [ 7/11] RUN make -C futhark-0.25.23-linux-x86_64 install                                                                                  0.0s
 => CACHED [ 8/11] COPY python /home/gradbench/python                                                                                                0.0s
 => CACHED [ 9/11] COPY tools/futhark /home/gradbench/tools/futhark                                                                                  0.0s
 => ERROR [10/11] RUN cd /home/gradbench/tools/futhark && futhark pkg sync                                                                           2.1s
------                                                                                                                                                    
 > [10/11] RUN cd /home/gradbench/tools/futhark && futhark pkg sync:
2.085 futhark: renameDirectory:renamePath:rename 'lib' to 'lib~old': unsupported operation (Invalid cross-device link)
------
Dockerfile:18
--------------------
  16 |     
  17 |     COPY tools/futhark /home/gradbench/tools/futhark
  18 | >>> RUN cd /home/gradbench/tools/futhark && futhark pkg sync
  19 |     
  20 |     WORKDIR /home/gradbench
--------------------
ERROR: failed to solve: process "/bin/sh -c cd /home/gradbench/tools/futhark && futhark pkg sync" did not complete successfully: exit code: 1
```