### PR TITLE
Don't use `cursor: pointer` for unclickables

### DIFF
--- a/packages/gradbench/src/App.css
+++ b/packages/gradbench/src/App.css
@@ -21,13 +21,13 @@ a:link {
 
 .row-header {
   align-items: center;
-  cursor: pointer;
   display: flex;
   font-weight: bold;
   padding: 5px;
 }
 
 .header-clickable {
+  cursor: pointer;
   text-decoration: underline;
 }
 


### PR DESCRIPTION
Quick followup on #270, making it so we only use [`cursor: pointer`](https://developer.mozilla.org/en-US/docs/Web/CSS/cursor) for row headers that are actually clickable.