### PR TITLE
Print Docker output when build is not cached

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -697,6 +697,7 @@ dependencies = [
  "indexmap",
  "nix",
  "pretty_assertions",
+ "regex",
  "serde",
  "serde_json",
  "strum",

--- a/crates/gradbench/Cargo.toml
+++ b/crates/gradbench/Cargo.toml
@@ -15,6 +15,7 @@ colored = "3"
 ctrlc = "3"
 indexmap = { version = "2", features = ["serde"] }
 nix = { version = "0.29", features = ["process", "signal"] }
+regex = "1"
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1"
 strum = { version = "0.27", features = ["derive"] }

--- a/crates/gradbench/src/main.rs
+++ b/crates/gradbench/src/main.rs
@@ -288,7 +288,9 @@ enum Verbosity {
 /// Run a `docker build` command but don't print output if everything is cached.
 fn docker_build_quiet(color: Color, mut cmd: Command) -> anyhow::Result<ExitStatus> {
     let mut child = cmd.arg("--progress=plain").stderr(Stdio::piped()).spawn()?;
-    let re = Regex::new(r"^#\d+ \d").unwrap();
+    // A digit mean the start of a number of seconds for an output line for a `RUN` command. The
+    // string `sha256` is the start of a line for downloading in a `FROM` command.
+    let re = Regex::new(r"^#\d+ (\d|sha256)").unwrap();
     let mut cached = true;
     let mut buffer = String::new();
     colored::control::set_override(true);
@@ -347,6 +349,7 @@ fn build_tool(name: &str, platform: Option<&str>, verbosity: Verbosity) -> Resul
         .arg(format!("ghcr.io/gradbench/tool-{name}"));
     match verbosity {
         Verbosity::Normal => {
+            cmd.arg("--progress=plain");
             run(&mut cmd)?;
             Ok(())
         }


### PR DESCRIPTION
Addresses the Docker part of #225 by checking for the regex `^#\d+ \d` in the `docker build` output with [`--progress=plain`](https://docs.docker.com/reference/cli/docker/buildx/build/#progress), and printing all output if any such lines are found. For the common case of using `./gradbench repo eval` and `./gradbench repo tool` at the same time, the former is printed in blue and the latter is printed in magenta.