### PR TITLE
Fail CI if Clippy warns

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Lint Rust code
-        run: cargo clippy
+        run: cargo clippy -- -Dwarnings
       - name: Test Rust code
         run: cargo test
 


### PR DESCRIPTION
Meant to do this back in #147 but I didn't know how; turns out it's not hard: https://doc.rust-lang.org/clippy/usage.html#command-line