### PR TITLE
Change all Docker images to use /gradbench instead of /home/gradbench

### DIFF
--- a/evals/ba/Dockerfile
+++ b/evals/ba/Dockerfile
@@ -6,17 +6,17 @@ RUN apt-get update && apt-get install -y \
 
 RUN pip install numpy==1.26.0 pydantic
 
-WORKDIR /home/gradbench
+WORKDIR /gradbench
 
-COPY python /home/gradbench/python
+COPY python /gradbench/python
 
-COPY cpp /home/gradbench/cpp
+COPY cpp /gradbench/cpp
 RUN make -C cpp
-COPY tools/manual/ /home/gradbench/tools/manual
-RUN make -C /home/gradbench/tools/manual -Bj
+COPY tools/manual/ /gradbench/tools/manual
+RUN make -C /gradbench/tools/manual -Bj
 
-COPY evals/ba/data /home/gradbench/evals/ba/data
+COPY evals/ba/data /gradbench/evals/ba/data
 
-ENV PYTHONPATH=/home/gradbench/python/gradbench:/home/gradbench/tools/
-ENTRYPOINT ["python", "/home/gradbench/python/gradbench/gradbench/evals/ba/run.py"]
+ENV PYTHONPATH=/gradbench/python/gradbench:/gradbench/tools/
+ENTRYPOINT ["python", "/gradbench/python/gradbench/gradbench/evals/ba/run.py"]
 LABEL org.opencontainers.image.source=https://github.com/gradbench/gradbench

--- a/evals/gmm/Dockerfile
+++ b/evals/gmm/Dockerfile
@@ -6,15 +6,15 @@ RUN apt-get update && apt-get install -y \
 
 RUN pip install numpy==1.26.0 pydantic scipy
 
-WORKDIR /home/gradbench
+WORKDIR /gradbench
 
-COPY python /home/gradbench/python
+COPY python /gradbench/python
 
-COPY cpp /home/gradbench/cpp
+COPY cpp /gradbench/cpp
 RUN make -C cpp
-COPY tools/manual/ /home/gradbench/tools/manual
-RUN make -C /home/gradbench/tools/manual -Bj
+COPY tools/manual/ /gradbench/tools/manual
+RUN make -C /gradbench/tools/manual -Bj
 
-ENV PYTHONPATH=/home/gradbench/python/gradbench:/home/gradbench/tools/
-ENTRYPOINT ["python", "/home/gradbench/python/gradbench/gradbench/evals/gmm/run.py"]
+ENV PYTHONPATH=/gradbench/python/gradbench:/gradbench/tools/
+ENTRYPOINT ["python", "/gradbench/python/gradbench/gradbench/evals/gmm/run.py"]
 LABEL org.opencontainers.image.source=https://github.com/gradbench/gradbench

--- a/evals/hello/Dockerfile
+++ b/evals/hello/Dockerfile
@@ -2,8 +2,8 @@ FROM python:3.11-slim
 
 RUN pip install numpy==1.26.0 pydantic
 
-COPY python /home/gradbench/python
-ENV PYTHONPATH=/home/gradbench/python/gradbench
+COPY python /gradbench/python
+ENV PYTHONPATH=/gradbench/python/gradbench
 
-ENTRYPOINT ["python", "/home/gradbench/python/gradbench/gradbench/evals/hello/run.py"]
+ENTRYPOINT ["python", "/gradbench/python/gradbench/gradbench/evals/hello/run.py"]
 LABEL org.opencontainers.image.source=https://github.com/gradbench/gradbench

--- a/evals/ht/Dockerfile
+++ b/evals/ht/Dockerfile
@@ -6,17 +6,17 @@ RUN apt-get update && apt-get install -y \
 
 RUN pip install numpy==1.26.0 pydantic dataclasses-json
 
-WORKDIR /home/gradbench
+WORKDIR /gradbench
 
-COPY python /home/gradbench/python
+COPY python /gradbench/python
 
-COPY cpp /home/gradbench/cpp
+COPY cpp /gradbench/cpp
 RUN make -C cpp
-COPY tools/manual/ /home/gradbench/tools/manual
-RUN make -C /home/gradbench/tools/manual -Bj
+COPY tools/manual/ /gradbench/tools/manual
+RUN make -C /gradbench/tools/manual -Bj
 
-COPY evals/ht/data /home/gradbench/evals/ht/data
+COPY evals/ht/data /gradbench/evals/ht/data
 
-ENV PYTHONPATH=/home/gradbench/python/gradbench:/home/gradbench/tools/
-ENTRYPOINT ["python", "/home/gradbench/python/gradbench/gradbench/evals/ht/run.py"]
+ENV PYTHONPATH=/gradbench/python/gradbench:/gradbench/tools/
+ENTRYPOINT ["python", "/gradbench/python/gradbench/gradbench/evals/ht/run.py"]
 LABEL org.opencontainers.image.source=https://github.com/gradbench/gradbench

--- a/evals/kmeans/Dockerfile
+++ b/evals/kmeans/Dockerfile
@@ -6,15 +6,15 @@ RUN apt-get update && apt-get install -y \
 
 RUN pip install numpy==1.26.0 pydantic dataclasses-json
 
-WORKDIR /home/gradbench
+WORKDIR /gradbench
 
-COPY python /home/gradbench/python
+COPY python /gradbench/python
 
-COPY cpp /home/gradbench/cpp
+COPY cpp /gradbench/cpp
 RUN make -C cpp
-COPY tools/manual/ /home/gradbench/tools/manual
-RUN make -C /home/gradbench/tools/manual -Bj
+COPY tools/manual/ /gradbench/tools/manual
+RUN make -C /gradbench/tools/manual -Bj
 
-ENV PYTHONPATH=/home/gradbench/python/gradbench:/home/gradbench/tools/
-ENTRYPOINT ["python", "/home/gradbench/python/gradbench/gradbench/evals/kmeans/run.py"]
+ENV PYTHONPATH=/gradbench/python/gradbench:/gradbench/tools/
+ENTRYPOINT ["python", "/gradbench/python/gradbench/gradbench/evals/kmeans/run.py"]
 LABEL org.opencontainers.image.source=https://github.com/gradbench/gradbench

--- a/evals/lstm/Dockerfile
+++ b/evals/lstm/Dockerfile
@@ -6,17 +6,17 @@ RUN apt-get update && apt-get install -y \
 
 RUN pip install numpy==1.26.0 pydantic dataclasses-json
 
-WORKDIR /home/gradbench
+WORKDIR /gradbench
 
-COPY python /home/gradbench/python
+COPY python /gradbench/python
 
-COPY cpp /home/gradbench/cpp
+COPY cpp /gradbench/cpp
 RUN make -C cpp
-COPY tools/manual/ /home/gradbench/tools/manual
-RUN make -C /home/gradbench/tools/manual -Bj
+COPY tools/manual/ /gradbench/tools/manual
+RUN make -C /gradbench/tools/manual -Bj
 
-COPY evals/lstm/data /home/gradbench/evals/lstm/data
+COPY evals/lstm/data /gradbench/evals/lstm/data
 
-ENV PYTHONPATH=/home/gradbench/python/gradbench:/home/gradbench/tools/
-ENTRYPOINT ["python", "/home/gradbench/python/gradbench/gradbench/evals/lstm/run.py"]
+ENV PYTHONPATH=/gradbench/python/gradbench:/gradbench/tools/
+ENTRYPOINT ["python", "/gradbench/python/gradbench/gradbench/evals/lstm/run.py"]
 LABEL org.opencontainers.image.source=https://github.com/gradbench/gradbench

--- a/tools/adept/Dockerfile
+++ b/tools/adept/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.11-slim
 
-WORKDIR /home/gradbench
+WORKDIR /gradbench
 
 RUN apt-get update && apt-get install -y \
     build-essential \
@@ -8,25 +8,25 @@ RUN apt-get update && apt-get install -y \
     wget \
     automake
 
-COPY python /home/gradbench/python
-ENV PYTHONPATH=/home/gradbench/python/gradbench
+COPY python /gradbench/python
+ENV PYTHONPATH=/gradbench/python/gradbench
 
 # Download and compile Adept.
 #
 # We copy in new versions of config.guess and config.sub because the
 # versions in the tarball are obsolete and do not recognise
 # new-fangled architectures such as ARM.
-ADD http://www.met.reading.ac.uk/clouds/adept/adept-2.1.1.tar.gz /home/gradbench
+ADD http://www.met.reading.ac.uk/clouds/adept/adept-2.1.1.tar.gz /gradbench
 RUN tar xvf adept-2.1.1.tar.gz
 RUN cp /usr/share/misc/config.guess /usr/share/misc/config.sub adept-2.1.1
 RUN cd adept-2.1.1 && ./configure && make && make install
 ENV LIBRARY_PATH=/usr/local/lib
 ENV LD_LIBRARY_PATH=/usr/local/lib
 
-COPY cpp /home/gradbench/cpp
+COPY cpp /gradbench/cpp
 RUN make -C cpp
 
-COPY tools/adept/ /home/gradbench/tools/adept
+COPY tools/adept/ /gradbench/tools/adept
 
-ENTRYPOINT ["python3", "/home/gradbench/tools/adept/run.py"]
+ENTRYPOINT ["python3", "/gradbench/tools/adept/run.py"]
 LABEL org.opencontainers.image.source=https://github.com/gradbench/gradbench

--- a/tools/adol-c/Dockerfile
+++ b/tools/adol-c/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.11-slim
 
-WORKDIR /home/gradbench
+WORKDIR /gradbench
 
 RUN apt-get update && apt-get install -y \
     build-essential \
@@ -10,8 +10,8 @@ RUN apt-get update && apt-get install -y \
     automake \
     autoconf
 
-COPY python /home/gradbench/python
-ENV PYTHONPATH=/home/gradbench/python/gradbench
+COPY python /gradbench/python
+ENV PYTHONPATH=/gradbench/python/gradbench
 
 # Install ADOL-C
 RUN wget https://github.com/coin-or/ADOL-C/archive/refs/tags/releases/2.7.2.tar.gz
@@ -22,10 +22,10 @@ RUN cd ADOL-C-releases-2.7.2 && make install
 ENV LIBRARY_PATH=/usr/local/lib64
 ENV LD_LIBRARY_PATH=/usr/local/lib64
 
-COPY cpp /home/gradbench/cpp
+COPY cpp /gradbench/cpp
 RUN make -C cpp
 
-COPY tools/adol-c/ /home/gradbench/tools/adol-c
+COPY tools/adol-c/ /gradbench/tools/adol-c
 
-ENTRYPOINT ["python3", "/home/gradbench/tools/adol-c/run.py"]
+ENTRYPOINT ["python3", "/gradbench/tools/adol-c/run.py"]
 LABEL org.opencontainers.image.source=https://github.com/gradbench/gradbench

--- a/tools/cppad/Dockerfile
+++ b/tools/cppad/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.11-slim
 
-WORKDIR /home/gradbench
+WORKDIR /gradbench
 
 RUN apt-get update && apt-get install -y \
     build-essential \
@@ -16,13 +16,13 @@ RUN make -C CppAD-20250000.2/build install
 ENV LIBRARY_PATH=/usr/local/lib
 ENV LD_LIBRARY_PATH=/usr/local/lib
 
-COPY python /home/gradbench/python
-ENV PYTHONPATH=/home/gradbench/python/gradbench
+COPY python /gradbench/python
+ENV PYTHONPATH=/gradbench/python/gradbench
 
-COPY cpp /home/gradbench/cpp
+COPY cpp /gradbench/cpp
 RUN make -C cpp
 
-COPY tools/cppad/ /home/gradbench/tools/cppad
+COPY tools/cppad/ /gradbench/tools/cppad
 
-ENTRYPOINT ["python3", "/home/gradbench/tools/cppad/run.py"]
+ENTRYPOINT ["python3", "/gradbench/tools/cppad/run.py"]
 LABEL org.opencontainers.image.source=https://github.com/gradbench/gradbench

--- a/tools/enzyme/Dockerfile
+++ b/tools/enzyme/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.11-slim
 ARG ENZYME_VER=0.0.168
 
-WORKDIR /home/gradbench
+WORKDIR /gradbench
 
 RUN apt-get update
 
@@ -18,8 +18,8 @@ RUN apt-get install -y \
     clang-19 \
     lld-19
 
-COPY python /home/gradbench/python
-ENV PYTHONPATH=/home/gradbench/python/gradbench
+COPY python /gradbench/python
+ENV PYTHONPATH=/gradbench/python/gradbench
 
 # Set clang
 RUN update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-19 100
@@ -29,13 +29,13 @@ RUN update-alternatives --install /usr/bin/lld lld /usr/bin/lld-19 100
 RUN wget https://github.com/EnzymeAD/Enzyme/archive/refs/tags/v${ENZYME_VER}.tar.gz
 RUN tar xvf v${ENZYME_VER}.tar.gz && rm -f v${ENZYME_VER}.tar.gz
 RUN mkdir enzyme-build
-RUN cd enzyme-build && cmake -G Ninja /home/gradbench/Enzyme-${ENZYME_VER}/enzyme -DLLVM_DIR=/usr/lib/llvm-19/lib/cmake/llvm/
+RUN cd enzyme-build && cmake -G Ninja /gradbench/Enzyme-${ENZYME_VER}/enzyme -DLLVM_DIR=/usr/lib/llvm-19/lib/cmake/llvm/
 RUN ninja -C enzyme-build
 
-COPY cpp /home/gradbench/cpp
+COPY cpp /gradbench/cpp
 RUN make -C cpp
 
-COPY tools/enzyme/ /home/gradbench/tools/enzyme
+COPY tools/enzyme/ /gradbench/tools/enzyme
 
-ENTRYPOINT ["python3", "/home/gradbench/tools/enzyme/run.py"]
+ENTRYPOINT ["python3", "/gradbench/tools/enzyme/run.py"]
 LABEL org.opencontainers.image.source=https://github.com/gradbench/gradbench

--- a/tools/enzyme/Makefile
+++ b/tools/enzyme/Makefile
@@ -3,7 +3,7 @@ LLD=lld
 CXXFLAGS=-std=c++17 -O3 -fno-math-errno -Wall -flto -I../../cpp
 LDFLAGS=-fuse-ld=$(LLD) -O3 -fno-math-errno -flto -Wl,--load-pass-plugin=$(LLDENZYME) -lm
 
-ENZYME_LIB?=/home/gradbench/enzyme-build/Enzyme/
+ENZYME_LIB?=/gradbench/enzyme-build/Enzyme/
 LLDENZYME=$(ENZYME_LIB)/LLDEnzyme-19.so
 
 EXECUTABLES=run_hello run_gmm run_lstm run_ba run_ht run_kmeans

--- a/tools/finite/Dockerfile
+++ b/tools/finite/Dockerfile
@@ -1,19 +1,19 @@
 FROM python:3.11-slim
 
-WORKDIR /home/gradbench
+WORKDIR /gradbench
 
 RUN apt-get update && apt-get install -y \
     build-essential \
     python3 \
     wget
 
-COPY python /home/gradbench/python
-ENV PYTHONPATH=/home/gradbench/python/gradbench
+COPY python /gradbench/python
+ENV PYTHONPATH=/gradbench/python/gradbench
 
-COPY cpp /home/gradbench/cpp
+COPY cpp /gradbench/cpp
 RUN make -C cpp
 
-COPY tools/finite/ /home/gradbench/tools/finite
+COPY tools/finite/ /gradbench/tools/finite
 
-ENTRYPOINT ["python3", "/home/gradbench/tools/finite/run.py"]
+ENTRYPOINT ["python3", "/gradbench/tools/finite/run.py"]
 LABEL org.opencontainers.image.source=https://github.com/gradbench/gradbench

--- a/tools/floretta/Dockerfile
+++ b/tools/floretta/Dockerfile
@@ -1,7 +1,7 @@
 FROM rust
 ARG TARGETARCH
 RUN apt-get update && apt-get install -y musl-tools
-WORKDIR /home/gradbench
+WORKDIR /gradbench
 COPY tools/floretta tools/floretta
 RUN rustup target add "$(tools/floretta/target.py $TARGETARCH)"
 COPY Cargo.toml .
@@ -11,8 +11,8 @@ RUN cargo build --release --target "$(tools/floretta/target.py $TARGETARCH)"
 RUN cp "target/$(tools/floretta/target.py $TARGETARCH)/release/gradbench-floretta" .
 
 FROM scratch
-WORKDIR /home/gradbench
+WORKDIR /gradbench
 COPY tools/floretta tools/floretta
-COPY --from=0 /home/gradbench/gradbench-floretta .
+COPY --from=0 /gradbench/gradbench-floretta .
 ENTRYPOINT ["./gradbench-floretta"]
 LABEL org.opencontainers.image.source=https://github.com/gradbench/gradbench

--- a/tools/futhark/Dockerfile
+++ b/tools/futhark/Dockerfile
@@ -11,12 +11,12 @@ RUN tar xvf futhark-0.25.23-linux-x86_64.tar.xz
 
 RUN make -C futhark-0.25.23-linux-x86_64 install
 
-COPY python /home/gradbench/python
-ENV PYTHONPATH=/home/gradbench/python/gradbench
+COPY python /gradbench/python
+ENV PYTHONPATH=/gradbench/python/gradbench
 
-COPY tools/futhark /home/gradbench/tools/futhark
-RUN cd /home/gradbench/tools/futhark && futhark pkg sync
+COPY tools/futhark /gradbench/tools/futhark
+RUN cd /gradbench/tools/futhark && futhark pkg sync
 
-WORKDIR /home/gradbench
-ENTRYPOINT ["python", "/home/gradbench/tools/futhark/run.py"]
+WORKDIR /gradbench
+ENTRYPOINT ["python", "/gradbench/tools/futhark/run.py"]
 LABEL org.opencontainers.image.source=https://github.com/gradbench/gradbench

--- a/tools/haskell/Dockerfile
+++ b/tools/haskell/Dockerfile
@@ -1,8 +1,8 @@
 FROM haskell:9
 
-WORKDIR /home/gradbench
+WORKDIR /gradbench
 
-COPY tools/haskell/ /home/gradbench/tools/haskell
+COPY tools/haskell/ /gradbench/tools/haskell
 
 RUN cabal update
 

--- a/tools/jax/Dockerfile
+++ b/tools/jax/Dockerfile
@@ -2,10 +2,10 @@ FROM python:3.11-slim
 
 RUN pip install jax jaxlib
 
-WORKDIR /home/gradbench
+WORKDIR /gradbench
 
-COPY python /home/gradbench/python
-ENV PYTHONPATH=/home/gradbench/python/gradbench
+COPY python /gradbench/python
+ENV PYTHONPATH=/gradbench/python/gradbench
 
-ENTRYPOINT ["taskset", "-c", "1", "python", "/home/gradbench/python/gradbench/gradbench/tools/jax/run.py"]
+ENTRYPOINT ["taskset", "-c", "1", "python", "/gradbench/python/gradbench/gradbench/tools/jax/run.py"]
 LABEL org.opencontainers.image.source=https://github.com/gradbench/gradbench

--- a/tools/manual/Dockerfile
+++ b/tools/manual/Dockerfile
@@ -1,20 +1,20 @@
 FROM python:3.11-slim
 
-WORKDIR /home/gradbench
+WORKDIR /gradbench
 
 RUN apt-get update && apt-get install -y \
     build-essential \
     python3 \
     wget
 
-COPY python /home/gradbench/python
-ENV PYTHONPATH=/home/gradbench/python/gradbench
+COPY python /gradbench/python
+ENV PYTHONPATH=/gradbench/python/gradbench
 
-COPY cpp /home/gradbench/cpp
+COPY cpp /gradbench/cpp
 
 RUN make -C cpp
 
-COPY tools/manual/ /home/gradbench/tools/manual
+COPY tools/manual/ /gradbench/tools/manual
 
-ENTRYPOINT ["python3", "/home/gradbench/tools/manual/run.py"]
+ENTRYPOINT ["python3", "/gradbench/tools/manual/run.py"]
 LABEL org.opencontainers.image.source=https://github.com/gradbench/gradbench

--- a/tools/ocaml/Dockerfile
+++ b/tools/ocaml/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:12-slim
 
-WORKDIR /home/gradbench
+WORKDIR /gradbench
 
 RUN apt-get update && apt-get install -y \
     build-essential \
@@ -25,10 +25,10 @@ RUN eval $(opam env) && opam install --yes yojson
 # Install owl.
 RUN eval $(opam env) && opam install --yes owl=1.2
 
-COPY tools/ocaml/ /home/gradbench/tools/ocaml
+COPY tools/ocaml/ /gradbench/tools/ocaml
 
 # Build tool.
 RUN eval $(opam env) && dune build --root tools/ocaml --profile release
 
-ENTRYPOINT ["/home/gradbench/tools/ocaml/_build/install/default/bin/gradbench"]
+ENTRYPOINT ["/gradbench/tools/ocaml/_build/install/default/bin/gradbench"]
 LABEL org.opencontainers.image.source=https://github.com/gradbench/gradbench

--- a/tools/pytorch/Dockerfile
+++ b/tools/pytorch/Dockerfile
@@ -4,8 +4,8 @@ RUN pip install numpy==1.26.0 dataclasses-json && \
     pip install torch --index-url https://download.pytorch.org/whl/cpu && \
     pip install scipy
 
-COPY python /home/gradbench/python
-ENV PYTHONPATH=/home/gradbench/python/gradbench
+COPY python /gradbench/python
+ENV PYTHONPATH=/gradbench/python/gradbench
 
-ENTRYPOINT ["python", "/home/gradbench/python/gradbench/gradbench/tools/pytorch/run.py"]
+ENTRYPOINT ["python", "/gradbench/python/gradbench/gradbench/tools/pytorch/run.py"]
 LABEL org.opencontainers.image.source=https://github.com/gradbench/gradbench

--- a/tools/scilean/Dockerfile
+++ b/tools/scilean/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu
 RUN apt-get update && apt-get install -y curl git jq build-essential libopenblas-dev
 RUN         curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | bash -s -- -y
 ENV PATH="/root/.elan/bin:$PATH"
-WORKDIR /home/gradbench
+WORKDIR /gradbench
 
 RUN elan default leanprover/lean4:v4.16.0  # download specific lean version
 
@@ -20,5 +20,5 @@ COPY tools/scilean/Gradbench.lean .
 COPY tools/scilean/Gradbench/ ./Gradbench/
 RUN lake build              # Build the SciLean gradbench tool
 
-ENTRYPOINT ["/home/gradbench/.lake/build/bin/gradbench"]
+ENTRYPOINT ["/gradbench/.lake/build/bin/gradbench"]
 LABEL org.opencontainers.image.source=https://github.com/gradbench/gradbench

--- a/tools/tapenade/Dockerfile
+++ b/tools/tapenade/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.11-slim
 
-WORKDIR /home/gradbench
+WORKDIR /gradbench
 
 RUN apt-get update && apt-get install -y \
     bash \
@@ -9,20 +9,20 @@ RUN apt-get update && apt-get install -y \
     wget \
     openjdk-17-jre-headless
 
-COPY python /home/gradbench/python
-ENV PYTHONPATH=/home/gradbench/python/gradbench
+COPY python /gradbench/python
+ENV PYTHONPATH=/gradbench/python/gradbench
 
 # install Tapenade
 RUN wget https://tapenade.gitlabpages.inria.fr/tapenade/distrib/tapenade_3.16.tar
 RUN tar -xvzf tapenade_3.16.tar
 
 # ensure Tapenade is accessible
-RUN ln -s /home/gradbench/tapenade_3.16/bin/tapenade /usr/local/bin/tapenade
+RUN ln -s /gradbench/tapenade_3.16/bin/tapenade /usr/local/bin/tapenade
 
-COPY cpp /home/gradbench/cpp
+COPY cpp /gradbench/cpp
 RUN make -C cpp
 
-COPY tools/tapenade/ /home/gradbench/tools/tapenade
+COPY tools/tapenade/ /gradbench/tools/tapenade
 
-ENTRYPOINT ["python3", "/home/gradbench/tools/tapenade/run.py"]
+ENTRYPOINT ["python3", "/gradbench/tools/tapenade/run.py"]
 LABEL org.opencontainers.image.source=https://github.com/gradbench/gradbench

--- a/tools/tensorflow/Dockerfile
+++ b/tools/tensorflow/Dockerfile
@@ -5,10 +5,10 @@ RUN apt-get update && apt-get install -y \
     libhdf5-dev
 RUN pip install h5py tensorflow scipy dataclasses-json
 
-WORKDIR /home/gradbench
+WORKDIR /gradbench
 
-COPY python /home/gradbench/python
-ENV PYTHONPATH=/home/gradbench/python/gradbench
+COPY python /gradbench/python
+ENV PYTHONPATH=/gradbench/python/gradbench
 
-ENTRYPOINT ["python", "/home/gradbench/python/gradbench/gradbench/tools/tensorflow/run.py"]
+ENTRYPOINT ["python", "/gradbench/python/gradbench/gradbench/tools/tensorflow/run.py"]
 LABEL org.opencontainers.image.source=https://github.com/gradbench/gradbench

--- a/tools/zygote/Dockerfile
+++ b/tools/zygote/Dockerfile
@@ -1,8 +1,8 @@
 FROM julia:1.10.4
-WORKDIR /home/gradbench
+WORKDIR /gradbench
 COPY tools/zygote/Project.toml .
 COPY tools/zygote/Manifest.toml .
 RUN julia --project=. -e 'import Pkg; Pkg.instantiate()'
 COPY tools/zygote/run.jl .
-ENTRYPOINT ["julia", "--project=/home/gradbench", "/home/gradbench/run.jl"]
+ENTRYPOINT ["julia", "--project=/gradbench", "/gradbench/run.jl"]
 LABEL org.opencontainers.image.source=https://github.com/gradbench/gradbench


### PR DESCRIPTION
This works with no downsides and maybe a purist can argue that it more appropriate since the Docker images have no 'gradbench' user. However, the real reason I am proposing this is simply because the Singularity container manager, which is relatively widely used in HPC environments, ends up removing /home/gradbench (under some important circumstances) because it has its own automation logic for handling /home.