### PR TITLE
Support backtraces for all CLI errors

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,7 +87,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: cli
-          path: target/x86_64-unknown-linux-musl/release/gradbench
+          path: target/x86_64-unknown-linux-musl/release-with-debug/gradbench
 
   windows:
     runs-on: windows-2022

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,7 +82,7 @@ jobs:
         uses: houseabsolute/actions-rust-cross@v1
         with:
           target: x86_64-unknown-linux-musl
-          args: --package gradbench --release
+          args: --package=gradbench --profile=release-with-debug
       - name: Upload CLI as artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -22,7 +22,7 @@ jobs:
         uses: houseabsolute/actions-rust-cross@v1
         with:
           target: x86_64-unknown-linux-musl
-          args: --package gradbench --release
+          args: --package=gradbench --profile=release-with-debug
       - name: Upload CLI as artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: cli
-          path: target/x86_64-unknown-linux-musl/release/gradbench
+          path: target/x86_64-unknown-linux-musl/release-with-debug/gradbench
 
   matrix:
     needs: cli

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,7 @@
 [workspace]
 members = ["crates/*"]
 resolver = "2"
+
+[profile.release-with-debug]
+inherits = "release"
+debug = true

--- a/crates/gradbench/src/intermediary.rs
+++ b/crates/gradbench/src/intermediary.rs
@@ -11,6 +11,7 @@ use indexmap::IndexMap;
 use serde::Deserialize;
 
 use crate::{
+    err_fail,
     protocol::{
         AnalysisResponse, DefineResponse, EvaluateResponse, Id, Message, StartResponse, Timing,
     },
@@ -399,7 +400,7 @@ pub fn run(
     match handle_ctrlc(eval, tool, Arc::clone(&outcome)) {
         Ok(()) => {}
         Err(err) => {
-            println!("{err:#}");
+            err_fail(err);
             return Err(BadOutcome::Error);
         }
     }

--- a/crates/gradbench/src/main.rs
+++ b/crates/gradbench/src/main.rs
@@ -218,7 +218,7 @@ fn err_fail(error: impl Into<anyhow::Error>) -> ExitCode {
         BacktraceStatus::Disabled => eprintln!(
             "note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace"
         ),
-        BacktraceStatus::Captured => eprintln!("{backtrace}"),
+        BacktraceStatus::Captured => eprint!("{backtrace}"),
         _ => {}
     }
     ExitCode::FAILURE

--- a/crates/gradbench/src/main.rs
+++ b/crates/gradbench/src/main.rs
@@ -4,6 +4,7 @@ mod stats;
 mod util;
 
 use std::{
+    backtrace::BacktraceStatus,
     collections::{BTreeMap, BTreeSet},
     env, fs,
     io::{self, BufRead},
@@ -208,6 +209,21 @@ enum RepoCommands {
     },
 }
 
+/// Print `error` to stderr, then return [`ExitCode::FAILURE`].
+fn err_fail(error: impl Into<anyhow::Error>) -> ExitCode {
+    let err = error.into();
+    eprintln!("{err:#}");
+    let backtrace = err.backtrace();
+    match backtrace.status() {
+        BacktraceStatus::Disabled => eprintln!(
+            "note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace"
+        ),
+        BacktraceStatus::Captured => eprintln!("{backtrace}"),
+        _ => {}
+    }
+    ExitCode::FAILURE
+}
+
 /// Return `Err` if the status is not successful, preserving its exit code whenever possible.
 fn status_code(status: ExitStatus) -> Result<(), ExitCode> {
     if status.success() {
@@ -228,10 +244,8 @@ fn run(command: &mut Command) -> Result<Output, ExitCode> {
     let output = command
         .spawn()
         .and_then(|child| child.wait_with_output())
-        .map_err(|err| {
-            eprintln!("error running {:?}: {err}", command.get_program());
-            ExitCode::FAILURE
-        })?;
+        .with_context(|| format!("error running {:?}", command.get_program()))
+        .map_err(err_fail)?;
     status_code(output.status)?;
     Ok(output)
 }
@@ -313,8 +327,7 @@ fn docker_build_quiet(color: Color, mut cmd: Command) -> anyhow::Result<ExitStat
 /// Build the Docker image for an eval.
 fn build_eval(name: &str, platform: Option<&str>, verbosity: Verbosity) -> Result<(), ExitCode> {
     if name.is_empty() || !fs::exists(Path::new("evals").join(name)).unwrap_or(false) {
-        eprintln!("can't find eval to build: {name:?}");
-        return Err(ExitCode::FAILURE);
+        return Err(err_fail(anyhow!("can't find eval to build: {name:?}")));
     }
     let mut cmd = Command::new("docker");
     cmd.arg("build");
@@ -330,21 +343,18 @@ fn build_eval(name: &str, platform: Option<&str>, verbosity: Verbosity) -> Resul
             run(&mut cmd)?;
             Ok(())
         }
-        Verbosity::Quiet => {
-            let color = Color::Blue;
-            status_code(docker_build_quiet(color, cmd).map_err(|err| {
-                eprintln!("error building eval {name}: {err}");
-                ExitCode::FAILURE
-            })?)
-        }
+        Verbosity::Quiet => status_code(
+            docker_build_quiet(Color::Blue, cmd)
+                .with_context(|| format!("error building eval {name}"))
+                .map_err(err_fail)?,
+        ),
     }
 }
 
 /// Build the Docker image for a tool.
 fn build_tool(name: &str, platform: Option<&str>, verbosity: Verbosity) -> Result<(), ExitCode> {
     if name.is_empty() || !fs::exists(Path::new("tools").join(name)).unwrap_or(false) {
-        eprintln!("can't find tool to build: {name:?}");
-        return Err(ExitCode::FAILURE);
+        return Err(err_fail(anyhow!("can't find tool to build: {name:?}")));
     }
     let mut cmd = Command::new("docker");
     cmd.arg("build");
@@ -361,13 +371,11 @@ fn build_tool(name: &str, platform: Option<&str>, verbosity: Verbosity) -> Resul
             run(&mut cmd)?;
             Ok(())
         }
-        Verbosity::Quiet => {
-            let color = Color::Magenta;
-            status_code(docker_build_quiet(color, cmd).map_err(|err| {
-                eprintln!("error building tool {name}: {err}");
-                ExitCode::FAILURE
-            })?)
-        }
+        Verbosity::Quiet => status_code(
+            docker_build_quiet(Color::Magenta, cmd)
+                .with_context(|| format!("error building tool {name}"))
+                .map_err(err_fail)?,
+        ),
     }
 }
 
@@ -410,19 +418,16 @@ impl From<BadOutcome> for ExitCode {
 /// Return a command's stdout as a string, preserving its exit code whenever possible.
 fn stdout(command: &mut Command) -> Result<String, ExitCode> {
     let output = run(command.stdout(Stdio::piped()))?;
-    String::from_utf8(output.stdout).map_err(|err| {
-        let program = command.get_program();
-        eprintln!("error processing output from {program:?}: {err}");
-        ExitCode::FAILURE
-    })
+    String::from_utf8(output.stdout)
+        .with_context(|| format!("error processing output from {:?}", command.get_program()))
+        .map_err(err_fail)
 }
 
 /// Check that the current working directory is the root of a Git repository.
 fn check_git() -> Result<(), ExitCode> {
-    let cwd = env::current_dir().map_err(|err| {
-        eprintln!("error getting current working directory: {err}");
-        ExitCode::FAILURE
-    })?;
+    let cwd = env::current_dir()
+        .context("error getting current working directory")
+        .map_err(err_fail)?;
     if let Ok(dir) = stdout(Command::new("git").args(["rev-parse", "--show-toplevel"])) {
         if dir.strip_suffix('\n').map(PathBuf::from) == Some(cwd) {
             return Ok(());
@@ -586,8 +591,7 @@ fn cli() -> Result<(), ExitCode> {
                     cmd.stdin(Stdio::piped()).stdout(Stdio::piped()).spawn()
                 },
             ) else {
-                eprintln!("error starting eval and tool commands");
-                return Err(ExitCode::FAILURE);
+                return Err(err_fail(anyhow!("error starting eval and tool commands")));
             };
             let timeout = timeout.map(Duration::from_secs);
             let outcome = match output {
@@ -595,10 +599,7 @@ fn cli() -> Result<(), ExitCode> {
                     Ok(mut file) => {
                         intermediary::run(&mut file, &mut eval_child, &mut tool_child, timeout)
                     }
-                    Err(err) => {
-                        println!("{err:#}");
-                        return Err(ExitCode::FAILURE);
-                    }
+                    Err(err) => return Err(err_fail(err)),
                 },
                 None => {
                     intermediary::run(&mut io::sink(), &mut eval_child, &mut tool_child, timeout)
@@ -623,8 +624,7 @@ fn cli() -> Result<(), ExitCode> {
                 if outcome == "success" {
                     Ok(())
                 } else {
-                    eprintln!("unknown outcome name {outcome:?}");
-                    Err(ExitCode::FAILURE)
+                    Err(err_fail(anyhow!("unknown outcome name {outcome:?}")))
                 }
             }
         },
@@ -655,20 +655,14 @@ fn cli() -> Result<(), ExitCode> {
                 RepoCommands::BuildTool { tool, platform } => {
                     build_tool(&tool, platform.as_deref(), Verbosity::Normal)
                 }
-                RepoCommands::Matrix => matrix().map_err(|err| {
-                    eprintln!("{err:#}");
-                    ExitCode::FAILURE
-                }),
+                RepoCommands::Matrix => matrix().map_err(err_fail),
                 RepoCommands::Stats {
                     input,
                     output,
                     date,
                     commit,
                 } => {
-                    stats::generate(input, output, StatsMetadata { date, commit }).map_err(|err| {
-                        eprintln!("{err:#}");
-                        ExitCode::FAILURE
-                    })
+                    stats::generate(input, output, StatsMetadata { date, commit }).map_err(err_fail)
                 }
             }
         }

--- a/gradbench
+++ b/gradbench
@@ -9,11 +9,23 @@ def eprint(s):
     sys.stderr.flush()
 
 
+def check(returncode):
+    if returncode != 0:
+        sys.exit(returncode)
+
+
+profile = "release-with-debug"
+
+
 def build():
-    process = subprocess.Popen(
-        ["cargo", "build", "--release", "--package", "gradbench", "--color", "always"],
-        stderr=subprocess.PIPE,
-    )
+    cmd = [
+        "cargo",
+        "build",
+        "--package=gradbench",
+        f"--profile={profile}",
+        "--color=always",
+    ]
+    process = subprocess.Popen(cmd, stderr=subprocess.PIPE)
     cached = True
     lines = []
     while True:
@@ -28,15 +40,18 @@ def build():
                     eprint(line)
         else:
             eprint(line)
-    returncode = process.wait()
-    if returncode != 0:
-        sys.exit(returncode)
+    check(process.wait())
+
+
+def run():
+    cmd = [f"target/{profile}/gradbench", *sys.argv[1:]]
+    check(subprocess.run(cmd).returncode)
 
 
 def main():
     try:
         build()
-        sys.exit(subprocess.run(["target/release/gradbench", *sys.argv[1:]]).returncode)
+        run()
     except KeyboardInterrupt:
         pass
 


### PR DESCRIPTION
For instance, on commit e72bcebcac3b3eb9a67fe7c66c4479d8881c46bb:

```
$ gh run download 13773302593 --dir run --pattern 'run-*'
$ rm -r run/run-ba-manual
$ ./gradbench repo stats run -o stats
ba
  run/run-ba-adept/log.jsonl
  run/run-ba-adol-c/log.jsonl
  run/run-ba-codipack/log.jsonl
  run/run-ba-enzyme/log.jsonl
  run/run-ba-finite/log.jsonl
  run/run-ba-futhark/log.jsonl
  run/run-ba-manual/log.jsonl
No such file or directory (os error 2)
$ RUST_BACKTRACE=1 ./gradbench repo stats run -o stats
ba
  run/run-ba-adept/log.jsonl
  run/run-ba-adol-c/log.jsonl
  run/run-ba-codipack/log.jsonl
  run/run-ba-enzyme/log.jsonl
  run/run-ba-finite/log.jsonl
  run/run-ba-futhark/log.jsonl
  run/run-ba-manual/log.jsonl
No such file or directory (os error 2)
```

In contrast, on commit a6a7e31cdae4c47df2e6ae9a6d5a1cb7e9815633:

```
$ ./gradbench repo stats run -o stats
ba
  run/run-ba-adept/log.jsonl
  run/run-ba-adol-c/log.jsonl
  run/run-ba-codipack/log.jsonl
  run/run-ba-enzyme/log.jsonl
  run/run-ba-finite/log.jsonl
  run/run-ba-futhark/log.jsonl
  run/run-ba-manual/log.jsonl
No such file or directory (os error 2)
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
$ RUST_BACKTRACE=1 ./gradbench repo stats run -o stats
ba
  run/run-ba-adept/log.jsonl
  run/run-ba-adol-c/log.jsonl
  run/run-ba-codipack/log.jsonl
  run/run-ba-enzyme/log.jsonl
  run/run-ba-finite/log.jsonl
  run/run-ba-futhark/log.jsonl
  run/run-ba-manual/log.jsonl
No such file or directory (os error 2)
   0: std::backtrace_rs::backtrace::libunwind::trace
             at /rustc/4d91de4e48198da2e33413efdcd9cd2cc0c46688/library/std/src/../../backtrace/src/backtrace/libunwind.rs:116:5
   1: std::backtrace_rs::backtrace::trace_unsynchronized
             at /rustc/4d91de4e48198da2e33413efdcd9cd2cc0c46688/library/std/src/../../backtrace/src/backtrace/mod.rs:66:5
   2: std::backtrace::Backtrace::create
             at /rustc/4d91de4e48198da2e33413efdcd9cd2cc0c46688/library/std/src/backtrace.rs:331:13
   3: anyhow::error::<impl core::convert::From<E> for anyhow::Error>::from
             at /Users/samueles/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/anyhow-1.0.96/src/backtrace.rs:27:14
   4: <core::result::Result<T,F> as core::ops::try_trait::FromResidual<core::result::Result<core::convert::Infallible,E>>>::from_residual
             at /Users/samueles/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/result.rs:2014:27
   5: gradbench::stats::generate
             at ./crates/gradbench/src/stats.rs:314:49
   6: gradbench::cli
             at ./crates/gradbench/src/main.rs:665:21
   7: gradbench::main
             at ./crates/gradbench/src/main.rs:674:11
   8: core::ops::function::FnOnce::call_once
             at /Users/samueles/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/ops/function.rs:250:5
   9: std::sys::backtrace::__rust_begin_short_backtrace
             at /Users/samueles/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/src/rust/library/std/src/sys/backtrace.rs:152:18
  10: std::rt::lang_start::{{closure}}
  11: core::ops::function::impls::<impl core::ops::function::FnOnce<A> for &F>::call_once
             at /rustc/4d91de4e48198da2e33413efdcd9cd2cc0c46688/library/core/src/ops/function.rs:284:13
  12: std::panicking::try::do_call
             at /rustc/4d91de4e48198da2e33413efdcd9cd2cc0c46688/library/std/src/panicking.rs:584:40
  13: std::panicking::try
             at /rustc/4d91de4e48198da2e33413efdcd9cd2cc0c46688/library/std/src/panicking.rs:547:19
  14: std::panic::catch_unwind
             at /rustc/4d91de4e48198da2e33413efdcd9cd2cc0c46688/library/std/src/panic.rs:358:14
  15: std::rt::lang_start_internal::{{closure}}
             at /rustc/4d91de4e48198da2e33413efdcd9cd2cc0c46688/library/std/src/rt.rs:174:48
  16: std::panicking::try::do_call
             at /rustc/4d91de4e48198da2e33413efdcd9cd2cc0c46688/library/std/src/panicking.rs:584:40
  17: std::panicking::try
             at /rustc/4d91de4e48198da2e33413efdcd9cd2cc0c46688/library/std/src/panicking.rs:547:19
  18: std::panic::catch_unwind
             at /rustc/4d91de4e48198da2e33413efdcd9cd2cc0c46688/library/std/src/panic.rs:358:14
  19: std::rt::lang_start_internal
             at /rustc/4d91de4e48198da2e33413efdcd9cd2cc0c46688/library/std/src/rt.rs:174:20
  20: _main
```