### PR TITLE
Use 2021 edition of Rust

### DIFF
--- a/crates/gradbench-floretta/Cargo.toml
+++ b/crates/gradbench-floretta/Cargo.toml
@@ -2,7 +2,7 @@
 name = "gradbench-floretta"
 version = "0.0.0"
 publish = false
-edition = "2024"
+edition = "2021"
 
 [dependencies]
 floretta = "0.4"

--- a/crates/gradbench/Cargo.toml
+++ b/crates/gradbench/Cargo.toml
@@ -4,7 +4,7 @@ description = "Benchmarks for differentiable programming across languages and do
 version = "0.0.0"
 license = "MIT"
 repository = "https://github.com/gradbench/gradbench"
-edition = "2024"
+edition = "2021"
 default-run = "gradbench"
 
 [dependencies]


### PR DESCRIPTION
Not all package systems yet have a compiler with Rust 2024 support (it was released about two weeks ago).