### PR TITLE
Add workflow to automatically delete CI branches

### DIFF
--- a/.github/workflows/delete-branches.yml
+++ b/.github/workflows/delete-branches.yml
@@ -1,0 +1,22 @@
+name: Delete branches
+on:
+  schedule:
+    # same as the nightly workflow
+    - cron: "0 1 * * *"
+  workflow_dispatch:
+
+jobs:
+  ci:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      # https://stackoverflow.com/a/27393574
+      - name: Track CI branches
+        run: git remote set-branches origin 'ci/refs/pull/*/merge'
+      - name: Checkout CI branches
+        run: git fetch --depth=1
+      # https://stackoverflow.com/q/3670355
+      - name: Delete CI branches
+        # we use a colon instead of `--delete`, in case there are zero
+        run: git for-each-ref --format=':%(refname:lstrip=3)' 'refs/remotes/origin/ci/refs/pull/*/merge' | xargs -d '\n' git push origin


### PR DESCRIPTION
Based off of penrose/penrose#1375, going along with #270. We only really need the _commits_ in those branches; the branch itself is just used when pushing the generated commit.