### PR TITLE
Replaced `pkgs.nixfmt` with `pkgs.nixfmt-classic`

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -64,7 +64,7 @@ in pkgs.stdenv.mkDerivation {
     pkgs.niv
     pkgs.gh
     pkgs.ruff
-    pkgs.nixfmt
+    pkgs.nixfmt-classic
 
     pkgs.futhark
     pkgs.enzyme


### PR DESCRIPTION
Currently, starting a Nix shell prints the following warning four times:

```
evaluation warning: nixfmt was renamed to nixfmt-classic. The nixfmt attribute may be used for the new RFC 166-style formatter in the future, which is currently available as nixfmt-rfc-style
evaluation warning: nixfmt was renamed to nixfmt-classic. The nixfmt attribute may be used for the new RFC 166-style formatter in the future, which is currently available as nixfmt-rfc-style
evaluation warning: nixfmt was renamed to nixfmt-classic. The nixfmt attribute may be used for the new RFC 166-style formatter in the future, which is currently available as nixfmt-rfc-style
evaluation warning: nixfmt was renamed to nixfmt-classic. The nixfmt attribute may be used for the new RFC 166-style formatter in the future, which is currently available as nixfmt-rfc-style
```

This PR fixes it.