### PR TITLE
Put the derivative chart above the ratio chart

### DIFF
--- a/packages/gradbench/src/Stats.tsx
+++ b/packages/gradbench/src/Stats.tsx
@@ -139,6 +139,17 @@ export const Stats = ({ url }: { url: string }) => {
         <VegaLite
           renderer="svg"
           spec={makeSpec({
+            title: "derivative",
+            yaxis: "derivative (seconds)",
+            tools,
+          })}
+          data={makeData(stats, ({ derivative }) => seconds(derivative))}
+        />
+      </div>
+      <div className="chart-box">
+        <VegaLite
+          renderer="svg"
+          spec={makeSpec({
             title: "ratio",
             yaxis: "derivative / primal",
             tools,
@@ -146,17 +157,6 @@ export const Stats = ({ url }: { url: string }) => {
           data={makeData(stats, ({ primal, derivative }) =>
             divide(seconds(derivative), seconds(primal)),
           )}
-        />
-      </div>
-      <div className="chart-box">
-        <VegaLite
-          renderer="svg"
-          spec={makeSpec({
-            title: "derivative",
-            yaxis: "derivative (seconds)",
-            tools,
-          })}
-          data={makeData(stats, ({ derivative }) => seconds(derivative))}
         />
       </div>
       <div className="chart-box">


### PR DESCRIPTION
I think it gives a better overall view of which tools are fast and which are slow.