### PR TITLE
Build CLI for musl

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,12 +79,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Build CLI
-        run: cargo build --package gradbench --release
+        uses: houseabsolute/actions-rust-cross@v1
+        with:
+          target: x86_64-unknown-linux-musl
+          args: --package gradbench --release
       - name: Upload CLI as artifact
         uses: actions/upload-artifact@v4
         with:
           name: cli
-          path: target/release/gradbench
+          path: target/x86_64-unknown-linux-musl/release/gradbench
 
   windows:
     runs-on: windows-2022

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -19,12 +19,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Build CLI
-        run: cargo build --release
+        uses: houseabsolute/actions-rust-cross@v1
+        with:
+          target: x86_64-unknown-linux-musl
+          args: --package gradbench --release
       - name: Upload CLI as artifact
         uses: actions/upload-artifact@v4
         with:
           name: cli
-          path: target/release/gradbench
+          path: target/x86_64-unknown-linux-musl/release/gradbench
 
   matrix:
     needs: cli


### PR DESCRIPTION
Seeing the build fail in #270 after bumping the Ubuntu version in #280 made me think that it'd be nice to build fully a static binary in CI (not that that'd actually have prevented those build failures, of course). Not sure why I didn't do this before.