### PR TITLE
Only update `nightly` branch if build succeeds

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -42,12 +42,6 @@ jobs:
         uses: actions/checkout@v4
       - name: Install CLI from artifact
         uses: ./.github/actions/cli
-      - name: Update nightly branch
-        run: |
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          git config --global user.name "github-actions[bot]"
-          git checkout -B nightly
-          git push origin nightly --force
       - name: Compute job parameters
         id: matrix
         run: gradbench repo matrix | tee -a "$GITHUB_OUTPUT"
@@ -208,15 +202,21 @@ jobs:
         with:
           name: stats
           path: stats
+      - name: Configure Git
+        run: |
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
       - name: Commit and push nightly stats branch
         working-directory: stats
         env:
           DATE: ${{ fromJSON(needs.matrix.outputs.date) }}
         run: |
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          git config --global user.name "github-actions[bot]"
           git add .
           git commit --allow-empty -m "Nightly stats on $DATE for commit $GITHUB_SHA"
           git push -f origin HEAD
           git tag "nightly-$DATE"
           git push origin "nightly-$DATE"
+      - name: Update nightly branch
+        run: |
+          git checkout -B nightly
+          git push origin nightly --force


### PR DESCRIPTION
I realized we should probably do this while I was working on #341.