### PR TITLE
Improve kmeans::objective

### DIFF
--- a/cpp/gradbench/evals/kmeans.hpp
+++ b/cpp/gradbench/evals/kmeans.hpp
@@ -17,18 +17,15 @@ T euclid_dist_2(int d, T const *a, T const *b) {
 
 template<typename T>
 void objective(int n, int k, int d,
-               T const *points, T const *centroids,
-               T* err) {
+               T const * __restrict__ points, T const * __restrict__ centroids,
+               T* __restrict__ err) {
   T cost = 0;
   for (int i = 0; i < n; i++) {
     T const *a = &points[i*d];
     T closest = INFINITY;
     for (int j = 0; j < k; j++) {
       T const *b = &centroids[j*d];
-      T dist = euclid_dist_2(d, a, b);
-      if (dist < closest) {
-        closest = dist;
-      }
+      closest = std::min(closest, euclid_dist_2(d, a, b));
     }
     cost += closest;
   }


### PR DESCRIPTION
The `__restrict__` annotations significantly help Enzyme. The use of std::min could theoretically help tools based on operator overloading, but I don't have any clear evidence that it does. It does make the code look slightly nicer.