### PR TITLE
Prevent race condition in CI/CD

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ on:
       - main
 
 concurrency:
-  group: ${{ github.event.pull_request.number || github.sha }}
+  group: ${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -5,6 +5,9 @@ on:
     - cron: "0 1 * * *"
   workflow_dispatch:
 
+concurrency:
+  group: nightly
+
 permissions:
   contents: write
   packages: write


### PR DESCRIPTION
This PR effectively just undoes #84. Currently, `main` CI has a bit of a race condition in the `deploy` job, and it's about to get a much more significant race condition in the `stats` job added by #270. I don't remember exactly what was the behavior when I did #84, but if it was that only the most recent workflow run gets queued up while waiting for the current one, that seems good; the bad scenario would be where _multiple_ workflow runs queue up serially, in which case I'll revisit this.