### PR TITLE
intermediary: show microseconds

### DIFF
--- a/crates/gradbench/src/intermediary.rs
+++ b/crates/gradbench/src/intermediary.rs
@@ -71,11 +71,11 @@ fn nanostring(nanoseconds: u128) -> String {
     let sec = ms / 1000;
     let min = sec / 60;
     if ms == 0 {
-        format!("{:2} {:2} {:3} μs", "", "", us)
+        format!("{:2} {:2} {:3}μs", "", "", us)
     } else if sec == 0 && ms < 100 {
-        format!("{:2} {:2}.{:03} ms", "", ms, us % 1000)
+        format!("{:2} {:2}.{:03}ms", "", ms, us % 1000)
     } else if sec == 0 {
-        format!("{:2} {:2} {:03} ms", "", "", ms)
+        format!("{:2} {:2} {:3}ms", "", "", ms)
     } else if min == 0 {
         format!("{:2} {:2}.{:03} s", "", sec, ms % 1000)
     } else if min < 60 {
@@ -448,17 +448,17 @@ mod tests {
 
     #[test]
     fn test_nanostring_0() {
-        nanostring_test("        0ms", Duration::ZERO);
+        nanostring_test("       0μs", Duration::ZERO);
     }
 
     #[test]
     fn test_nanostring_999_microseconds() {
-        nanostring_test("        0ms", Duration::from_micros(999));
+        nanostring_test("     999μs", Duration::from_micros(999));
     }
 
     #[test]
     fn test_nanostring_1_millisecond() {
-        nanostring_test("        1ms", Duration::from_millis(1));
+        nanostring_test("    1.000ms", Duration::from_millis(1));
     }
 
     #[test]

--- a/crates/gradbench/src/intermediary.rs
+++ b/crates/gradbench/src/intermediary.rs
@@ -66,11 +66,16 @@ const WIDTH_DESCRIPTION: usize = 15;
 
 /// Return an 11-character human-readable string for the given number of nanoseconds.
 fn nanostring(nanoseconds: u128) -> String {
-    let ms = nanoseconds / 1_000_000;
+    let us = nanoseconds / 1000;
+    let ms = us / 1000;
     let sec = ms / 1000;
     let min = sec / 60;
-    if sec == 0 {
-        format!("{:2} {:2} {:3}ms", "", "", ms)
+    if ms == 0 {
+        format!("{:2} {:2} {:3} μs", "", "", us)
+    } else if sec == 0 && ms < 100 {
+        format!("{:2} {:2}.{:03} ms", "", ms, us % 1000)
+    } else if sec == 0 {
+        format!("{:2} {:2} {:03} ms", "", "", ms)
     } else if min == 0 {
         format!("{:2} {:2}.{:03} s", "", sec, ms % 1000)
     } else if min < 60 {

--- a/crates/gradbench/src/intermediary.rs
+++ b/crates/gradbench/src/intermediary.rs
@@ -71,7 +71,7 @@ fn nanostring(nanoseconds: u128) -> String {
     let sec = ms / 1000;
     let min = sec / 60;
     if ms == 0 {
-        format!("{:2} {:2} {:3}μs", "", "", us)
+        format!("{:2} {:2} {:3}us", "", "", us)
     } else if sec == 0 && ms < 100 {
         format!("{:2} {:2}.{:03}ms", "", ms, us % 1000)
     } else if sec == 0 {
@@ -448,12 +448,12 @@ mod tests {
 
     #[test]
     fn test_nanostring_0() {
-        nanostring_test("       0μs", Duration::ZERO);
+        nanostring_test("        0us", Duration::ZERO);
     }
 
     #[test]
     fn test_nanostring_999_microseconds() {
-        nanostring_test("     999μs", Duration::from_micros(999));
+        nanostring_test("      999us", Duration::from_micros(999));
     }
 
     #[test]

--- a/crates/gradbench/src/intermediary.rs
+++ b/crates/gradbench/src/intermediary.rs
@@ -71,7 +71,7 @@ fn nanostring(nanoseconds: u128) -> String {
     let sec = ms / 1000;
     let min = sec / 60;
     if ms == 0 {
-        format!("{:2} {:2} {:3}us", "", "", us)
+        format!("{:2} {:2} {:3}μs", "", "", us)
     } else if sec == 0 && ms < 100 {
         format!("{:2} {:2}.{:03}ms", "", ms, us % 1000)
     } else if sec == 0 {
@@ -442,18 +442,18 @@ mod tests {
     };
 
     fn nanostring_test(expected: &str, duration: Duration) {
-        assert_eq!(expected.len(), 11);
+        assert_eq!(expected.chars().count(), 11);
         assert_eq!(nanostring(duration.as_nanos()), expected);
     }
 
     #[test]
     fn test_nanostring_0() {
-        nanostring_test("        0us", Duration::ZERO);
+        nanostring_test("        0μs", Duration::ZERO);
     }
 
     #[test]
     fn test_nanostring_999_microseconds() {
-        nanostring_test("      999us", Duration::from_micros(999));
+        nanostring_test("      999μs", Duration::from_micros(999));
     }
 
     #[test]

--- a/crates/gradbench/src/outputs/define_error.txt
+++ b/crates/gradbench/src/outputs/define_error.txt
@@ -1,3 +1,3 @@
   [0] start
-  [1] def   foo                                     0us ✗
+  [1] def   foo                                     0μs ✗
 never heard of foo

--- a/crates/gradbench/src/outputs/define_error.txt
+++ b/crates/gradbench/src/outputs/define_error.txt
@@ -1,3 +1,3 @@
   [0] start
-  [1] def   foo                                     0μs ✗
+  [1] def   foo                                     0us ✗
 never heard of foo

--- a/crates/gradbench/src/outputs/define_error.txt
+++ b/crates/gradbench/src/outputs/define_error.txt
@@ -1,3 +1,3 @@
   [0] start
-  [1] def   foo                                     0ms ✗
+  [1] def   foo                                     0μs ✗
 never heard of foo

--- a/crates/gradbench/src/outputs/define_success_error.txt
+++ b/crates/gradbench/src/outputs/define_success_error.txt
@@ -1,4 +1,4 @@
   [0] start
-  [1] def   foo                                     0us ✓
+  [1] def   foo                                     0μs ✓
 all good!
 tool reported success but gave an error

--- a/crates/gradbench/src/outputs/define_success_error.txt
+++ b/crates/gradbench/src/outputs/define_success_error.txt
@@ -1,4 +1,4 @@
   [0] start
-  [1] def   foo                                     0μs ✓
+  [1] def   foo                                     0us ✓
 all good!
 tool reported success but gave an error

--- a/crates/gradbench/src/outputs/define_success_error.txt
+++ b/crates/gradbench/src/outputs/define_success_error.txt
@@ -1,4 +1,4 @@
   [0] start
-  [1] def   foo                                     0ms ✓
+  [1] def   foo                                     0μs ✓
 all good!
 tool reported success but gave an error

--- a/crates/gradbench/src/outputs/define_timings.txt
+++ b/crates/gradbench/src/outputs/define_timings.txt
@@ -1,2 +1,2 @@
   [0] start
-  [1] def   foo                                    40ms ~        10ms busywork ✓
+  [1] def   foo                                40.000ms ~    10.000ms busywork ✓

--- a/crates/gradbench/src/outputs/evaluate_error.txt
+++ b/crates/gradbench/src/outputs/evaluate_error.txt
@@ -1,4 +1,4 @@
   [0] start
-  [1] def   foo                                     0us ✓
-  [2] eval  foo::bar        42                      0us ✗
+  [1] def   foo                                     0μs ✓
+  [2] eval  foo::bar        42                      0μs ✗
 foobar failure

--- a/crates/gradbench/src/outputs/evaluate_error.txt
+++ b/crates/gradbench/src/outputs/evaluate_error.txt
@@ -1,4 +1,4 @@
   [0] start
-  [1] def   foo                                     0ms ✓
-  [2] eval  foo::bar        42                      0ms ✗
+  [1] def   foo                                     0μs ✓
+  [2] eval  foo::bar        42                      0μs ✗
 foobar failure

--- a/crates/gradbench/src/outputs/evaluate_error.txt
+++ b/crates/gradbench/src/outputs/evaluate_error.txt
@@ -1,4 +1,4 @@
   [0] start
-  [1] def   foo                                     0μs ✓
-  [2] eval  foo::bar        42                      0μs ✗
+  [1] def   foo                                     0us ✓
+  [2] eval  foo::bar        42                      0us ✗
 foobar failure

--- a/crates/gradbench/src/outputs/evaluate_success_error.txt
+++ b/crates/gradbench/src/outputs/evaluate_success_error.txt
@@ -1,5 +1,5 @@
   [0] start
-  [1] def   foo                                     0μs ✓
-  [2] eval  foo::bar        42                      0μs ✗
+  [1] def   foo                                     0us ✓
+  [2] eval  foo::bar        42                      0us ✗
 foobar all good
 tool reported success but gave an error

--- a/crates/gradbench/src/outputs/evaluate_success_error.txt
+++ b/crates/gradbench/src/outputs/evaluate_success_error.txt
@@ -1,5 +1,5 @@
   [0] start
-  [1] def   foo                                     0us ✓
-  [2] eval  foo::bar        42                      0us ✗
+  [1] def   foo                                     0μs ✓
+  [2] eval  foo::bar        42                      0μs ✗
 foobar all good
 tool reported success but gave an error

--- a/crates/gradbench/src/outputs/evaluate_success_error.txt
+++ b/crates/gradbench/src/outputs/evaluate_success_error.txt
@@ -1,5 +1,5 @@
   [0] start
-  [1] def   foo                                     0ms ✓
-  [2] eval  foo::bar        42                      0ms ✗
+  [1] def   foo                                     0μs ✓
+  [2] eval  foo::bar        42                      0μs ✗
 foobar all good
 tool reported success but gave an error

--- a/crates/gradbench/src/outputs/evaluate_success_no_output.txt
+++ b/crates/gradbench/src/outputs/evaluate_success_no_output.txt
@@ -1,4 +1,4 @@
   [0] start
-  [1] def   foo                                     0μs ✓
-  [2] eval  foo::bar        42                      0μs
+  [1] def   foo                                     0us ✓
+  [2] eval  foo::bar        42                      0us
 tool reported success but gave no output

--- a/crates/gradbench/src/outputs/evaluate_success_no_output.txt
+++ b/crates/gradbench/src/outputs/evaluate_success_no_output.txt
@@ -1,4 +1,4 @@
   [0] start
-  [1] def   foo                                     0ms ✓
-  [2] eval  foo::bar        42                      0ms
+  [1] def   foo                                     0μs ✓
+  [2] eval  foo::bar        42                      0μs
 tool reported success but gave no output

--- a/crates/gradbench/src/outputs/evaluate_success_no_output.txt
+++ b/crates/gradbench/src/outputs/evaluate_success_no_output.txt
@@ -1,4 +1,4 @@
   [0] start
-  [1] def   foo                                     0us ✓
-  [2] eval  foo::bar        42                      0us
+  [1] def   foo                                     0μs ✓
+  [2] eval  foo::bar        42                      0μs
 tool reported success but gave no output

--- a/crates/gradbench/src/outputs/evaluate_success_null_output.txt
+++ b/crates/gradbench/src/outputs/evaluate_success_null_output.txt
@@ -1,3 +1,3 @@
   [0] start
-  [1] def   foo                                     0μs ✓
-  [2] eval  foo::null       null                    0μs ✓
+  [1] def   foo                                     0us ✓
+  [2] eval  foo::null       null                    0us ✓

--- a/crates/gradbench/src/outputs/evaluate_success_null_output.txt
+++ b/crates/gradbench/src/outputs/evaluate_success_null_output.txt
@@ -1,3 +1,3 @@
   [0] start
-  [1] def   foo                                     0ms ✓
-  [2] eval  foo::null       null                    0ms ✓
+  [1] def   foo                                     0μs ✓
+  [2] eval  foo::null       null                    0μs ✓

--- a/crates/gradbench/src/outputs/evaluate_success_null_output.txt
+++ b/crates/gradbench/src/outputs/evaluate_success_null_output.txt
@@ -1,3 +1,3 @@
   [0] start
-  [1] def   foo                                     0us ✓
-  [2] eval  foo::null       null                    0us ✓
+  [1] def   foo                                     0μs ✓
+  [2] eval  foo::null       null                    0μs ✓

--- a/crates/gradbench/src/outputs/readme_example.txt
+++ b/crates/gradbench/src/outputs/readme_example.txt
@@ -1,5 +1,5 @@
   [0] start
-  [1] def   foo                                     4ms ✓
-  [2] eval  foo::bar        3.1415926535...         6ms ~         5ms evaluate ✗
+  [1] def   foo                                 4.000ms ✓
+  [2] eval  foo::bar        3.1415926535...     6.000ms ~     5.000ms evaluate ✗
 Expected tau, got e.
-  [4] eval  foo::baz        {"mynumber":...        10ms ~         7ms evaluate ✓
+  [4] eval  foo::baz        {"mynumber":...    10.000ms ~     7.000ms evaluate ✓

--- a/crates/gradbench/src/outputs/timeout.txt
+++ b/crates/gradbench/src/outputs/timeout.txt
@@ -1,3 +1,3 @@
   [0] start
-  [1] def   foo                                     0ms ✓
-  [2] eval  foo::bar        null                    0ms ⧖
+  [1] def   foo                                     0μs ✓
+  [2] eval  foo::bar        null                    0μs ⧖

--- a/crates/gradbench/src/outputs/timeout.txt
+++ b/crates/gradbench/src/outputs/timeout.txt
@@ -1,3 +1,3 @@
   [0] start
-  [1] def   foo                                     0μs ✓
-  [2] eval  foo::bar        null                    0μs ⧖
+  [1] def   foo                                     0us ✓
+  [2] eval  foo::bar        null                    0us ⧖

--- a/crates/gradbench/src/outputs/timeout.txt
+++ b/crates/gradbench/src/outputs/timeout.txt
@@ -1,3 +1,3 @@
   [0] start
-  [1] def   foo                                     0us ✓
-  [2] eval  foo::bar        null                    0us ⧖
+  [1] def   foo                                     0μs ✓
+  [2] eval  foo::bar        null                    0μs ⧖


### PR DESCRIPTION
This somewhat arbitrarily switches from writing milisecond-level numbers as 'xy.abc ms' to just ' xy ms' at 100 ms. This is supposed to ease the eyeballing of microsecond-level timings with milisecond-level timings, but there is going to be some kind of cut, unless we simply always print second-level timing with six digits (essentially using microseconds as our base unit).

This fixes #304.