### PR TITLE
Explicit tool colors when plotting

### DIFF
--- a/packages/gradbench/src/Stats.tsx
+++ b/packages/gradbench/src/Stats.tsx
@@ -8,7 +8,7 @@ import "./Stats.css";
 // some are unfortunately a little close to each other.
 const colors = [
   ["adept", "#d8702f"],
-  ["adolc", "#0d1117"],
+  ["adol-c", "#0d1117"],
   ["codipack", "#d02718"],
   ["cppad", "#eeb10f"],
   ["enzyme", "#173559"],

--- a/packages/gradbench/src/Stats.tsx
+++ b/packages/gradbench/src/Stats.tsx
@@ -6,25 +6,25 @@ import "./Stats.css";
 // These colors have been determined by sampling the tool websites.
 // They are not picked to make a particularly pleasing scheme, and
 // some are unfortunately a little close to each other.
-const colors = [
-  ["adept", "#d8702f"],
-  ["adol-c", "#0d1117"],
-  ["codipack", "#d02718"],
-  ["cppad", "#eeb10f"],
-  ["enzyme", "#173559"],
-  ["finite", "#aaaaaa"],
-  ["floretta", "#f10537"],
-  ["futhark", "#5f021f"],
-  ["haskell", "#5e5086"],
-  ["jax", "#5e98f6"],
-  ["manual", "#000000"],
-  ["ocaml", "#c24f1e"],
-  ["pytorch", "#ee4c2c"],
-  ["scilean", "#5c123a"],
-  ["tapenade", "#047f01"],
-  ["tensorflow", "#ff8d00"],
-  ["zygote", "#6daa5e"],
-];
+const colors = {
+  adept: "#d8702f",
+  "adol-c": "#0d1117",
+  codipack: "#d02718",
+  cppad: "#eeb10f",
+  enzyme: "#173559",
+  finite: "#aaaaaa",
+  floretta: "#f10537",
+  futhark: "#5f021f",
+  haskell: "#5e5086",
+  jax: "#5e98f6",
+  manual: "#000000",
+  ocaml: "#c24f1e",
+  pytorch: "#ee4c2c",
+  scilean: "#5c123a",
+  tapenade: "#047f01",
+  tensorflow: "#ff8d00",
+  zygote: "#6daa5e",
+};
 
 const makeSpec = ({
   title,
@@ -53,8 +53,8 @@ const makeSpec = ({
         field: "tool",
         type: "nominal",
         scale: {
-          domain: colors.map((l) => l[0]),
-          range: colors.map((l) => l[1]),
+          domain: Object.keys(colors),
+          range: Object.values(colors),
         },
         legend: { values: tools },
       },

--- a/packages/gradbench/src/Stats.tsx
+++ b/packages/gradbench/src/Stats.tsx
@@ -50,11 +50,13 @@ const makeSpec = ({
     transform: [{ filter: { param: "tool" } }],
     encoding: {
       color: {
-          field: "tool",
-          type: "nominal",
-          scale: {domain: colors.map(l => l[0]),
-                  range: colors.map(l => l[1])},
-          legend: { values: tools },
+        field: "tool",
+        type: "nominal",
+        scale: {
+          domain: colors.map((l) => l[0]),
+          range: colors.map((l) => l[1]),
+        },
+        legend: { values: tools },
       },
       x: {
         field: "workload",

--- a/packages/gradbench/src/Stats.tsx
+++ b/packages/gradbench/src/Stats.tsx
@@ -3,6 +3,29 @@ import { PlainObject, VegaLite } from "react-vega";
 import { TopLevelSpec } from "vega-lite";
 import "./Stats.css";
 
+// These colors have been determined by sampling the tool websites.
+// They are not picked to make a particularly pleasing scheme, and
+// some are unfortunately a little close to each other.
+const colors = [
+  ["adept", "#d8702f"],
+  ["adolc", "#0d1117"],
+  ["codipack", "#d02718"],
+  ["cppad", "#eeb10f"],
+  ["enzyme", "#173559"],
+  ["finite", "#aaaaaa"],
+  ["floretta", "#f10537"],
+  ["futhark", "#5f021f"],
+  ["haskell", "#5e5086"],
+  ["jax", "#5e98f6"],
+  ["manual", "#000000"],
+  ["ocaml", "#c24f1e"],
+  ["pytorch", "#ee4c2c"],
+  ["scilean", "#5c123a"],
+  ["tapenade", "#047f01"],
+  ["tensorflow", "#ff8d00"],
+  ["zygote", "#6daa5e"],
+];
+
 const makeSpec = ({
   title,
   yaxis,
@@ -27,9 +50,11 @@ const makeSpec = ({
     transform: [{ filter: { param: "tool" } }],
     encoding: {
       color: {
-        field: "tool",
-        type: "nominal",
-        legend: { values: tools },
+          field: "tool",
+          type: "nominal",
+          scale: {domain: colors.map(l => l[0]),
+                  range: colors.map(l => l[1])},
+          legend: { values: tools },
       },
       x: {
         field: "workload",

--- a/packages/gradbench/src/Stats.tsx
+++ b/packages/gradbench/src/Stats.tsx
@@ -137,6 +137,7 @@ export const Stats = ({ url }: { url: string }) => {
       </p>
       <div className="chart-box">
         <VegaLite
+          renderer="svg"
           spec={makeSpec({
             title: "ratio",
             yaxis: "derivative / primal",
@@ -149,6 +150,7 @@ export const Stats = ({ url }: { url: string }) => {
       </div>
       <div className="chart-box">
         <VegaLite
+          renderer="svg"
           spec={makeSpec({
             title: "derivative",
             yaxis: "derivative (seconds)",
@@ -159,6 +161,7 @@ export const Stats = ({ url }: { url: string }) => {
       </div>
       <div className="chart-box">
         <VegaLite
+          renderer="svg"
           spec={makeSpec({
             title: "primal",
             yaxis: "primal (seconds)",

--- a/packages/gradbench/src/Stats.tsx
+++ b/packages/gradbench/src/Stats.tsx
@@ -8,7 +8,7 @@ import "./Stats.css";
 // some are unfortunately a little close to each other.
 const colors = {
   adept: "#d8702f",
-  "adol-c": "#0d1117",
+  "adol-c": "#9da117",
   codipack: "#d02718",
   cppad: "#eeb10f",
   enzyme: "#173559",


### PR DESCRIPTION
These colors are pretty arbitrarily set, but easy to change. It still doesn't make the graphs exactly easy to read, but at least they are unambiguous. When I could not find a theme color on a tool home page, I tried writing the tools name in 1337 speak.

Fixes #346.