### PR TITLE
Ignore push errors instead of checking permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -267,19 +267,13 @@ jobs:
           git add .
           git commit --allow-empty -m 'Stats for commit ${{ github.event.pull_request.head.sha || github.sha }}'
           echo "CI_COMMIT_SHA=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
-      - name: Check for write permissions
-        id: check
-        uses: scherermichael-oss/action-has-permission@17f29510f1bf987b916c8cbb451566a56eed23f1
-        with:
-          required-permission: write
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Push to stats branch
-        if: steps.check.outputs.has-permission
+        continue-on-error: true
         working-directory: stats
         run: git push -f origin HEAD
       - name: Comment on PR
-        if: github.event_name == 'pull_request' && steps.check.outputs.has-permission
+        if: github.event_name == 'pull_request'
+        continue-on-error: true
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           message: |


### PR DESCRIPTION
Resolves #322 by just always trying to push and ignoring errors, instead of attempting to check permissions beforehand, since I don't know how to do that correctly. Also fixes #319.