### PR TITLE
intermediary: kill tool on timeout

### DIFF
--- a/crates/gradbench/src/intermediary.rs
+++ b/crates/gradbench/src/intermediary.rs
@@ -405,7 +405,7 @@ pub fn run(
         }
     }
     let start = Instant::now();
-    Intermediary {
+    let outcome = Intermediary {
         outcome,
         eval_in: eval.stdin.take().unwrap(),
         tool_in: tool.stdin.take().unwrap(),
@@ -414,8 +414,22 @@ pub fn run(
         clock: || start.elapsed(),
         out: io::stdout(),
         log,
+    }.run();
+    // If fail due to a timeout, the tool may still be running. Kill
+    // its process group to ensure that we will not be hanging in a
+    // wait() call in main.rs.
+    if let Err(BadOutcome::Timeout) = outcome {
+        #[cfg(unix)] {
+            use nix::{sys::signal, unistd};
+            if let Ok(tool_id) = tool.id().try_into() {
+                let tool_pid = unistd::Pid::from_raw(tool_id);
+                if let Ok(pgid) = unistd::getpgid(Some(tool_pid)) {
+                    let _ = signal::killpg(pgid, signal::Signal::SIGKILL);
+                }
+            }
+        }
     }
-    .run()
+    return outcome;
 }
 
 #[cfg(test)]

--- a/crates/gradbench/src/intermediary.rs
+++ b/crates/gradbench/src/intermediary.rs
@@ -414,12 +414,14 @@ pub fn run(
         clock: || start.elapsed(),
         out: io::stdout(),
         log,
-    }.run();
+    }
+    .run();
     // If fail due to a timeout, the tool may still be running. Kill
     // its process group to ensure that we will not be hanging in a
     // wait() call in main.rs.
     if let Err(BadOutcome::Timeout) = outcome {
-        #[cfg(unix)] {
+        #[cfg(unix)]
+        {
             use nix::{sys::signal, unistd};
             if let Ok(tool_id) = tool.id().try_into() {
                 let tool_pid = unistd::Pid::from_raw(tool_id);


### PR DESCRIPTION
This kills the tool process when the intermediary fails with a timeout.

Fixes #374, but will in most cases not actually kill all subprocesses spawned by the tool, in case they are in a sub-process group.