### PR TITLE
Tweak Enzyme Dockerfile

### DIFF
--- a/tools/enzyme/Dockerfile
+++ b/tools/enzyme/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM debian:trixie
 ARG ENZYME_VER=0.0.172
 
 WORKDIR /gradbench
@@ -8,7 +8,8 @@ RUN apt-get update
 RUN apt-get install -y \
     build-essential \
     python3 \
-    wget
+    wget \
+    git
 
 RUN apt-get install -y \
     ninja-build \
@@ -16,6 +17,7 @@ RUN apt-get install -y \
     libzstd-dev \
     llvm-19 \
     clang-19 \
+    libclang-19-dev \
     lld-19
 
 COPY python /gradbench/python
@@ -29,7 +31,7 @@ RUN update-alternatives --install /usr/bin/lld lld /usr/bin/lld-19 100
 RUN wget https://github.com/EnzymeAD/Enzyme/archive/refs/tags/v${ENZYME_VER}.tar.gz
 RUN tar xvf v${ENZYME_VER}.tar.gz && rm -f v${ENZYME_VER}.tar.gz
 RUN mkdir enzyme-build
-RUN cd enzyme-build && cmake -G Ninja /gradbench/Enzyme-${ENZYME_VER}/enzyme -DLLVM_DIR=/usr/lib/llvm-19/lib/cmake/llvm/
+RUN cd enzyme-build && cmake -G Ninja /gradbench/Enzyme-${ENZYME_VER}/enzyme -DLLVM_DIR=/usr/lib/llvm-19/lib/cmake/llvm/ -DClang_DIR=/usr/lib/llvm-19/lib/cmake/clang/
 RUN ninja -C enzyme-build
 
 COPY cpp /gradbench/cpp


### PR DESCRIPTION
Now builds from a more controllable Debian image, and also ensure that the Enzyme Clang plugin is built (although we don't yet use it).

The main short-term purpose of this is actually to get a slightly newer version of LLVM.