### PR TITLE
Update ad.hpp Makefile.

### DIFF
--- a/tools/ad-hpp/Makefile
+++ b/tools/ad-hpp/Makefile
@@ -1,18 +1,24 @@
-COMMIT=f8a524c5e2dd373933115a3c2c0c7e6fe30f0690
+GIT_TAG=v1.7
 CXX?=c++
 CC?=cc
-CFLAGS=-std=c++17 -O3 -Wall -I../../cpp
+CFLAGS=-std=c++17 -O3 -Wall -I../../cpp -Iinclude
 LDFLAGS=-lm
 
 EXECUTABLES=hello llsq
 
 all: $(EXECUTABLES)
 
-%: %.cpp ad.hpp
+%: %.cpp include/ad.hpp
 	$(CXX) -o $@ $< $(LDFLAGS) $(CFLAGS)
 
 clean:
 	rm -f $(EXECUTABLES)
 
-ad.hpp:
-	wget https://gitlab.stce.rwth-aachen.de/stce/ad/-/raw/$(COMMIT)/ad.hpp -O $@
+include/ad.hpp:
+	mkdir -p include
+	wget https://gitlab.stce.rwth-aachen.de/stce/ad/-/raw/$(GIT_TAG)/$@ -O $@
+
+include/extensions/ad_interoperability_eigen.hpp:
+	mkdir -p include/extensions
+	wget https://gitlab.stce.rwth-aachen.de/stce/ad/-/raw/$(GIT_TAG)/$@ -O $@
+


### PR DESCRIPTION
- I reorganized the ad.hpp repo (slightly)
- Example rule for including some of the extension components
   - currently only Eigen3 is relevant (in my onion)


The v1.7 "release" of ad.hpp includes a mechanism for allocating a larger tape. Currently you may just have to guess as to how big it should be. 