### PR TITLE
kmeans: change type of points to double

### DIFF
--- a/cpp/gradbench/evals/kmeans.hpp
+++ b/cpp/gradbench/evals/kmeans.hpp
@@ -6,9 +6,9 @@
 #include "json.hpp"
 
 namespace kmeans {
-template<typename T>
-T euclid_dist_2(int d, T const *a, T const *b) {
-  T dist = 0;
+template<typename A, typename B>
+B euclid_dist_2(int d, A const *a, B const *b) {
+  B dist = 0;
   for (int i = 0; i < d; i++) {
     dist += (a[i]-b[i])*(a[i]-b[i]);
   }
@@ -17,11 +17,12 @@ T euclid_dist_2(int d, T const *a, T const *b) {
 
 template<typename T>
 void objective(int n, int k, int d,
-               T const * __restrict__ points, T const * __restrict__ centroids,
+               double const * __restrict__ points,
+               T const * __restrict__ centroids,
                T* __restrict__ err) {
   T cost = 0;
   for (int i = 0; i < n; i++) {
-    T const *a = &points[i*d];
+    double const *a = &points[i*d];
     T closest = INFINITY;
     for (int j = 0; j < k; j++) {
       T const *b = &centroids[j*d];

--- a/tools/adol-c/kmeans.cpp
+++ b/tools/adol-c/kmeans.cpp
@@ -15,21 +15,17 @@ public:
       _H(input.k*input.d),
       _J(input.k*input.d),
       _tangent(input.centroids.size()) {
-    std::vector<adouble> apoints(input.points.size());
     std::vector<adouble> acentroids(input.centroids.size());
     adouble aerr;
 
     trace_on(tapeTag);
 
-    for (size_t i = 0; i < apoints.size(); i++) {
-      apoints[i] = _input.points[i];
-    }
     for (size_t i = 0; i < acentroids.size(); i++) {
       acentroids[i] <<= _input.centroids[i];
     }
 
     kmeans::objective<adouble>(_input.n, _input.k, _input.d,
-                               apoints.data(), acentroids.data(),
+                               _input.points.data(), acentroids.data(),
                                &aerr);
     double err;
     aerr >>= err;

--- a/tools/codipack/kmeans.cpp
+++ b/tools/codipack/kmeans.cpp
@@ -16,11 +16,8 @@ public:
     output.d = _input.d;
     output.dir.resize(_input.k * _input.d);
 
-    std::vector<r2s> ad_points(_input.points.size());
     std::vector<r2s> ad_centroids(_input.centroids.size());
 
-    std::copy(_input.points.begin(), _input.points.end(),
-              ad_points.begin());
     std::copy(_input.centroids.begin(), _input.centroids.end(),
               ad_centroids.begin());
 
@@ -35,7 +32,7 @@ public:
     r2s err;
 
     kmeans::objective<r2s>(_input.n, _input.k, _input.d,
-                           ad_points.data(),
+                           _input.points.data(),
                            ad_centroids.data(),
                            &err);
 

--- a/tools/cppad/kmeans.cpp
+++ b/tools/cppad/kmeans.cpp
@@ -10,7 +10,7 @@ class Dir : public Function<kmeans::Input, kmeans::DirOutput> {
   CppAD::sparse_hessian_work _work;
   std::vector<bool> _p;
   std::vector<size_t> _row, _col;
-  std::vector<ADdouble> _apoints, _acentroids;
+  std::vector<ADdouble> _acentroids;
 public:
   Dir(kmeans::Input& input)
     : Function(input),
@@ -19,13 +19,8 @@ public:
       _p((input.k*input.d)*(input.k*input.d)),
       _row(input.k*input.d),
       _col(input.k*input.d),
-      _apoints(_input.points.size()),
       _acentroids(_input.centroids.size())
   {
-    std::copy(_input.points.begin(),
-              _input.points.end(),
-              _apoints.begin());
-
     std::copy(_input.centroids.begin(),
               _input.centroids.end(),
               _acentroids.data());
@@ -54,13 +49,12 @@ public:
     output.d = _input.d;
     output.dir.resize(_input.k * _input.d);
 
-
     CppAD::Independent(_acentroids);
 
     std::vector<ADdouble> err(1);
 
     kmeans::objective<ADdouble>(_input.n, _input.k, _input.d,
-                                _apoints.data(), _acentroids.data(),
+                                _input.points.data(), _acentroids.data(),
                                 &err[0]);
 
     CppAD::ADFun<double> f(_acentroids, err);


### PR DESCRIPTION
The points parameter is inactive, and it is disadvantageous for overloading-based tools to use a more heavyweight representation for this array.

Fixes #490.