### PR TITLE
Run Prettier in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,26 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  test:
+  check-js:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install Bun
+        uses: oven-sh/setup-bun@v2
+      - name: Install npm dependencies
+        run: bun install
+      - name: Check Markdown tables of contents
+        run: |
+          bun run toc
+          CHANGES=$(git status --porcelain)
+          echo "$CHANGES"
+          git diff
+          [ -z "$CHANGES" ]
+      - name: Check Prettier formatting
+        run: bun run prettier --check .
+
+  check-py:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
@@ -19,22 +38,16 @@ jobs:
         uses: actions/setup-python@v5
       - name: Install uv
         uses: astral-sh/setup-uv@v5
-      - name: Install Bun
-        uses: oven-sh/setup-bun@v2
-      - name: Install npm dependencies
-        run: bun install
-      - name: Update Markdown tables of contents
-        run: bun run toc
-      - name: Check if that changed anything
-        run: |
-          CHANGES=$(git status --porcelain)
-          echo "$CHANGES"
-          git diff
-          [ -z "$CHANGES" ]
       - name: Lint Python code
         run: uv run ruff check
       - name: Check Python formatting
         run: uv run ruff format --check
+
+  check-rs:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
       - name: Lint Rust code
         run: cargo clippy
       - name: Test Rust code

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,4 @@
+/.venv/
+/nix/sources.json
+/tools/haskell/dist-newstyle/
+/tools/scilean/lake-manifest.json

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,1 +1,0 @@
-{ "plugins": ["prettier-plugin-organize-imports"] }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,15 @@
 {
+  "[css]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
+  "[html]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
+  "[json]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
+  "[jsonc]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
+  "[markdown]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
   "[python]": {
     "editor.codeActionsOnSave": { "source.organizeImports": "always" },
     "editor.defaultFormatter": "charliermarsh.ruff"
   },
+  "[typescript]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
+  "[typescriptreact]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
   "editor.formatOnSave": true,
   "files.associations": {
     "time.h": "c"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,7 @@
   - [Multi-platform images](#multi-platform-images)
 - [Tools](#tools)
 - [JavaScript](#javascript)
+  - [Prettier](#prettier)
   - [Markdown](#markdown)
   - [Website](#website)
 - [Python](#python)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,6 +116,14 @@ We use Bun for JavaScript code in this repository. First install all dependencie
 bun install
 ```
 
+### Prettier
+
+We use [Prettier][] to format a lot of different files in this repository. If you're using [VS Code][], our configuration in this repository should automatically recommend that you install the Prettier extension, as well as automatically run it whenever you save an applicable file. You can also run it manually via the command line:
+
+```sh
+bun run format
+```
+
 ### Markdown
 
 This file and [`README.md`](README.md) use [markdown-toc][] to generate the table of contents at the top. If you add/modify/delete any Markdown section headers, run this command to regenerate those tables of contents:
@@ -317,6 +325,7 @@ type Session = (MessageLine | ResponseLine)[];
 [markdown-toc]: https://www.npmjs.com/package/markdown-toc
 [multi-platform images]: https://docs.docker.com/build/building/multi-platform/
 [nix]: https://nixos.org/
+[prettier]: https://prettier.io/
 [python]: https://docs.astral.sh/uv/guides/install-python/
 [qemu]: https://docs.docker.com/build/building/multi-platform/#install-qemu-manually
 [ruff]: https://docs.astral.sh/ruff/

--- a/package.json
+++ b/package.json
@@ -20,8 +20,14 @@
     "vite": "^5"
   },
   "scripts": {
+    "format": "prettier --write .",
     "toc": "bun run toc-contributing && bun run toc-readme",
     "toc-contributing": "markdown-toc --bullets='-' -i CONTRIBUTING.md",
     "toc-readme": "markdown-toc --bullets='-' -i README.md"
+  },
+  "prettier": {
+    "plugins": [
+      "prettier-plugin-organize-imports"
+    ]
   }
 }

--- a/tools/adol-c/README.md
+++ b/tools/adol-c/README.md
@@ -6,7 +6,7 @@ based on operator overloading. Its usage is discussed in [Algorithm
 written in C/C++](https://dl.acm.org/doi/10.1145/229473.229474).
 
 When using ADOL-C, you first evaluate the objective function to
-construct the *tape*, which will contain a record of all arithmetic
+construct the _tape_, which will contain a record of all arithmetic
 operations. Then you interpret the tape in various ways to compute
 gradients. In the [ADBench
 implementations](https://github.com/microsoft/ADBench/blob/38cb7931303a830c3700ca36ba9520868327ac87/tools/ADOLC/main.cpp),

--- a/tools/ocaml/README.md
+++ b/tools/ocaml/README.md
@@ -45,4 +45,4 @@ actually want to pass this command as the `--tool` argument to
 `gradbench`.
 
 [opam]: https://opam.ocaml.org/
-[Dune](https://dune.build/)
+[Dune]: https://dune.build/


### PR DESCRIPTION
This PR splits our `test` CI job into three `check-*` jobs according to what tools need to be installed for each, and adds Prettier to the `check-js` job. For consistency and convenience, I also created a [`.prettierignore`](https://prettier.io/docs/ignore) file and added relevant stuff to `CONTRIBUTING.md` and `.vscode/settings.json`.