### PR TITLE
Enable Clippy in VS Code

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,5 +9,6 @@
   },
   "files.insertFinalNewline": true,
   "files.trimFinalNewlines": true,
-  "files.trimTrailingWhitespace": true
+  "files.trimTrailingWhitespace": true,
+  "rust-analyzer.check.command": "clippy"
 }


### PR DESCRIPTION
We've been running it in CI since #147, so might as well automatically enable it in VS Code too.