### PR TITLE
Don't install PyTorch in eval Docker images

### DIFF
--- a/evals/ba/Dockerfile
+++ b/evals/ba/Dockerfile
@@ -4,8 +4,7 @@ RUN apt-get update && apt-get install -y \
     build-essential \
     wget
 
-RUN pip install numpy==1.26.0 pydantic && \
-    pip install torch --index-url https://download.pytorch.org/whl/cpu
+RUN pip install numpy==1.26.0 pydantic
 
 WORKDIR /home/gradbench
 

--- a/evals/gmm/Dockerfile
+++ b/evals/gmm/Dockerfile
@@ -4,8 +4,7 @@ RUN apt-get update && apt-get install -y \
     build-essential \
     wget
 
-RUN pip install numpy==1.26.0 pydantic scipy && \
-    pip install torch --index-url https://download.pytorch.org/whl/cpu
+RUN pip install numpy==1.26.0 pydantic scipy
 
 WORKDIR /home/gradbench
 

--- a/evals/ht/Dockerfile
+++ b/evals/ht/Dockerfile
@@ -4,8 +4,7 @@ RUN apt-get update && apt-get install -y \
     build-essential \
     wget
 
-RUN pip install numpy==1.26.0 pydantic dataclasses-json && \
-    pip install torch --index-url https://download.pytorch.org/whl/cpu
+RUN pip install numpy==1.26.0 pydantic dataclasses-json
 
 WORKDIR /home/gradbench
 

--- a/evals/kmeans/Dockerfile
+++ b/evals/kmeans/Dockerfile
@@ -4,8 +4,7 @@ RUN apt-get update && apt-get install -y \
     build-essential \
     wget
 
-RUN pip install numpy==1.26.0 pydantic dataclasses-json && \
-    pip install torch --index-url https://download.pytorch.org/whl/cpu
+RUN pip install numpy==1.26.0 pydantic dataclasses-json
 
 WORKDIR /home/gradbench
 

--- a/evals/lstm/Dockerfile
+++ b/evals/lstm/Dockerfile
@@ -4,8 +4,7 @@ RUN apt-get update && apt-get install -y \
     build-essential \
     wget
 
-RUN pip install numpy==1.26.0 pydantic dataclasses-json && \
-    pip install torch --index-url https://download.pytorch.org/whl/cpu
+RUN pip install numpy==1.26.0 pydantic dataclasses-json
 
 WORKDIR /home/gradbench
 


### PR DESCRIPTION
Following up on #264, these images shouldn't need PyTorch at all anymore.