### PR TITLE
Use uv in `shell.nix`

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -23,10 +23,11 @@ in pkgs.stdenv.mkDerivation {
   name = "gradbench";
   buildInputs = [
     pkgs.bun
-    pkgs.niv
     pkgs.gh
-    pkgs.uv
+    pkgs.niv
     pkgs.nixfmt-classic
+    pkgs.python311
+    pkgs.uv
 
     pkgs.futhark
     pkgs.enzyme

--- a/shell.nix
+++ b/shell.nix
@@ -1,8 +1,5 @@
 # shell.nix for use with Nix, in order to run GradBench locally.
 #
-# May get out of sync with the uv setup, but hopefully it is not too
-# difficult to maintain manually.
-#
 # The Nixpkgs snapshot is pinned with niv. Use
 #
 #  $ niv update nixpkgs -b nixos-unstable
@@ -18,40 +15,6 @@ let
   sources = import ./nix/sources.nix;
   pkgs = import sources.nixpkgs { };
 
-  gradbench-python-packages = ps:
-    with ps; [
-      (buildPythonPackage rec {
-        pname = "futhark-data";
-        version = "1.0.2";
-        src = fetchPypi {
-          inherit pname version;
-          sha256 = "sha256-FJOhVr65U3kP408BbA42jbGGD6x+tVh+TNhsYv8bUT0=";
-        };
-        doCheck = false;
-      })
-      (buildPythonPackage rec {
-        pname = "futhark-server";
-        version = "1.0.0";
-        src = fetchPypi {
-          inherit pname version;
-          sha256 = "sha256-I2+8BeEOPOV0fXtrXdz/eqCj8DFAJTbKmUKy43oiyjE=";
-        };
-        doCheck = false;
-      })
-      numpy
-      termcolor
-      black
-      isort
-      pytorch
-      jax
-      jaxlib
-      tensorflow
-      autograd
-      dataclasses-json
-      pydantic
-      matplotlib
-    ];
-  gradbench-python = pkgs.python3.withPackages gradbench-python-packages;
   cppad = pkgs.callPackage ./nix/cppad.nix { };
   adept = pkgs.callPackage ./nix/adept.nix { };
   codipack = pkgs.callPackage ./nix/codipack.nix { };
@@ -59,11 +22,10 @@ let
 in pkgs.stdenv.mkDerivation {
   name = "gradbench";
   buildInputs = [
-    gradbench-python
     pkgs.bun
     pkgs.niv
     pkgs.gh
-    pkgs.ruff
+    pkgs.uv
     pkgs.nixfmt-classic
 
     pkgs.futhark


### PR DESCRIPTION
I don't see a reason to list all the Python packages separately via Nix, resulting in different versions from `uv.lock`. @athas I seem to remember you saying there was some reason not to do this, though; can you remind me what that is?