### PR TITLE
Enable Ruff lints

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,4 +24,4 @@ gradbench = { workspace = true }
 members = ["python/*"]
 
 [tool.ruff.lint]
-select = ["I"]
+extend-select = ["I"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,4 +24,4 @@ gradbench = { workspace = true }
 members = ["python/*"]
 
 [tool.ruff.lint]
-extend-select = ["I"]
+extend-select = ["I", "RUF"]

--- a/python/gradbench/gradbench/adbench/ba_data.py
+++ b/python/gradbench/gradbench/adbench/ba_data.py
@@ -6,6 +6,7 @@
 """
 Changes Made:
 - Reformatted all "np.ndarray = field(default = np.empty(0, dtype = np.float64))" to "np.ndarray = field(default_factory=lambda: np.empty(0, dtype=np.float64))"
+- Removed `save_output_to_file` method
 """
 
 from dataclasses import dataclass, field
@@ -30,14 +31,3 @@ class BAOutput:
     )
     w_err: np.ndarray = field(default_factory=lambda: np.empty(0, dtype=np.float64))
     J: BASparseMat = field(default=BASparseMat())
-
-    def save_output_to_file(self, output_prefix, input_basename, module_basename):
-        save_errors_to_file(
-            objective_file_name(output_prefix, input_basename, module_basename),
-            self.reproj_err,
-            self.w_err,
-        )
-
-        save_sparse_j_to_file(
-            jacobian_file_name(output_prefix, input_basename, module_basename), self.J
-        )

--- a/python/gradbench/gradbench/adbench/defs.py
+++ b/python/gradbench/gradbench/adbench/defs.py
@@ -3,8 +3,7 @@
 
 # https://github.com/microsoft/ADBench/blob/38cb7931303a830c3700ca36ba9520868327ac87/src/python/shared/defs.py
 
-from dataclasses import dataclass, field
-from typing import Tuple
+from dataclasses import dataclass
 
 from numpy import float64, int32
 

--- a/python/gradbench/gradbench/adbench/ht_data.py
+++ b/python/gradbench/gradbench/adbench/ht_data.py
@@ -7,6 +7,7 @@
 Changes Made:
 - Changed default= to default_factory in data classes.
 - Added dataclass_json decorators.
+- Removed `save_output_to_file` method.
 """
 
 from dataclasses import dataclass, field
@@ -108,17 +109,6 @@ class HandOutput:
         default_factory=lambda: np.empty(0, dtype=np.float64),
         metadata=config(encoder=lambda x: x.tolist(), decoder=np.asarray),
     )
-
-    def save_output_to_file(self, output_prefix, input_basename, module_basename):
-        save_vector_to_file(
-            objective_file_name(output_prefix, input_basename, module_basename),
-            self.objective,
-        )
-
-        save_jacobian_to_file(
-            jacobian_file_name(output_prefix, input_basename, module_basename),
-            self.jacobian,
-        )
 
 
 @dataclass_json

--- a/python/gradbench/gradbench/comparison.py
+++ b/python/gradbench/gradbench/comparison.py
@@ -32,7 +32,7 @@ def compare_json_objects(expected, actual, tolerance=1e-4, path=""):
     if type(expected) is float and type(actual) is int:
         actual = float(actual)
 
-    if type(expected) != type(actual):
+    if type(expected) != type(actual):  # noqa: E721
         mismatches.append(
             f"{path}: expected value of type {type(expected)}, got value of type {type(actual)}"
         )

--- a/python/gradbench/gradbench/cpp_main.py
+++ b/python/gradbench/gradbench/cpp_main.py
@@ -37,7 +37,7 @@ def functions(pathname: str, functions=["objective", "jacobian"]):
     provide = {}
     provide["compile"] = compile
 
-    def mk_run(l):
+    def mk_run(l):  # noqa: E741
         def run(input):
             with tempfile.NamedTemporaryFile("w") as tmp:
                 json.dump(input, tmp)

--- a/python/gradbench/gradbench/cpp_run.py
+++ b/python/gradbench/gradbench/cpp_run.py
@@ -3,7 +3,6 @@
 
 import json
 import sys
-import time
 import traceback
 from importlib import import_module
 from pathlib import Path

--- a/python/gradbench/gradbench/eval.py
+++ b/python/gradbench/gradbench/eval.py
@@ -91,7 +91,7 @@ class SingleModuleValidatedEval:
         print(flush=True)
         if message["kind"] == "end":
             return
-        l = sys.stdin.readline()
+        l = sys.stdin.readline()  # noqa: E741
         if l == "":
             raise EOFError
         response = json.loads(l)

--- a/python/gradbench/gradbench/evals/ba/run.py
+++ b/python/gradbench/gradbench/evals/ba/run.py
@@ -5,7 +5,7 @@ from typing import Any
 
 import manual.ba as golden
 from gradbench.comparison import compare_json_objects
-from gradbench.eval import SingleModuleValidatedEval, approve, mismatch
+from gradbench.eval import Analysis, SingleModuleValidatedEval, approve, mismatch
 
 
 def parse(file):

--- a/python/gradbench/gradbench/evals/ba/run.py
+++ b/python/gradbench/gradbench/evals/ba/run.py
@@ -4,10 +4,8 @@ from pathlib import Path
 from typing import Any
 
 import manual.ba as golden
-import numpy as np
 from gradbench.comparison import compare_json_objects
 from gradbench.eval import SingleModuleValidatedEval, approve, mismatch
-from gradbench.wrap import Wrapped
 
 
 def parse(file):

--- a/python/gradbench/gradbench/evals/gmm/data_gen.py
+++ b/python/gradbench/gradbench/evals/gmm/data_gen.py
@@ -68,8 +68,6 @@ def generate(data_uniform, data_normal, D, k, n):
     view_uniform = data_uniform[:]
     view_normal = data_normal[:]
 
-    filename = f"gmm_d{D}_K{k}_N{n}.txt"
-
     output = {}
 
     output["d"] = D

--- a/python/gradbench/gradbench/evals/gmm/run.py
+++ b/python/gradbench/gradbench/evals/gmm/run.py
@@ -4,7 +4,7 @@ from typing import Any
 
 import manual.gmm as golden
 from gradbench.comparison import compare_json_objects
-from gradbench.eval import SingleModuleValidatedEval, approve, mismatch
+from gradbench.eval import Analysis, SingleModuleValidatedEval, approve, mismatch
 from gradbench.evals.gmm import data_gen
 
 

--- a/python/gradbench/gradbench/evals/gmm/run.py
+++ b/python/gradbench/gradbench/evals/gmm/run.py
@@ -1,14 +1,11 @@
 import argparse
 import json
-from pathlib import Path
 from typing import Any
 
 import manual.gmm as golden
-import numpy as np
 from gradbench.comparison import compare_json_objects
 from gradbench.eval import SingleModuleValidatedEval, approve, mismatch
 from gradbench.evals.gmm import data_gen
-from gradbench.wrap import Wrapped
 
 
 def check(function: str, input: Any, output: Any) -> None:

--- a/python/gradbench/gradbench/evals/hello/run.py
+++ b/python/gradbench/gradbench/evals/hello/run.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 from typing import Any
 
 import numpy as np

--- a/python/gradbench/gradbench/evals/ht/run.py
+++ b/python/gradbench/gradbench/evals/ht/run.py
@@ -5,11 +5,9 @@ from pathlib import Path
 from typing import Any
 
 import manual.ht as golden
-import numpy as np
 from gradbench.comparison import compare_json_objects
 from gradbench.eval import SingleModuleValidatedEval, approve, mismatch
 from gradbench.evals.ht import io
-from gradbench.wrap import Wrapped
 
 
 def check(function: str, input: Any, output: Any) -> None:

--- a/python/gradbench/gradbench/evals/ht/run.py
+++ b/python/gradbench/gradbench/evals/ht/run.py
@@ -6,7 +6,7 @@ from typing import Any
 
 import manual.ht as golden
 from gradbench.comparison import compare_json_objects
-from gradbench.eval import SingleModuleValidatedEval, approve, mismatch
+from gradbench.eval import Analysis, SingleModuleValidatedEval, approve, mismatch
 from gradbench.evals.ht import io
 
 

--- a/python/gradbench/gradbench/evals/kmeans/run.py
+++ b/python/gradbench/gradbench/evals/kmeans/run.py
@@ -5,7 +5,7 @@ from typing import Any
 import manual.kmeans as golden
 import numpy as np
 from gradbench.comparison import compare_json_objects
-from gradbench.eval import SingleModuleValidatedEval, mismatch
+from gradbench.eval import Analysis, SingleModuleValidatedEval, mismatch
 
 
 def check(function: str, input: Any, output: Any) -> None:

--- a/python/gradbench/gradbench/evals/kmeans/run.py
+++ b/python/gradbench/gradbench/evals/kmeans/run.py
@@ -1,14 +1,11 @@
 import argparse
-import gzip
 import json
-from pathlib import Path
 from typing import Any
 
 import manual.kmeans as golden
 import numpy as np
 from gradbench.comparison import compare_json_objects
 from gradbench.eval import SingleModuleValidatedEval, mismatch
-from gradbench.wrap import Wrapped
 
 
 def check(function: str, input: Any, output: Any) -> None:

--- a/python/gradbench/gradbench/evals/lstm/io.py
+++ b/python/gradbench/gradbench/evals/lstm/io.py
@@ -40,7 +40,6 @@ def read_lstm_instance(fn):
     line = fid.readline().split()
     layer_count = int(line[0])
     char_count = int(line[1])
-    char_bits = int(line[2])
 
     fid.readline()
     main_params = np.array(

--- a/python/gradbench/gradbench/evals/lstm/run.py
+++ b/python/gradbench/gradbench/evals/lstm/run.py
@@ -5,7 +5,7 @@ from typing import Any
 
 import manual.lstm as golden
 from gradbench.comparison import compare_json_objects
-from gradbench.eval import SingleModuleValidatedEval, approve, mismatch
+from gradbench.eval import Analysis, SingleModuleValidatedEval, approve, mismatch
 from gradbench.evals.lstm import io
 
 
@@ -39,7 +39,7 @@ def main():
     if e.define().success:
         data_root = Path("evals/lstm/data")  # assumes cwd is set correctly
 
-        for l in args.l:
+        for l in args.l:  # noqa: E741
             for c in args.c:
                 fn = next(data_root.glob(f"lstm_l{l}_c{c}.txt"), None)
                 input = io.read_lstm_instance(fn).to_dict()

--- a/python/gradbench/gradbench/evals/lstm/run.py
+++ b/python/gradbench/gradbench/evals/lstm/run.py
@@ -4,11 +4,9 @@ from pathlib import Path
 from typing import Any
 
 import manual.lstm as golden
-import numpy as np
 from gradbench.comparison import compare_json_objects
 from gradbench.eval import SingleModuleValidatedEval, approve, mismatch
 from gradbench.evals.lstm import io
-from gradbench.wrap import Wrapped
 
 
 def check(function: str, input: Any, output: Any) -> None:

--- a/python/gradbench/gradbench/tools/autograd/run.py
+++ b/python/gradbench/gradbench/tools/autograd/run.py
@@ -27,7 +27,7 @@ def main():
             try:
                 import_module(message["module"])
                 response["success"] = True
-            except:
+            except:  # noqa: E722
                 response["success"] = False
         print(json.dumps({"id": message["id"]} | response), flush=True)
 

--- a/python/gradbench/gradbench/tools/jax/gmm.py
+++ b/python/gradbench/gradbench/tools/jax/gmm.py
@@ -1,12 +1,12 @@
 import jax
 import numpy as np
-
-jax.config.update("jax_enable_x64", True)
 from gradbench import wrap
 from gradbench.adbench.defs import Wishart
 from gradbench.adbench.gmm_data import GMMInput
 from gradbench.tools.jax.gmm_objective import gmm_objective
 from jax import grad, jit
+
+jax.config.update("jax_enable_x64", True)
 
 
 @jit

--- a/python/gradbench/gradbench/tools/jax/gmm.py
+++ b/python/gradbench/gradbench/tools/jax/gmm.py
@@ -2,7 +2,6 @@ import jax
 import numpy as np
 
 jax.config.update("jax_enable_x64", True)
-import jax.numpy as jnp
 from gradbench import wrap
 from gradbench.adbench.defs import Wishart
 from gradbench.adbench.gmm_data import GMMInput

--- a/python/gradbench/gradbench/tools/jax/kmeans.py
+++ b/python/gradbench/gradbench/tools/jax/kmeans.py
@@ -1,10 +1,10 @@
 import jax
-
-jax.config.update("jax_enable_x64", True)
 import jax.numpy as jnp
 import numpy as np
 from gradbench import wrap
 from jax import grad, jit, jvp
+
+jax.config.update("jax_enable_x64", True)
 
 
 def costfun(points, centers):

--- a/python/gradbench/gradbench/tools/mygrad/run.py
+++ b/python/gradbench/gradbench/tools/mygrad/run.py
@@ -27,7 +27,7 @@ def main():
             try:
                 import_module(message["module"])
                 response["success"] = True
-            except:
+            except:  # noqa: E722
                 response["success"] = False
         print(json.dumps({"id": message["id"]} | response), flush=True)
 

--- a/python/gradbench/gradbench/tools/pytorch/ba.py
+++ b/python/gradbench/gradbench/tools/pytorch/ba.py
@@ -30,7 +30,6 @@ Changes Made:
 - Added a function to create BA input based on data provided in files
 """
 
-
 import numpy as np
 import torch
 from gradbench import wrap

--- a/python/gradbench/gradbench/tools/pytorch/ba.py
+++ b/python/gradbench/gradbench/tools/pytorch/ba.py
@@ -30,12 +30,11 @@ Changes Made:
 - Added a function to create BA input based on data provided in files
 """
 
-import signal
 
 import numpy as np
 import torch
 from gradbench import wrap
-from gradbench.adbench.ba_data import BAInput, BAOutput
+from gradbench.adbench.ba_data import BAInput
 from gradbench.adbench.ba_sparse_mat import BASparseMat
 from gradbench.adbench.itest import ITest
 from gradbench.tools.pytorch.ba_objective import compute_reproj_err, compute_w_err

--- a/python/gradbench/gradbench/tools/pytorch/ba_objective.py
+++ b/python/gradbench/gradbench/tools/pytorch/ba_objective.py
@@ -24,7 +24,7 @@
 
 
 import torch
-from gradbench.adbench.defs import BA_NCAMPARAMS, C_IDX, F_IDX, RAD_IDX, ROT_IDX, X0_IDX
+from gradbench.adbench.defs import C_IDX, F_IDX, RAD_IDX, ROT_IDX, X0_IDX
 
 ######### BA objective in Python (torch) #############
 

--- a/python/gradbench/gradbench/tools/pytorch/gmm.py
+++ b/python/gradbench/gradbench/tools/pytorch/gmm.py
@@ -29,7 +29,6 @@ Changes Made:
 - Import a decorator to convert input and outputs to necessary types
 """
 
-import numpy as np
 import torch
 from gradbench import wrap
 from gradbench.adbench.defs import Wishart
@@ -37,7 +36,6 @@ from gradbench.adbench.gmm_data import GMMInput
 from gradbench.adbench.itest import ITest
 from gradbench.tools.pytorch.gmm_objective import gmm_objective
 from gradbench.tools.pytorch.utils import (
-    to_torch_tensor,
     to_torch_tensors,
     torch_jacobian,
 )

--- a/python/gradbench/gradbench/tools/pytorch/ht_objective.py
+++ b/python/gradbench/gradbench/tools/pytorch/ht_objective.py
@@ -149,7 +149,7 @@ def get_skinned_vertex_positions(
         .transpose(1, 2)
     )
 
-    positions2 = torch.sum(positions * weights.reshape(weights.shape + (1,)), 1)[:, :3]
+    positions2 = torch.sum(positions * weights.reshape((*weights.shape, 1)), 1)[:, :3]
 
     positions3 = apply_global_transform(pose_params, positions2)
 

--- a/python/gradbench/gradbench/tools/pytorch/ht_objective.py
+++ b/python/gradbench/gradbench/tools/pytorch/ht_objective.py
@@ -3,7 +3,6 @@
 
 # https://github.com/microsoft/ADBench/blob/38cb7931303a830c3700ca36ba9520868327ac87/src/python/modules/PyTorch/hand_objective.py
 
-import sys
 
 import torch
 

--- a/python/gradbench/gradbench/tools/pytorch/lstm.py
+++ b/python/gradbench/gradbench/tools/pytorch/lstm.py
@@ -8,11 +8,10 @@ Changes Made:
 - Added two functions to create a PyTorchHand object and call calculate_objective and calculate_jacobian
 """
 
-import numpy as np
 import torch
 from gradbench import wrap
 from gradbench.adbench.itest import ITest
-from gradbench.adbench.lstm_data import LSTMInput, LSTMOutput
+from gradbench.adbench.lstm_data import LSTMInput
 from gradbench.tools.pytorch.lstm_objective import lstm_objective
 from gradbench.tools.pytorch.utils import to_torch_tensors, torch_jacobian
 

--- a/python/gradbench/gradbench/tools/pytorch/utils.py
+++ b/python/gradbench/gradbench/tools/pytorch/utils.py
@@ -106,7 +106,7 @@ def torch_jacobian(func, inputs, params=None, flatten=True):
 
             J.append(torch.cat(list(get_grad(inp, flatten) for inp in inputs)))
 
-    if params != None:
+    if params is not None:
         res = func(*inputs, *params)
     else:
         res = func(*inputs)

--- a/python/gradbench/gradbench/tools/tensorflow/ba.py
+++ b/python/gradbench/gradbench/tools/tensorflow/ba.py
@@ -9,7 +9,6 @@ Changes made:
   * Add jacobian/objective top level functions.
 """
 
-import sys
 
 import numpy as np
 import tensorflow as tf
@@ -22,7 +21,7 @@ from gradbench.adbench.ba_data import BAInput
 from gradbench.adbench.ba_sparse_mat import BASparseMat
 from gradbench.adbench.itest import ITest
 from gradbench.tools.tensorflow.ba_objective import compute_reproj_err, compute_w_err
-from gradbench.tools.tensorflow.utils import flatten, to_tf_tensor
+from gradbench.tools.tensorflow.utils import flatten
 
 
 class TensorflowBA(ITest):

--- a/python/gradbench/gradbench/tools/tensorflow/ba.py
+++ b/python/gradbench/gradbench/tools/tensorflow/ba.py
@@ -9,19 +9,17 @@ Changes made:
   * Add jacobian/objective top level functions.
 """
 
-
 import numpy as np
 import tensorflow as tf
-from tensorflow.python.framework.ops import disable_eager_execution
-
-disable_eager_execution()  # turn eager execution off
-
 from gradbench import wrap
 from gradbench.adbench.ba_data import BAInput
 from gradbench.adbench.ba_sparse_mat import BASparseMat
 from gradbench.adbench.itest import ITest
 from gradbench.tools.tensorflow.ba_objective import compute_reproj_err, compute_w_err
 from gradbench.tools.tensorflow.utils import flatten
+from tensorflow.python.framework.ops import disable_eager_execution
+
+disable_eager_execution()  # turn eager execution off
 
 
 class TensorflowBA(ITest):

--- a/python/gradbench/gradbench/tools/tensorflow/ba_objective.py
+++ b/python/gradbench/gradbench/tools/tensorflow/ba_objective.py
@@ -24,7 +24,7 @@
 
 
 import tensorflow as tf
-from gradbench.adbench.defs import BA_NCAMPARAMS, C_IDX, F_IDX, RAD_IDX, ROT_IDX, X0_IDX
+from gradbench.adbench.defs import C_IDX, F_IDX, RAD_IDX, ROT_IDX, X0_IDX
 
 
 def rodrigues_rotate_point(rot, X):

--- a/python/gradbench/gradbench/tools/tensorflow/gmm.py
+++ b/python/gradbench/gradbench/tools/tensorflow/gmm.py
@@ -11,16 +11,15 @@ Changes made:
 
 import numpy as np
 import tensorflow as tf
-from tensorflow.python.framework.ops import disable_eager_execution
-
-disable_eager_execution()  # turn eager execution off
-
 from gradbench import wrap
 from gradbench.adbench.defs import Wishart
 from gradbench.adbench.gmm_data import GMMInput
 from gradbench.adbench.itest import ITest
 from gradbench.tools.tensorflow.gmm_objective import gmm_objective
 from gradbench.tools.tensorflow.utils import flatten, to_tf_tensor
+from tensorflow.python.framework.ops import disable_eager_execution
+
+disable_eager_execution()  # turn eager execution off
 
 
 class TensorflowGMM(ITest):

--- a/python/gradbench/gradbench/tools/tensorflow/ht.py
+++ b/python/gradbench/gradbench/tools/tensorflow/ht.py
@@ -2,7 +2,6 @@
 # Licensed under the MIT license.
 
 # https://github.com/microsoft/ADBench/blob/38cb7931303a830c3700ca36ba9520868327ac87/src/python/modules/TensorflowGraph/TensorflowGraphHand.py
-import sys
 
 import numpy as np
 import tensorflow as tf
@@ -17,7 +16,7 @@ from gradbench.tools.tensorflow.ht_objective import (
     ht_objective,
     ht_objective_complicated,
 )
-from gradbench.tools.tensorflow.utils import flatten, shape, to_tf_tensor
+from gradbench.tools.tensorflow.utils import flatten, to_tf_tensor
 
 
 class TensorflowHT(ITest):

--- a/python/gradbench/gradbench/tools/tensorflow/ht.py
+++ b/python/gradbench/gradbench/tools/tensorflow/ht.py
@@ -5,10 +5,6 @@
 
 import numpy as np
 import tensorflow as tf
-from tensorflow.python.framework.ops import disable_eager_execution
-
-disable_eager_execution()  # turn eager execution off
-
 from gradbench import wrap
 from gradbench.adbench.ht_data import HandInput
 from gradbench.adbench.itest import ITest
@@ -17,6 +13,9 @@ from gradbench.tools.tensorflow.ht_objective import (
     ht_objective_complicated,
 )
 from gradbench.tools.tensorflow.utils import flatten, to_tf_tensor
+from tensorflow.python.framework.ops import disable_eager_execution
+
+disable_eager_execution()  # turn eager execution off
 
 
 class TensorflowHT(ITest):

--- a/python/gradbench/gradbench/tools/tensorflow/ht_objective.py
+++ b/python/gradbench/gradbench/tools/tensorflow/ht_objective.py
@@ -182,9 +182,7 @@ def get_skinned_vertex_positions(
     transforms = absolutes @ inverse_base_absolutes
 
     positions = base_positions @ tf.transpose(transforms, perm=[0, 2, 1])
-    positions = tf.reduce_sum(
-        positions * tf.reshape(weights, (shape(weights) + [1])), 0
-    )
+    positions = tf.reduce_sum(positions * tf.reshape(weights, [*shape(weights), 1]), 0)
     positions = apply_global_transform(pose_params, positions[:, :3])
 
     return positions
@@ -250,7 +248,7 @@ def ht_objective_complicated(
             + (1.0 - us[:, 0] - us[:, 1]) * tf.gather(vertex_positions, triangles[:, 2])
         )
 
-    us = tf.reshape(us, us.shape + [1])
+    us = tf.reshape(us, [*us.shape, 1])
     err = points - get_hand_pt(us, tf.gather(triangles, correspondences))
 
     return err

--- a/python/gradbench/gradbench/tools/tensorflow/lstm.py
+++ b/python/gradbench/gradbench/tools/tensorflow/lstm.py
@@ -11,7 +11,7 @@ disable_eager_execution()  # turn eager execution off
 
 from gradbench import wrap
 from gradbench.adbench.itest import ITest
-from gradbench.adbench.lstm_data import LSTMInput, LSTMOutput
+from gradbench.adbench.lstm_data import LSTMInput
 from gradbench.tools.tensorflow.lstm_objective import lstm_objective
 from gradbench.tools.tensorflow.utils import flatten, to_tf_tensor
 

--- a/python/gradbench/gradbench/tools/tensorflow/lstm.py
+++ b/python/gradbench/gradbench/tools/tensorflow/lstm.py
@@ -5,15 +5,14 @@
 
 import numpy as np
 import tensorflow as tf
-from tensorflow.python.framework.ops import disable_eager_execution
-
-disable_eager_execution()  # turn eager execution off
-
 from gradbench import wrap
 from gradbench.adbench.itest import ITest
 from gradbench.adbench.lstm_data import LSTMInput
 from gradbench.tools.tensorflow.lstm_objective import lstm_objective
 from gradbench.tools.tensorflow.utils import flatten, to_tf_tensor
+from tensorflow.python.framework.ops import disable_eager_execution
+
+disable_eager_execution()  # turn eager execution off
 
 
 class TensorflowLSTM(ITest):

--- a/python/gradbench/gradbench/tools/tensorflow/lstm_objective.py
+++ b/python/gradbench/gradbench/tools/tensorflow/lstm_objective.py
@@ -44,7 +44,9 @@ def lstm_objective(main_params, extra_params, state, sequence):
     """Gets the average loss for the LSTM across a sequence of inputs."""
 
     max_t = sequence.shape[0] - 1
-    cond = lambda t, state, inp, total, count: tf.less(t, max_t)
+
+    def cond(t, state, inp, total, count):
+        return tf.less(t, max_t)
 
     def body(t, state, inp, total, count):
         ypred, state = predict(main_params, extra_params, state, inp)

--- a/tools/futhark/ba.py
+++ b/tools/futhark/ba.py
@@ -1,4 +1,3 @@
-import futhark_server
 import futhark_utils
 import numpy as np
 

--- a/tools/futhark/futhark_utils.py
+++ b/tools/futhark/futhark_utils.py
@@ -2,7 +2,7 @@ import re
 
 
 def get_runtime_ns(ls):
-    for l in ls:
+    for l in ls:  # noqa: E741
         m = re.match("runtime: ([0-9]+)", l)
         if m:
             return int(m.group(1)) * 1000

--- a/tools/futhark/gmm.py
+++ b/tools/futhark/gmm.py
@@ -1,4 +1,3 @@
-
 import futhark_utils
 import numpy as np
 

--- a/tools/futhark/gmm.py
+++ b/tools/futhark/gmm.py
@@ -1,7 +1,4 @@
-import os
-import re
 
-import futhark_server
 import futhark_utils
 import numpy as np
 

--- a/tools/futhark/hello.py
+++ b/tools/futhark/hello.py
@@ -1,4 +1,3 @@
-import futhark_server
 import futhark_utils
 import numpy as np
 

--- a/tools/futhark/hello.py
+++ b/tools/futhark/hello.py
@@ -14,8 +14,6 @@ def square(server, input):
 
 
 def double(server, input):
-    min_runs = 1
-    min_seconds = 0
     (out,), times = futhark_utils.run(
         server, "double", ("output",), ("input",), min_runs=1, min_seconds=0
     )

--- a/tools/futhark/ht.py
+++ b/tools/futhark/ht.py
@@ -1,7 +1,6 @@
-import futhark_server
 import futhark_utils
 import numpy as np
-from gradbench.adbench.ht_data import HandInput, HandOutput
+from gradbench.adbench.ht_data import HandInput
 
 
 def prepare(server, input):

--- a/tools/futhark/kmeans.py
+++ b/tools/futhark/kmeans.py
@@ -1,4 +1,3 @@
-
 import futhark_utils
 import numpy as np
 

--- a/tools/futhark/kmeans.py
+++ b/tools/futhark/kmeans.py
@@ -1,7 +1,4 @@
-import os
-import re
 
-import futhark_server
 import futhark_utils
 import numpy as np
 

--- a/tools/futhark/lstm.py
+++ b/tools/futhark/lstm.py
@@ -1,6 +1,4 @@
-import futhark_server
 import futhark_utils
-import numpy as np
 from gradbench.adbench.lstm_data import LSTMInput
 
 

--- a/tools/futhark/run.py
+++ b/tools/futhark/run.py
@@ -5,11 +5,9 @@ import json
 import os
 import subprocess
 import sys
-import time
 from importlib import import_module
 
 import futhark_server
-import numpy as np
 
 
 def server_prog_source(prog):

--- a/tools/futhark/run.py
+++ b/tools/futhark/run.py
@@ -51,7 +51,7 @@ def main():
             response = run(message)
         elif message["kind"] == "define":
             try:
-                c = subprocess.check_output(
+                subprocess.check_output(
                     [
                         "futhark",
                         args.backend,

--- a/tools/tapenade/hello.py
+++ b/tools/tapenade/hello.py
@@ -1,6 +1,4 @@
 import subprocess
-import sys
-import time
 
 
 def compile():
@@ -54,7 +52,7 @@ def compile():
 
         return (True, None)
 
-    except Exception as e:
+    except Exception:
         # print(f"Compilation failed with error {e}", file=sys.stderr)
         return False
 


### PR DESCRIPTION
Followup on #309. This caught some usages of `gradbench.eval.Analysis` that we forgot to `import` before.