### PR TITLE
intermediary: set 'docker build' stdout to /dev/null

### DIFF
--- a/crates/gradbench/src/main.rs
+++ b/crates/gradbench/src/main.rs
@@ -302,6 +302,10 @@ enum Verbosity {
 fn docker_build_quiet(color: Color, mut cmd: Command) -> anyhow::Result<ExitStatus> {
     let mut child = cmd
         .arg("--progress=plain")
+        // Podman-based Dockers print build logs to stdout, which will
+        // interfere with the GradBench protocol when building as part
+        // of a 'gradbench repo tool' command. To avoid this, we
+        // silence stdout.
         .stdout(Stdio::null())
         .stderr(Stdio::piped())
         .spawn()?;

--- a/crates/gradbench/src/main.rs
+++ b/crates/gradbench/src/main.rs
@@ -300,7 +300,11 @@ enum Verbosity {
 
 /// Run a `docker build` command but don't print output if everything is cached.
 fn docker_build_quiet(color: Color, mut cmd: Command) -> anyhow::Result<ExitStatus> {
-    let mut child = cmd.arg("--progress=plain").stderr(Stdio::piped()).spawn()?;
+    let mut child = cmd
+        .arg("--progress=plain")
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()?;
     // A digit mean the start of a number of seconds for an output line for a `RUN` command. The
     // string `sha256` is the start of a line for downloading in a `FROM` command.
     let re = Regex::new(r"^#\d+ (\d|sha256)").unwrap();


### PR DESCRIPTION
Only done on the quiet path. This is critical for Podman-based Dockers, which print diagnostics to stdout. Otherwise, 'gradbench repo tool' will not work, as the diagnostics interfere with the protocol.