### PR TITLE
Don't try to increase disk space in the `run` job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -187,8 +187,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Increase disk space
-        uses: ./.github/actions/space
       - name: Install CLI from artifact
         uses: ./.github/actions/cli
       - name: Download eval Docker image from artifact


### PR DESCRIPTION
I added this in #234, but it makes CI significantly slower; usually it takes either about 15 seconds or about 1 minute, which really adds up when there are over a hundred jobs in the matrix. And it seems unnecessary, since nightly doesn't have it and has been working fine.

![violin](https://github.com/user-attachments/assets/a732e7dc-aa25-4f7f-8a82-3a702287f681)

Plot generated by running these commands...

```sh
gh run view 13619988564 --log > log.txt
uv run collect.py
```

... using this script:

```python
# /// script
# requires-python = ">=3.11"
# dependencies = [
#     "matplotlib",
# ]
# ///

import re
from collections import defaultdict
from datetime import datetime
from pathlib import Path

import matplotlib.pyplot as plt

timestamps = defaultdict(list)
regex = re.compile(r"^(.*)Increase disk space\t(\S*)")
for line in Path("log.txt").read_text().splitlines():
    caps = regex.match(line)
    if caps:
        timestamps[caps.group(1)].append(
            datetime.fromisoformat(caps.group(2).replace("Z", "+00:00"))
        )
durations = [
    (max(times) - min(times)).total_seconds()
    for key, times in timestamps.items()
    if key.startswith("run (")
]
plt.violinplot(durations, vert=False)
plt.show()
```