### PR TITLE
ba: deduplicate Jacobian

### DIFF
--- a/cpp/gradbench/evals/ba.hpp
+++ b/cpp/gradbench/evals/ba.hpp
@@ -364,10 +364,30 @@ void to_json(nlohmann::json& j, const ObjOutput& p) {
 }
 
 void to_json(nlohmann::json& j, const JacOutput& p) {
+  int num_reproj_err_elems = 2*(BA_NCAMPARAMS+4);
+
+  std::vector<double> repeated_vals(num_reproj_err_elems+1);
+  std::copy(p.vals.begin(),
+            p.vals.begin()+num_reproj_err_elems,
+            repeated_vals.begin());
+  repeated_vals[num_reproj_err_elems] = p.vals.back();
+
+  std::vector<int> repeated_rows(num_reproj_err_elems+1);
+  std::copy(p.rows.begin(),
+            p.rows.begin()+num_reproj_err_elems,
+            repeated_rows.begin());
+  repeated_rows[num_reproj_err_elems] = p.rows.back();
+
+  std::vector<int> repeated_cols(num_reproj_err_elems+1);
+  std::copy(p.cols.begin(),
+            p.cols.begin()+num_reproj_err_elems,
+            repeated_cols.begin());
+  repeated_cols[num_reproj_err_elems] = p.cols.back();
+
   j = {
-    {"rows", p.rows},
-    {"cols", p.cols},
-    {"vals", p.vals}
+    {"rows", repeated_rows},
+    {"cols", repeated_cols},
+    {"vals", repeated_vals}
   };
 }
 

--- a/evals/ba/README.md
+++ b/evals/ba/README.md
@@ -68,20 +68,38 @@ interface BAInput extends Runs {
 }
 ```
 
+The `p` input is a duplication parameter - the tool is expected to
+duplicate the input `p` times. The tool must not actually exploit this
+duplication to reduce the work.
+
 ### Outputs
 
 A tool must respond to an `EvaluateMessage` with an `EvaluateResponse`. The type of the `output` field in the `EvaluateResponse` depends on the `function` field in the `EvaluateMessage`:
 
 - `"objective"`: `BAObjectiveOutput`.
-- `"jacobian"`: `BAObjectiveOutput`.
+- `"jacobian"`: `BAJacobianOutput`.
 
 ```typescript
-interface BAOutput {
-  cols: int[];
-  rows: int[];
-  vals: double[];
+interface BAObjectiveOutput {
+  reproj_err: double[];
+  w_err: double[];
 }
 ```
+
+```typescript
+interface BAJacobianOutput {
+  cols: int[31];
+  rows: int[31];
+  vals: double[31];
+}
+```
+
+The `BAJacobianOutput` represents a sparse matrix in [COO][] format,
+albeit in the form of three lists instead of a list of triples.
+Further, to make the matrix smaller, we undo the factor-`p`
+duplication of the input (see above) and store only a subset of the
+full lists. Specifically, we transmit only the first 30 elements and
+the last element.
 
 Because the input extends `Runs`, the tool is expected to run the function some number of times. It should include one timing entry with the name `"evaluate"` for each time it ran the function.
 
@@ -89,3 +107,4 @@ Because the input extends `Runs`, the tool is expected to run the function some 
 [data]: https://github.com/microsoft/ADBench/tree/38cb7931303a830c3700ca36ba9520868327ac87/data/ba
 [io]: https://github.com/microsoft/ADBench/blob/38cb7931303a830c3700ca36ba9520868327ac87/src/python/shared/BAData.py
 [typescript]: https://www.typescriptlang.org/
+[COO]: https://en.wikipedia.org/wiki/Sparse_matrix#Coordinate_list_(COO)

--- a/python/gradbench/gradbench/comparison.py
+++ b/python/gradbench/gradbench/comparison.py
@@ -59,10 +59,11 @@ def compare_json_objects(expected, actual, tolerance=1e-4, path=""):
             mismatches.append(
                 f"{path}: Expected array of length {expected_len}, got array of length {actual_len}."
             )
-        for i in range(expected_len):
-            mismatches.extend(
-                compare_json_objects(expected[i], actual[i], tolerance, f"{path}[{i}]")
-            )
+        else:
+            for i in range(expected_len):
+                mismatches.extend(
+                    compare_json_objects(expected[i], actual[i], tolerance, f"{path}[{i}]")
+                )
 
     elif isinstance(expected, float) and isinstance(actual, float):
         if difference(np.array(actual), np.array(expected)) > tolerance:

--- a/python/gradbench/gradbench/tools/pytorch/ba.py
+++ b/python/gradbench/gradbench/tools/pytorch/ba.py
@@ -117,10 +117,12 @@ def objective_output(errors):
 
 # Convert jacobian output to dictionary
 def jacobian_output(ba_mat):
+    def dedup(A):
+        return A[0:30] + [A[-1]]
     return {
-        "rows": list(map(int, list(ba_mat.rows))),
-        "cols": list(map(int, list(ba_mat.cols))),
-        "vals": list(map(float, list(ba_mat.vals))),
+        "rows": list(map(int,dedup(list(ba_mat.rows)))),
+        "cols": list(map(int,dedup(list(ba_mat.cols)))),
+        "vals": list(map(float,dedup(list(ba_mat.vals)))),
     }
 
 

--- a/python/gradbench/gradbench/tools/tensorflow/ba.py
+++ b/python/gradbench/gradbench/tools/tensorflow/ba.py
@@ -197,10 +197,12 @@ def objective_output(errors):
 
 
 def jacobian_output(ba_mat):
+    def dedup(A):
+        return A[0:30] + [A[-1]]
     return {
-        "rows": list(map(int, list(ba_mat.rows))),
-        "cols": list(map(int, list(ba_mat.cols))),
-        "vals": list(map(float, list(ba_mat.vals))),
+        "rows": list(map(int, dedup(list(ba_mat.rows)))),
+        "cols": list(map(int, dedup(list(ba_mat.cols)))),
+        "vals": list(map(float, dedup(list(ba_mat.vals)))),
     }
 
 

--- a/tools/futhark/ba.py
+++ b/tools/futhark/ba.py
@@ -60,11 +60,14 @@ def jacobian(server, input):
         input["min_runs"],
         input["min_seconds"],
     )
+    def dedup(A):
+        l = A.tolist()
+        return l[0:30] + [l[-1]]
     return (
         {
-            "rows": rows.tolist(),
-            "cols": cols.tolist(),
-            "vals": vals.tolist(),
+            "rows": dedup(rows),
+            "cols": dedup(cols),
+            "vals": dedup(vals),
         },
         times,
     )


### PR DESCRIPTION
This modifies the ba eval to not require transmitting the repeated parts of the Jacobian.

The purpose of this is to significantly shrink the size of the ba log files.