### PR TITLE
Add Commentary

### DIFF
--- a/evals/ba/README.md
+++ b/evals/ba/README.md
@@ -103,6 +103,11 @@ the last element.
 
 Because the input extends `Runs`, the tool is expected to run the function some number of times. It should include one timing entry with the name `"evaluate"` for each time it ran the function.
 
+## Commentary
+
+The actual objective function in this eval is not particularly
+challenging.
+
 [adbench]: https://github.com/microsoft/ADBench/tree/38cb7931303a830c3700ca36ba9520868327ac87
 [data]: https://github.com/microsoft/ADBench/tree/38cb7931303a830c3700ca36ba9520868327ac87/data/ba
 [io]: https://github.com/microsoft/ADBench/blob/38cb7931303a830c3700ca36ba9520868327ac87/src/python/shared/BAData.py

--- a/evals/ba/README.md
+++ b/evals/ba/README.md
@@ -105,11 +105,22 @@ Because the input extends `Runs`, the tool is expected to run the function some 
 
 ## Commentary
 
-The actual objective function in this eval is not particularly
-challenging.
+The actual objective function in this benchmark is not particularly
+challenging, and is mostly a bunch of scalar control flow with a
+bounded control flow graph. The annoying part is that the result must
+be reported as a particular encoding of a sparse matrix. This is not
+so difficult if you are implementing this eval in C++ - use the
+provided data structure in [ba.hpp][] and look at how
+[tools/manual/run_ba.cpp] does it. It is a lot more annoying if you
+are using another language, and _particulary_ if you want to compute
+the sparse Jacobian in parallel. See [tools/futhark/ba.fut][] for how
+to do this.
 
 [adbench]: https://github.com/microsoft/ADBench/tree/38cb7931303a830c3700ca36ba9520868327ac87
 [data]: https://github.com/microsoft/ADBench/tree/38cb7931303a830c3700ca36ba9520868327ac87/data/ba
 [io]: https://github.com/microsoft/ADBench/blob/38cb7931303a830c3700ca36ba9520868327ac87/src/python/shared/BAData.py
 [typescript]: https://www.typescriptlang.org/
 [COO]: https://en.wikipedia.org/wiki/Sparse_matrix#Coordinate_list_(COO)
+[ba.hpp]: ../../cpp/gradbench/evals/ba.hpp
+[tools/manual/run_ba.cpp]: ../../tools/manual/run_ba.cpp
+[tools/futhark/ba.fut]: ../../tools/futhark/ba.fut

--- a/evals/ba/README.md
+++ b/evals/ba/README.md
@@ -121,6 +121,6 @@ to do this.
 [io]: https://github.com/microsoft/ADBench/blob/38cb7931303a830c3700ca36ba9520868327ac87/src/python/shared/BAData.py
 [typescript]: https://www.typescriptlang.org/
 [COO]: https://en.wikipedia.org/wiki/Sparse_matrix#Coordinate_list_(COO)
-[ba.hpp]: ../../cpp/gradbench/evals/ba.hpp
-[tools/manual/run_ba.cpp]: ../../tools/manual/run_ba.cpp
-[tools/futhark/ba.fut]: ../../tools/futhark/ba.fut
+[ba.hpp]: /cpp/gradbench/evals/ba.hpp
+[tools/manual/run_ba.cpp]: /tools/manual/run_ba.cpp
+[tools/futhark/ba.fut]: /tools/futhark/ba.fut

--- a/evals/ba/README.md
+++ b/evals/ba/README.md
@@ -112,7 +112,7 @@ be reported as a particular encoding of a sparse matrix. This is not
 so difficult if you are implementing this eval in C++ - use the
 provided data structure in [ba.hpp][] and look at how
 [tools/manual/run_ba.cpp] does it. It is a lot more annoying if you
-are using another language, and _particulary_ if you want to compute
+are using another language, and _particularly_ if you want to compute
 the sparse Jacobian in parallel. See [tools/futhark/ba.fut][] for how
 to do this.
 

--- a/evals/det/README.md
+++ b/evals/det/README.md
@@ -77,4 +77,4 @@ the only way to express this problem. See [det.fut][] for an example.
 [expansion by minors]: https://mathworld.wolfram.com/DeterminantExpansionbyMinors.html
 [protocol]: /CONTRIBUTING.md#types
 [typescript]: https://www.typescriptlang.org/
-[det.fut]: ../../tools/futhark/det.fut
+[det.fut]: /tools/futhark/det.fut

--- a/evals/det/README.md
+++ b/evals/det/README.md
@@ -60,8 +60,21 @@ type GradientOutput = double[];
 The `GradientOutput` is the gradient in row-major order, its length is
 equal to the length of the input field `A`.
 
+## Commentary
+
+This benchmark is best implemented with reverse mode. The main
+challenge (for some tools) is that the direct formulation of this
+problem is extremely scalar-oriented, and based on recursion. This
+makes it difficult or impossible for tools to bundle up the work in
+larger chunks, which particularly hinders systems such as PyTorch. One
+solution is to refactor the computation to be nonrecursive, and
+instead directly compute all of the necessary $O(n!)$ permutations of
+multiplications. This is overall more expensive, but is for some tools
+the only way to express this problem. See [det.fut][] for an example.
+
 [cmpad]: https://github.com/bradbell/cmpad
 [original documentation]: https://cmpad.readthedocs.io/det_by_minor.html
 [expansion by minors]: https://mathworld.wolfram.com/DeterminantExpansionbyMinors.html
 [protocol]: /CONTRIBUTING.md#types
 [typescript]: https://www.typescriptlang.org/
+[det.fut]: ../../tools/futhark/det.fut

--- a/evals/gmm/README.md
+++ b/evals/gmm/README.md
@@ -96,9 +96,9 @@ difficult.
 [io]: https://github.com/microsoft/ADBench/blob/38cb7931303a830c3700ca36ba9520868327ac87/src/python/shared/GMMData.py
 [protocol]: /CONTRIBUTING.md#types
 [typescript]: https://www.typescriptlang.org/
-[gmm.hpp]: ../../cpp/gradbench/evals/gmm.hpp
-[gmm.fut]: ../../tool/futhark/gmm.fut
-[gmm_objective.py]: ../../python/gradbench/gradbench/tools/pytorch/gmm_objective.py
-[llsq]: ../llsq
-[lstm]: ../lstm
-[ode]: ../ode
+[gmm.hpp]: /cpp/gradbench/evals/gmm.hpp
+[gmm.fut]: /tool/futhark/gmm.fut
+[gmm_objective.py]: /python/gradbench/gradbench/tools/pytorch/gmm_objective.py
+[llsq]: /evals/llsq
+[lstm]: /evals/lstm
+[ode]: /evals/ode

--- a/evals/gmm/README.md
+++ b/evals/gmm/README.md
@@ -79,9 +79,26 @@ The `GMMJacobianOutput` value contains the concatenated gradients for the `alpha
 
 Because the input extends `Runs`, the tool is expected to run the function some number of times. It should include one timing entry with the name `"evaluate"` for each time it ran the function.
 
+## Commentary
+
+This eval is straightforward to implement from an AD perspective, as
+it computes a dense gradient of a scalar-valued function. The
+objective function can be easily expressed in a scalar way (see
+[gmm.hpp][] or [gmm.fut][]), or through linear algebra operations (see
+[gmm_objective.py][]). An even simpler eval with the same properties
+is [llsq][], which you might consider implementing first. After
+implementing `gmm`, implementing [lstm][] or [ode][] should not be so
+difficult.
+
 [adbench]: https://github.com/microsoft/ADBench/tree/38cb7931303a830c3700ca36ba9520868327ac87
 [data]: https://github.com/microsoft/ADBench/tree/38cb7931303a830c3700ca36ba9520868327ac87/data/gmm
 [gen]: https://github.com/microsoft/ADBench/blob/38cb7931303a830c3700ca36ba9520868327ac87/data/gmm/gmm-data-gen.py
 [io]: https://github.com/microsoft/ADBench/blob/38cb7931303a830c3700ca36ba9520868327ac87/src/python/shared/GMMData.py
 [protocol]: /CONTRIBUTING.md#types
 [typescript]: https://www.typescriptlang.org/
+[gmm.hpp]: ../../cpp/gradbench/evals/gmm.hpp
+[gmm.fut]: ../../tool/futhark/gmm.fut
+[gmm_objective.py]: ../../python/gradbench/gradbench/tools/pytorch/gmm_objective.py
+[llsq]: ../llsq
+[lstm]: ../lstm
+[ode]: ../ode

--- a/evals/hello/README.md
+++ b/evals/hello/README.md
@@ -5,3 +5,17 @@ The `hello` eval is the simplest one; it first defines a module named `"hello"` 
 - The `"square"` function implements $f : \mathbb{R} \to \mathbb{R}$ given by $f(x) = x^2$, taking a single number as output and returning the square of that value as output.
 
 - The `"double"` function is the gradient of the `"square"` function! It implements $\nabla f : \mathbb{R} \to \mathbb{R}$ given by $\nabla f(x) = 2x$, taking a single number as input, and returns twice that value as output.
+
+## Commentary
+
+This is not a real benchmark, in the sense that reporting its runtime
+is meaningful. Its only purpose is for testing a new tool, to verify
+that the basic implementation of the [protocol][] is operational.
+
+The simplest (real) benchmark is likely [llsq][].
+
+Note that in contrast to most other evals, `hello` does not have
+`min_runs` and `min_seconds` fields.
+
+[protocol]: /CONTRIBUTING.md#types
+[llsq]: ../llsq

--- a/evals/hello/README.md
+++ b/evals/hello/README.md
@@ -18,4 +18,4 @@ Note that in contrast to most other evals, `hello` does not have
 `min_runs` and `min_seconds` fields.
 
 [protocol]: /CONTRIBUTING.md#types
-[llsq]: ../llsq
+[llsq]: /evals/llsq

--- a/evals/kmeans/README.md
+++ b/evals/kmeans/README.md
@@ -53,7 +53,7 @@ Because the input extends `Runs`, the tool is expected to run the function some 
 Despite the quite simple objective function, this benchmark exercises
 a number of interesting things:
 
-1. Efficiently computing a *sparse* Hessian (just the diagonal). This
+1. Efficiently computing a _sparse_ Hessian (just the diagonal). This
    means that a tool that can compute the Hessian, but only the entire
    thing, would be at a disadvantage.
 

--- a/evals/kmeans/README.md
+++ b/evals/kmeans/README.md
@@ -48,6 +48,23 @@ type DirOutput = double[][];
 
 Because the input extends `Runs`, the tool is expected to run the function some number of times. It should include one timing entry with the name `"evaluate"` for each time it ran the function.
 
+## Commentary
+
+Despite the quite simple objective function, this benchmark exercises
+a number of interesting things:
+
+1. Efficiently computing a *sparse* Hessian (just the diagonal). This
+   means that a tool that can compute the Hessian, but only the entire
+   thing, would be at a disadvantage.
+
+2. Computing the Jacobian along with the Hessian. It is most efficient
+   to compute both at the same time (reusing work), but a tool might
+   not allow this.
+
+3. Computing the adjoint of the minimum operation in the primal
+   function may not be entirely straightforward, as it is "sparse",
+   but it is important for performance.
+
 [paper]: https://proceedings.neurips.cc/paper/1994/hash/a1140a3d0df1c81e24ae954d935e8926-Abstract.html
 [protocol]: /CONTRIBUTING.md#types
 [typescript]: https://www.typescriptlang.org/

--- a/evals/llsq/README.md
+++ b/evals/llsq/README.md
@@ -76,4 +76,4 @@ implementing it in tools such as [pytorch][].
 [original documentation]: https://cmpad.readthedocs.io/llsq_obj.html
 [protocol]: /CONTRIBUTING.md#types
 [typescript]: https://www.typescriptlang.org/
-[pytorch]: ../tools/pytorch
+[pytorch]: /tools/pytorch

--- a/evals/llsq/README.md
+++ b/evals/llsq/README.md
@@ -66,7 +66,14 @@ type GradientOutput = double[];
 The size of the `GradientOutput` is equal to the size of the input
 `x`.
 
+## Commentary
+
+This is a rather simple benchmark, and a good first one to implement.
+It can easily be expressed in a vectorised form, which is useful for
+implementing it in tools such as [pytorch][].
+
 [cmpad]: https://github.com/bradbell/cmpad
 [original documentation]: https://cmpad.readthedocs.io/llsq_obj.html
 [protocol]: /CONTRIBUTING.md#types
 [typescript]: https://www.typescriptlang.org/
+[pytorch]: ../tools/pytorch

--- a/evals/lstm/README.md
+++ b/evals/lstm/README.md
@@ -35,7 +35,18 @@ The `LSTMJacobianOutput` is the gradient of `main_params` and `extra_params`, fl
 
 Because the input extends `Runs`, the tool is expected to run the function some number of times. It should include one timing entry with the name `"evaluate"` for each time it ran the function.
 
+## Commentary
+
+This eval is similar to [gmm][] in that it asks for the gradient of a
+scalar-valued function, and is thus suited for reverse mode. The main
+additional challenge is that `lstm` also contains a sequential loop,
+which will require an AD tool to handle the taping/tracing
+efficiently. An even simpler eval with the same properties is [ode][],
+which you might consider implementing first.
+
 [adbench]: https://github.com/microsoft/ADBench
 [protocol]: /CONTRIBUTING.md#types
 [rename]: https://github.com/microsoft/ADBench/blob/38cb7931303a830c3700ca36ba9520868327ac87/ADBench/plot_graphs.py#L89-L92
 [typescript]: https://www.typescriptlang.org/
+[gmm]: ../gmm
+[ode]: ../ode

--- a/evals/lstm/README.md
+++ b/evals/lstm/README.md
@@ -48,5 +48,5 @@ which you might consider implementing first.
 [protocol]: /CONTRIBUTING.md#types
 [rename]: https://github.com/microsoft/ADBench/blob/38cb7931303a830c3700ca36ba9520868327ac87/ADBench/plot_graphs.py#L89-L92
 [typescript]: https://www.typescriptlang.org/
-[gmm]: ../gmm
-[ode]: ../ode
+[gmm]: /evals/gmm
+[ode]: /evals/ode

--- a/evals/ode/README.md
+++ b/evals/ode/README.md
@@ -61,7 +61,15 @@ type PrimalOutput = double[];
 type GradientOutput = double[];
 ```
 
+## Commentary
+
+This eval is best implemented with reverse mode, and the main
+challenge for this eval is the sequential loop with $s$ steps, which
+requires the AD tool to maintain a tape. The [lstm][] eval is a more
+complicated problem that exercises roughly the same parts of AD.
+
 [cmpad]: https://github.com/bradbell/cmpad
 [original documentation]: https://cmpad.readthedocs.io/an_ode.html
 [protocol]: /CONTRIBUTING.md#types
 [typescript]: https://www.typescriptlang.org/
+[lstm]: ../lstm

--- a/evals/ode/README.md
+++ b/evals/ode/README.md
@@ -72,4 +72,4 @@ complicated problem that exercises roughly the same parts of AD.
 [original documentation]: https://cmpad.readthedocs.io/an_ode.html
 [protocol]: /CONTRIBUTING.md#types
 [typescript]: https://www.typescriptlang.org/
-[lstm]: ../lstm
+[lstm]: /evals/lstm

--- a/evals/particle/README.md
+++ b/evals/particle/README.md
@@ -77,7 +77,30 @@ type SaddleOutput = double;
 
 The output is the final value of $w$.
 
+## Commentary
+
+The challenging part about `particle` (and [saddle][]) is that it
+involves nested AD, and not merely in the simple way needed by
+[kmeans][] for computing hessians. These benchmarks things optimise
+objective functions that themselves contain instances of AD (in the
+case of 'saddle', this is a nested solver). The`'particle'`eval even
+has an unbounded `while` loop in the primal function, which can be a
+challenge to some tools. In particular, for the C++ tools built on
+operator overloading, the types can get quite involved.
+
+`particle` is a scalar benchmark, with no large arrays, and no
+meaningful potential for parallel execution. In principle, the two
+"attractors" that depend on $w$ could be extended to a much larger
+quantity, but that might not actually be a sensible thing to simulate.
+
+It is not required that all of the four function variants are
+implemented by instantiating some generic function (although some of
+our tools do it like that). It is fine to have four completely
+independent implementations.
+
 [protocol]: /CONTRIBUTING.md#types
 [typescript]: https://www.typescriptlang.org/
 [paper]: https://link.springer.com/chapter/10.1007/978-3-540-68942-3_8
 [euler]: https://en.wikipedia.org/wiki/Euler_method
+[kmeans]: ../kmeans
+[saddle]: ../saddle

--- a/evals/particle/README.md
+++ b/evals/particle/README.md
@@ -1,6 +1,6 @@
 # Charged particle trajectory
 
-The benchmark models a charged particle accelerated by an electric field formed by a pair of repulsive bodies, with the goal being to find a control parameter that causes the movement of the particle to intersect the origin. This benchmark, along with [saddle](../saddle), was originally proposed by Pearlmutter and Siskind in the paper [Using Programming Language Theory to Make Automatic Differentiation Sound and Efficient](https://link.springer.com/chapter/10.1007/978-3-540-68942-3_8). The benchmark has also been covered in [Putting the Automatic Back into AD: Part I, What’s Wrong](https://docs.lib.purdue.edu/cgi/viewcontent.cgi?article=1369&context=ecetr), which mainly discusses how the tools of the time had a very hard time handling it correctly.
+The benchmark models a charged particle accelerated by an electric field formed by a pair of repulsive bodies, with the goal being to find a control parameter that causes the movement of the particle to intersect the origin. This benchmark, along with [saddle](/evals/saddle), was originally proposed by Pearlmutter and Siskind in the paper [Using Programming Language Theory to Make Automatic Differentiation Sound and Efficient](https://link.springer.com/chapter/10.1007/978-3-540-68942-3_8). The benchmark has also been covered in [Putting the Automatic Back into AD: Part I, What’s Wrong](https://docs.lib.purdue.edu/cgi/viewcontent.cgi?article=1369&context=ecetr), which mainly discusses how the tools of the time had a very hard time handling it correctly.
 
 ## Specification
 
@@ -102,5 +102,5 @@ independent implementations.
 [typescript]: https://www.typescriptlang.org/
 [paper]: https://link.springer.com/chapter/10.1007/978-3-540-68942-3_8
 [euler]: https://en.wikipedia.org/wiki/Euler_method
-[kmeans]: ../kmeans
-[saddle]: ../saddle
+[kmeans]: /evals/kmeans
+[saddle]: /evals/saddle

--- a/evals/particle/README.md
+++ b/evals/particle/README.md
@@ -83,7 +83,7 @@ The challenging part about `particle` (and [saddle][]) is that it
 involves nested AD, and not merely in the simple way needed by
 [kmeans][] for computing hessians. These benchmarks things optimise
 objective functions that themselves contain instances of AD (in the
-case of 'saddle', this is a nested solver). The`'particle'`eval even
+case of `saddle'` this is a nested solver). The `particle` eval even
 has an unbounded `while` loop in the primal function, which can be a
 challenge to some tools. In particular, for the C++ tools built on
 operator overloading, the types can get quite involved.

--- a/evals/saddle/README.md
+++ b/evals/saddle/README.md
@@ -94,5 +94,11 @@ type SaddleOutput = double[4];
 
 The output contains the points `x` and `y` concatenated.
 
+## Commentary
+
+This benchmark is similar to [particle][], and it is worth reading the
+commentary there.
+
 [protocol]: /CONTRIBUTING.md#types
 [typescript]: https://www.typescriptlang.org/
+[particle]: ../particle

--- a/evals/saddle/README.md
+++ b/evals/saddle/README.md
@@ -1,6 +1,6 @@
 # Finding Saddle Points with Gradient Descent
 
-The benchmark uses gradient descent to compute the saddle point of a simple function. This benchmark, along with [particle](../particle), was originally proposed by Pearlmutter and Siskind in the paper [Using Programming Language Theory to Make Automatic Differentiation Sound and Efficient](https://link.springer.com/chapter/10.1007/978-3-540-68942-3_8). The benchmark has also been covered in [Putting the Automatic Back into AD: Part I, What’s Wrong](https://docs.lib.purdue.edu/cgi/viewcontent.cgi?article=1369&context=ecetr), which mainly discusses how the tools of the time had a very hard time handling it correctly.
+The benchmark uses gradient descent to compute the saddle point of a simple function. This benchmark, along with [particle](/evals/particle), was originally proposed by Pearlmutter and Siskind in the paper [Using Programming Language Theory to Make Automatic Differentiation Sound and Efficient](https://link.springer.com/chapter/10.1007/978-3-540-68942-3_8). The benchmark has also been covered in [Putting the Automatic Back into AD: Part I, What’s Wrong](https://docs.lib.purdue.edu/cgi/viewcontent.cgi?article=1369&context=ecetr), which mainly discusses how the tools of the time had a very hard time handling it correctly.
 
 ## Specification
 
@@ -101,4 +101,4 @@ commentary there.
 
 [protocol]: /CONTRIBUTING.md#types
 [typescript]: https://www.typescriptlang.org/
-[particle]: ../particle
+[particle]: /evals/particle

--- a/tools/futhark/README.md
+++ b/tools/futhark/README.md
@@ -10,4 +10,32 @@ To run this outside Docker, you'll first need to install Futhark and run the fol
 futhark pkg sync
 ```
 
+## Commentary
+
+Most of the implementations are clean and perform well, relative to
+the expectations of a pure functional language. The implementations
+are always (when algorithmically possible) written in a parallel
+style, even though the programs are run sequentially by default, and
+sometimes the parallel style is slower in that case.
+
+* [det.fut][]: Futhark does not support parallelism, so this is
+  implemented in a rather different way that is less efficient but
+  data parallel, based on computing and applying permutations. The
+  amount (and form) of floating-point work is the same, so this is in
+  spirit still the same (inefficient) algorithm as specified by the
+  eval.
+
+* [saddle.fut][] and [particle.fut][] make use of [solver.fut][],
+  which is a rather simple implementation of Gradient Descent. Their
+  performance is slightly hampered by representing two-dimensional
+  points as two-element arrays, which is [not particularly efficient
+  in Futhark][]. The implementation is otherwise very clean, and works
+  by defining a generic function that is then instantiated by the four
+  different combinations of differential operators.
+
 [futhark]: https://futhark-lang.org/
+[det.fut]: det.fut
+[saddle.fut]: saddle.fut
+[particle.fut]: particle.fut
+[solver.fut]: solver.fut
+[not particularly efficient in Futhark]: https://futhark-lang.org/blog/2019-01-13-giving-programmers-what-they-want.html

--- a/tools/futhark/README.md
+++ b/tools/futhark/README.md
@@ -33,6 +33,10 @@ sometimes the parallel style is slower in that case.
   by defining a generic function that is then instantiated by the four
   different combinations of differential operators.
 
+- [ba.fut][]: Just as much time is spent packing the sparse Jacobian
+  in the expected format as in actually computing it. This part is not
+  subject to AD.
+
 [futhark]: https://futhark-lang.org/
 [det.fut]: det.fut
 [saddle.fut]: saddle.fut

--- a/tools/futhark/README.md
+++ b/tools/futhark/README.md
@@ -18,14 +18,14 @@ are always (when algorithmically possible) written in a parallel
 style, even though the programs are run sequentially by default, and
 sometimes the parallel style is slower in that case.
 
-* [det.fut][]: Futhark does not support parallelism, so this is
+- [det.fut][]: Futhark does not support parallelism, so this is
   implemented in a rather different way that is less efficient but
   data parallel, based on computing and applying permutations. The
   amount (and form) of floating-point work is the same, so this is in
   spirit still the same (inefficient) algorithm as specified by the
   eval.
 
-* [saddle.fut][] and [particle.fut][] make use of [solver.fut][],
+- [saddle.fut][] and [particle.fut][] make use of [solver.fut][],
   which is a rather simple implementation of Gradient Descent. Their
   performance is slightly hampered by representing two-dimensional
   points as two-element arrays, which is [not particularly efficient

--- a/tools/futhark/README.md
+++ b/tools/futhark/README.md
@@ -18,7 +18,7 @@ are always (when algorithmically possible) written in a parallel
 style, even though the programs are run sequentially by default, and
 sometimes the parallel style is slower in that case.
 
-- [det.fut][]: Futhark does not support parallelism, so this is
+- [det.fut][]: Futhark does not support recursion, so this is
   implemented in a rather different way that is less efficient but
   data parallel, based on computing and applying permutations. The
   amount (and form) of floating-point work is the same, so this is in

--- a/tools/futhark/README.md
+++ b/tools/futhark/README.md
@@ -43,3 +43,4 @@ sometimes the parallel style is slower in that case.
 [particle.fut]: particle.fut
 [solver.fut]: solver.fut
 [not particularly efficient in Futhark]: https://futhark-lang.org/blog/2019-01-13-giving-programmers-what-they-want.html
+[ba.fut]: ba.fut

--- a/tools/haskell/README.md
+++ b/tools/haskell/README.md
@@ -41,4 +41,4 @@ but its diagnostic output can interfere with the protocol when used as
 the `--tool` argument to `gradbench`.
 
 [ghcup]: https://www.haskell.org/ghcup/
-[shell.nix]: ../../shell.nix
+[shell.nix]: /shell.nix

--- a/tools/manual/README.md
+++ b/tools/manual/README.md
@@ -24,7 +24,7 @@ algorithmic improvements: a tool may beat `manual` through operational
 advantages, such as efficient implementations of primitives like
 matrix multiplication, parallel execution, etc. that the `manual`
 implementation of a tool does not do. It is not a goal that the
-`manual` tool is at all costs the *fastest it can possibly be*.
+`manual` tool is at all costs the _fastest it can possibly be_.
 
 It is not expected that we will be able to implement
 hand-differentiated versions of all evals. AD is after all most useful

--- a/tools/manual/README.md
+++ b/tools/manual/README.md
@@ -14,3 +14,18 @@ Then, to run the tool itself:
 ```sh
 python3 python/gradbench/gradbench/cpp.py manual
 ```
+
+## Commentary
+
+We expect that in most cases, the hand-differentiated versions should
+be the fastest, as they may exploit mathematical properties that it is
+not reasonable to expect of an AD tool. However, these are only
+algorithmic improvements: a tool may beat `manual` through operational
+advantages, such as efficient implementations of primitives like
+matrix multiplication, parallel execution, etc. that the `manual`
+implementation of a tool does not do. It is not a goal that the
+`manual` tool is at all costs the *fastest it can possibly be*.
+
+It is not expected that we will be able to implement
+hand-differentiated versions of all evals. AD is after all most useful
+for those cases where hand-differentiation is impractical.

--- a/tools/ocaml/README.md
+++ b/tools/ocaml/README.md
@@ -15,7 +15,7 @@ replaced with GradBench-specific code.
 You must have [opam][] and [Dune][]. Make sure the `opam` environment
 is set - this may require you to run `eval $(opam env)`, although this
 is usually done in your shell configuration, and it is not necessary
-when using the [shell.nix](../../shell.nix). You may need to do `opam
+when using the [shell.nix](/shell.nix). You may need to do `opam
 init` if you have not done so before.
 
 Standing in the root of the GradBench repository, first run


### PR DESCRIPTION
The idea behind the Commentary is to have a place for non-normative information about evals and tools. We can imagine the Commentary helps in the following cases:

* You are writing a paper about some new AD tool, and you need to explain why some of the existing implementations in GradBench are particularly slow or fast.

* You want to add a new tool to GradBench, and you are looking for advice on which evals to start with.