### PR TITLE
Temporarily disable `lstm` benchmark for SciLean

### DIFF
--- a/tools/scilean/Main.lean
+++ b/tools/scilean/Main.lean
@@ -15,7 +15,7 @@ def resolve (module : String)
   | "hello" => some hello
   | "gmm" => some gmm
   | "kmeans" => some kmeans
-  | "lstm" => some lstm
+  -- | "lstm" => some lstm
   | "llsq" => some llsq
   | _ => none
 

--- a/tools/scilean/evals.txt
+++ b/tools/scilean/evals.txt
@@ -2,4 +2,3 @@ gmm
 hello
 kmeans
 llsq
-lstm


### PR DESCRIPTION
I can't reproduce the issue with `lstm` in a separate executable. Right now, I have no idea how to debug this. So this PR temporarily disables `lstm` for SciLean