### PR TITLE
Don't reorder timing names in the intermediary

### DIFF
--- a/crates/gradbench/src/intermediary.rs
+++ b/crates/gradbench/src/intermediary.rs
@@ -1,5 +1,4 @@
 use std::{
-    collections::BTreeMap,
     io::{self, BufRead, Write},
     process::{Child, ChildStdout},
     sync::{Arc, Mutex},
@@ -8,6 +7,7 @@ use std::{
 
 use anyhow::{anyhow, Context};
 use colored::Colorize;
+use indexmap::IndexMap;
 use serde::Deserialize;
 
 use crate::{
@@ -145,14 +145,14 @@ impl<
 
     /// Print subtask timings.
     fn print_timings(&mut self, timings: &[Timing]) -> anyhow::Result<()> {
-        let mut sorted = BTreeMap::new();
+        let mut collected = IndexMap::new();
         for Timing { name, nanoseconds } in timings {
-            let (num, ns) = sorted.entry(name).or_insert((0, 0));
+            let (num, ns) = collected.entry(name).or_insert((0, 0));
             *num += 1;
             *ns += nanoseconds;
         }
         let mut first = true;
-        for (name, (num, ns)) in sorted {
+        for (name, (num, ns)) in collected {
             if first {
                 write!(self.out, " {}", "~".dimmed())?;
             } else {


### PR DESCRIPTION
Now it's just up to the tool. For example, running this command:

```sh
./gradbench run --eval "./gradbench repo eval kmeans" --tool "./gradbench repo tool codipack"
```

Before:

```
  [0] start kmeans (codipack)
  [1] def   kmeans                              3.988 s ✓
  [2] eval  kmeans::cost    k=10,n=1000,d=8     1.048 s ~         0ms evaluate × 16296,         0ms prepare ✓
  [4] eval  kmeans::dir     k=10,n=1000,d=8     1.024 s ~         6ms evaluate × 156,         0ms prepare ✓
  [6] eval  kmeans::cost    k=10,n=1000,...     1.042 s ~         0ms evaluate × 8723,         0ms prepare ✓
  [8] eval  kmeans::dir     k=10,n=1000,...     1.056 s ~         9ms evaluate × 105,         0ms prepare ✓
 [10] eval  kmeans::cost    k=10,n=10000...     1.129 s ~         0ms evaluate × 1563,         0ms prepare ✓
 [12] eval  kmeans::dir     k=10,n=10000...     1.166 s ~        31ms evaluate × 33,         0ms prepare ✓
 [14] eval  kmeans::cost    k=100,n=1000...     1.022 s ~         0ms evaluate × 2433,         0ms prepare ✓
 [16] eval  kmeans::dir     k=100,n=1000...     1.040 s ~        27ms evaluate × 37,         0ms prepare ✓
 [18] eval  kmeans::cost    k=10,n=10000...     1.233 s ~         1ms evaluate × 990,         0ms prepare ✓
 [20] eval  kmeans::dir     k=10,n=10000...     1.524 s ~        61ms evaluate × 21,         0ms prepare ✓
 [22] eval  kmeans::cost    k=100,n=1000...     1.037 s ~         0ms evaluate × 1431,         0ms prepare ✓
 [24] eval  kmeans::dir     k=100,n=1000...     1.063 s ~        44ms evaluate × 23,         0ms prepare ✓
 [26] eval  kmeans::cost    k=100,n=1000...     1.124 s ~         3ms evaluate × 255,         0ms prepare ✓
 [28] eval  kmeans::dir     k=100,n=1000...     1.308 s ~       191ms evaluate × 6,         0ms prepare ✓
 [30] eval  kmeans::cost    k=1000,n=100...     1.029 s ~         3ms evaluate × 299,         0ms prepare ✓
 [32] eval  kmeans::dir     k=1000,n=100...     1.420 s ~       195ms evaluate × 7,         0ms prepare ✓
 [34] eval  kmeans::cost    k=100,n=1000...     1.264 s ~         7ms evaluate × 142,         0ms prepare ✓
 [36] eval  kmeans::dir     k=100,n=1000...     1.423 s ~       555ms evaluate × 2,         0ms prepare ✓
 [38] eval  kmeans::cost    k=1000,n=100...     1.058 s ~         6ms evaluate × 166,         0ms prepare ✓
 [40] eval  kmeans::dir     k=1000,n=100...     1.835 s ~       585ms evaluate × 3,         0ms prepare ✓
 [42] eval  kmeans::cost    k=1000,n=100...     1.165 s ~        41ms evaluate × 25,         0ms prepare ✓
 [44] eval  kmeans::dir     k=1000,n=100...     3.753 s ~     3.545 s evaluate,         0ms prepare ✓
 [46] eval  kmeans::cost    k=1000,n=100...     1.349 s ~        76ms evaluate × 14,         0ms prepare ✓
 [48] eval  kmeans::dir     k=1000,n=100...     9.693 s ~     9.121 s evaluate,         0ms prepare ✓
```

After:

```
  [0] start kmeans (codipack)
  [1] def   kmeans                              4.375 s ✓
  [2] eval  kmeans::cost    k=10,n=1000,d=8     1.052 s ~         0ms prepare,         0ms evaluate × 16255 ✓
  [4] eval  kmeans::dir     k=10,n=1000,d=8     1.028 s ~         0ms prepare,         7ms evaluate × 139 ✓
  [6] eval  kmeans::cost    k=10,n=1000,...     1.047 s ~         0ms prepare,         0ms evaluate × 8693 ✓
  [8] eval  kmeans::dir     k=10,n=1000,...     1.047 s ~         0ms prepare,        10ms evaluate × 94 ✓
 [10] eval  kmeans::cost    k=10,n=10000...     1.122 s ~         0ms prepare,         0ms evaluate × 1551 ✓
 [12] eval  kmeans::dir     k=10,n=10000...     1.124 s ~         0ms prepare,        35ms evaluate × 28 ✓
 [14] eval  kmeans::cost    k=100,n=1000...     1.022 s ~         0ms prepare,         0ms evaluate × 2293 ✓
 [16] eval  kmeans::dir     k=100,n=1000...     1.067 s ~         0ms prepare,        32ms evaluate × 32 ✓
 [18] eval  kmeans::cost    k=10,n=10000...     1.211 s ~         0ms prepare,         0ms evaluate × 1003 ✓
 [20] eval  kmeans::dir     k=10,n=10000...     1.291 s ~         0ms prepare,        55ms evaluate × 19 ✓
 [22] eval  kmeans::cost    k=100,n=1000...     1.033 s ~         0ms prepare,         0ms evaluate × 1396 ✓
 [24] eval  kmeans::dir     k=100,n=1000...     1.333 s ~         0ms prepare,        61ms evaluate × 21 ✓
 [26] eval  kmeans::cost    k=100,n=1000...     1.126 s ~         0ms prepare,         3ms evaluate × 251 ✓
 [28] eval  kmeans::dir     k=100,n=1000...     1.369 s ~         0ms prepare,       246ms evaluate × 5 ✓
 [30] eval  kmeans::cost    k=1000,n=100...     1.033 s ~         0ms prepare,         3ms evaluate × 300 ✓
 [32] eval  kmeans::dir     k=1000,n=100...     1.156 s ~         0ms prepare,       185ms evaluate × 6 ✓
 [34] eval  kmeans::cost    k=100,n=1000...     1.245 s ~         0ms prepare,         7ms evaluate × 142 ✓
 [36] eval  kmeans::dir     k=100,n=1000...     1.508 s ~         0ms prepare,       422ms evaluate × 3 ✓
 [38] eval  kmeans::cost    k=1000,n=100...     1.055 s ~         0ms prepare,         5ms evaluate × 169 ✓
 [40] eval  kmeans::dir     k=1000,n=100...     1.614 s ~         0ms prepare,       386ms evaluate × 4 ✓
 [42] eval  kmeans::cost    k=1000,n=100...     1.158 s ~         0ms prepare,        33ms evaluate × 30 ✓
 [44] eval  kmeans::dir     k=1000,n=100...     3.151 s ~         0ms prepare,     2.942 s evaluate ✓
 [46] eval  kmeans::cost    k=1000,n=100...     1.297 s ~         0ms prepare,        60ms evaluate × 17 ✓
 [48] eval  kmeans::dir     k=1000,n=100...     8.773 s ~         0ms prepare,     8.308 s evaluate ✓
```