### PR TITLE
Undo wrong x-axis sorting on website

### DIFF
--- a/packages/gradbench/src/Stats.tsx
+++ b/packages/gradbench/src/Stats.tsx
@@ -34,6 +34,7 @@ const makeSpec = ({
       x: {
         field: "workload",
         type: "nominal",
+        sort: null,
         axis: { labelAngle: -45 },
       },
       y: {


### PR DESCRIPTION
Thanks @lecopivo for noticing this!

---

Before:

<img width="716" alt="Screenshot 2025-03-05 at 4 03 36 PM" src="https://github.com/user-attachments/assets/24a7bad0-4557-495c-b7ff-8576d0f2fdf6" />

---

After:

<img width="716" alt="Screenshot 2025-03-05 at 4 03 33 PM" src="https://github.com/user-attachments/assets/4260fe8f-9d07-4cec-ac5a-e4d613626919" />
