### PR TITLE
codipack: reset the tape before each evaluation

### DIFF
--- a/tools/codipack/run_gmm.cpp
+++ b/tools/codipack/run_gmm.cpp
@@ -16,20 +16,15 @@ public:
     alphas_d(_input.k),
     means_d(_input.d*_input.k),
     icf_d((_input.d*(_input.d + 1) / 2)*_input.k) {
-    Tape& tape = Real::getTape();
-    tape.setActive();
 
     for (size_t i = 0; i < alphas_d.size(); i++) {
       alphas_d[i] = _input.alphas[i];
-      tape.registerInput(alphas_d[i]);
     }
     for (size_t i = 0; i < means_d.size(); i++) {
       means_d[i] = _input.means[i];
-      tape.registerInput(means_d[i]);
     }
     for (size_t i = 0; i < icf_d.size(); i++) {
       icf_d[i] = _input.icf[i];
-      tape.registerInput(icf_d[i]);
     }
   }
 
@@ -38,6 +33,18 @@ public:
     output.resize(Jcols);
 
     Tape& tape = Real::getTape();
+    tape.reset();
+    tape.setActive();
+
+    for (size_t i = 0; i < alphas_d.size(); i++) {
+      tape.registerInput(alphas_d[i]);
+    }
+    for (size_t i = 0; i < means_d.size(); i++) {
+      tape.registerInput(means_d[i]);
+    }
+    for (size_t i = 0; i < icf_d.size(); i++) {
+      tape.registerInput(icf_d[i]);
+    }
 
     Real error;
     gmm::objective(_input.d, _input.k, _input.n,

--- a/tools/codipack/run_lstm.cpp
+++ b/tools/codipack/run_lstm.cpp
@@ -19,19 +19,13 @@ public:
     state_d(_input.state.size()),
     sequence_d(_input.sequence.size()) {
 
-    Tape& tape = Real::getTape();
-    tape.setActive();
-
     for (size_t i = 0; i < main_params_d.size(); i++) {
       main_params_d[i] = _input.main_params[i];
-      tape.registerInput(main_params_d[i]);
     }
 
     for (size_t i = 0; i < extra_params_d.size(); i++) {
       extra_params_d[i] = _input.extra_params[i];
-      tape.registerInput(extra_params_d[i]);
     }
-
 
     for (size_t i = 0; i < state_d.size(); i++) {
       state_d[i] = _input.state[i];
@@ -47,6 +41,16 @@ public:
 
     Real loss;
     Tape& tape = Real::getTape();
+    tape.reset();
+    tape.setActive();
+
+    for (size_t i = 0; i < main_params_d.size(); i++) {
+      tape.registerInput(main_params_d[i]);
+    }
+
+    for (size_t i = 0; i < extra_params_d.size(); i++) {
+      tape.registerInput(extra_params_d[i]);
+    }
 
     lstm::objective(_input.l, _input.c, _input.b,
                     main_params_d.data(), extra_params_d.data(),


### PR DESCRIPTION
Based on a discussion on the Discord, I decided to make the CoDiPack implementations of GMM and LSTM explicitly reset the tape (and indicate the inputs) during each evaluation. This is due to uncertainty about how much work CoDiPack can otherwise reuse across evaluations - the first executions are *much* slower than the rest.

CoDiPack is still pretty fast overall, but this does make it slower on some workloads.