### PR TITLE
Limit Jax to a single thread

### DIFF
--- a/tools/jax/Dockerfile
+++ b/tools/jax/Dockerfile
@@ -7,5 +7,5 @@ WORKDIR /home/gradbench
 COPY python /home/gradbench/python
 ENV PYTHONPATH=/home/gradbench/python/gradbench
 
-ENTRYPOINT ["python", "/home/gradbench/python/gradbench/gradbench/jax/run.py"]
+ENTRYPOINT ["taskset", "-c", "1", "python", "/home/gradbench/python/gradbench/gradbench/jax/run.py"]
 LABEL org.opencontainers.image.source=https://github.com/gradbench/gradbench


### PR DESCRIPTION
This is enforced via taskset in the Docker container itself, so it won't apply if you run Jax directly.

Surprisingly, Jax does not seem to have an obvious API to control parallel execution.