### PR TITLE
Implement LSTM, BA, HT with Zygote

### DIFF
--- a/julia/GradBench/src/GradBench.jl
+++ b/julia/GradBench/src/GradBench.jl
@@ -63,6 +63,7 @@ function main(tool)
     return
 end
 
+include("benchmarks/ba.jl")
 include("benchmarks/gmm.jl")
 include("benchmarks/hello.jl")
 include("benchmarks/ode.jl")

--- a/julia/GradBench/src/GradBench.jl
+++ b/julia/GradBench/src/GradBench.jl
@@ -66,6 +66,7 @@ end
 include("benchmarks/ba.jl")
 include("benchmarks/gmm.jl")
 include("benchmarks/hello.jl")
+include("benchmarks/ht.jl")
 include("benchmarks/ode.jl")
 include("benchmarks/lse.jl")
 include("benchmarks/lstm.jl")

--- a/julia/GradBench/src/GradBench.jl
+++ b/julia/GradBench/src/GradBench.jl
@@ -67,5 +67,6 @@ include("benchmarks/gmm.jl")
 include("benchmarks/hello.jl")
 include("benchmarks/ode.jl")
 include("benchmarks/lse.jl")
+include("benchmarks/lstm.jl")
 
 end # module GradBench

--- a/julia/GradBench/src/benchmarks/ba.jl
+++ b/julia/GradBench/src/benchmarks/ba.jl
@@ -1,0 +1,170 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+#
+# Based on: https://github.com/microsoft/ADBench/blob/38cb7931303a830c3700ca36ba9520868327ac87/src/julia/modules/Zygote/ZygoteBA.jl
+
+module BA
+
+using LinearAlgebra
+
+export BAInput, input_from_json, objective, compute_reproj_err, insert_w_err_block, dedup_jacobian
+
+##################### data #############################
+
+const N_CAM_PARAMS = 11
+const ROT_IDX = 1
+const C_IDX = 4
+const F_IDX = 7
+const X0_IDX = 8
+const RAD_IDX = 10
+
+struct BAInput
+    n::Int
+    m::Int
+    p::Int
+    cams::Matrix{Float64}
+    X::Matrix{Float64}
+    w::Vector{Float64}
+    feats::Matrix{Float64}
+    obs::Matrix{Int}
+end
+
+function input_from_json(j)
+    n = j["n"]
+    m = j["m"]
+    p = j["p"]
+
+    one_cam = convert(Vector{Float64}, j["cam"])
+    one_X = convert(Vector{Float64}, j["x"])
+    one_w = j["w"]
+    one_feat = convert(Vector{Float64}, j["feat"])
+
+    cams = repeat(one_cam,1,n)
+    X = repeat(one_X,1,m)
+    w = repeat([one_w],p)
+    feats = repeat(one_feat,1,p)
+
+    camIdx = 1
+    ptIdx = 1
+    obs = zeros(Int,2,p)
+    for i in 1:p
+        obs[1,i] = camIdx
+        obs[2,i] = ptIdx
+        camIdx = (camIdx%n) + 1
+        ptIdx = (ptIdx%m) + 1
+    end
+
+    return BAInput(n, m, p, cams, X, w, feats, obs)
+end
+
+struct SparseMatrix
+    "Number of cams"
+    n::Int
+    "Number of points"
+    m::Int
+    "Number of observations"
+    p::Int
+    nrows::Int
+    ncols::Int
+    """
+    Int[nrows + 1]. Defined recursively as follows:
+    rows[0] = 0
+    rows[i] = rows[i-1] + the number of nonzero elements on the i-1 row of the matrix
+    """
+    rows::Vector{Int}
+    "Column index in the matrix of each element of vals. Has the same size"
+    cols::Vector{Int}
+    "All the nonzero entries of the matrix in the left-to-right top-to-bottom order"
+    vals::Vector{Float64}
+    SparseMatrix(n::Int, m::Int, p::Int) = new(n, m, p, 2 * p + p, N_CAM_PARAMS * n + 3 * m + p, [0], [], [])
+end
+
+function insert_reproj_err_block!(matrix::SparseMatrix, obsIdx::Int, camIdx::Int, ptIdx::Int, J::AbstractMatrix{Float64})
+    # We use zero-based indexing for storage, but Julia uses 1-bsed indexing
+    # Hence, the conversion
+    obsIdxZeroBased = obsIdx - 1
+    camIdxZeroBased = camIdx - 1
+    ptIdxZeroBased = ptIdx - 1
+    n_new_cols = N_CAM_PARAMS + 3 + 1
+    lastrow = matrix.rows[end]
+    push!(matrix.rows, lastrow + n_new_cols, lastrow + n_new_cols + n_new_cols)
+    for i_row ∈ 1:2
+        for i ∈ 1:N_CAM_PARAMS
+            push!(matrix.cols, N_CAM_PARAMS * camIdxZeroBased + (i - 1))
+            push!(matrix.vals, J[i_row, i])
+        end
+        col_offset = N_CAM_PARAMS * matrix.n
+        for i ∈ 1:3
+            push!(matrix.cols, col_offset + 3 * ptIdxZeroBased + (i - 1))
+            push!(matrix.vals, J[i_row, N_CAM_PARAMS + i])
+        end
+        col_offset += 3 * matrix.m
+        val_offset = N_CAM_PARAMS + 3
+        push!(matrix.cols, col_offset + obsIdxZeroBased);
+        push!(matrix.vals, J[i_row, val_offset + 1]);
+    end
+end
+
+function insert_w_err_block!(matrix::SparseMatrix, wIdx::Int, w_d::Float64)
+    # We use zero-based indexing for storage, but Julia uses 1-bsed indexing
+    # Hence, the conversion
+    wIdxZeroBased = wIdx - 1
+    push!(matrix.rows, matrix.rows[end] + 1)
+    push!(matrix.cols, N_CAM_PARAMS * matrix.n + 3 * matrix.m + wIdxZeroBased)
+    push!(matrix.vals, w_d)
+end
+
+# The BA input is duplicated during unpacking, so we deduplicate the
+# Jacobian at the end.
+function dedup_jacobian(J)
+    Dict("rows" => vcat(J.rows[1:30], [J.rows[end]]),
+         "cols" => vcat(J.cols[1:30], [J.cols[end]]),
+         "vals" => vcat(J.vals[1:30], [J.vals[end]]))
+end
+
+##################### objective #############################
+
+function rodrigues_rotate_point(rot :: Vector{T}, X :: Vector{T}) where T
+    sqtheta = sum(rot .* rot)
+    if sqtheta > 1e-10
+        theta = sqrt(sqtheta)
+        costheta = cos(theta)
+        sintheta = sin(theta)
+        theta_inverse = 1. / theta
+
+        w = theta_inverse * rot
+        w_cross_X = cross(w, X)
+        tmp = dot(w, X) * (1. - costheta)
+
+        X * costheta + w_cross_X * sintheta + w * tmp
+    else
+        X + cross(rot, X)
+    end
+end
+
+function radial_distort(rad_params, proj)
+    rsq = sum(proj .* proj)
+    L = 1. + rad_params[1] * rsq + rad_params[2] * rsq * rsq
+    proj * L
+end
+
+function project(cam, X)
+    Xcam = rodrigues_rotate_point(cam[ROT_IDX:ROT_IDX+2], X - cam[C_IDX:C_IDX+2])
+    distorted = radial_distort(cam[RAD_IDX:RAD_IDX+1], Xcam[1:2] / Xcam[3])
+    distorted * cam[F_IDX] + cam[X0_IDX:X0_IDX+1]
+end
+
+function compute_reproj_err(cam, X, w, feat)
+    w * (project(cam, X) - feat)
+end
+
+function objective(cams, X, w, obs, feats)
+    reproj_err = similar(feats)
+    for i in 1:size(feats, 2)
+        reproj_err[:, i] = compute_reproj_err(cams[:, obs[1, i]], X[:, obs[2, i]], w[i], feats[:, i])
+    end
+    w_err = 1.0 .- w .* w
+    (reproj_err, w_err)
+end
+
+end

--- a/julia/GradBench/src/benchmarks/gmm.jl
+++ b/julia/GradBench/src/benchmarks/gmm.jl
@@ -7,7 +7,7 @@ module GMM
 using SpecialFunctions
 using LinearAlgebra
 
-export Wishart, GMMInput, get_Q, expdiags, diagsums
+export Wishart, GMMInput, input_from_json, objective, get_Q, expdiags, diagsums
 
 struct Wishart
     gamma::Float64

--- a/julia/GradBench/src/benchmarks/ht.jl
+++ b/julia/GradBench/src/benchmarks/ht.jl
@@ -1,0 +1,224 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+#
+# Based on: https://github.com/microsoft/ADBench/blob/38cb7931303a830c3700ca36ba9520868327ac87/src/julia/modules/Zygote/ZygoteHT.jl
+
+module HT
+
+using LinearAlgebra
+
+export HTModel, HTInput, objective_simple, objective_complicated
+
+struct HTModel
+    bone_names::Vector{String}
+    parents::Vector{Int}
+    base_relatives::Vector{Matrix{Float64}}
+    inverse_base_absolutes::Vector{Matrix{Float64}}
+    base_positions::Matrix{Float64}
+    weights::Matrix{Float64}
+    triangles::Vector{Vector{Int}}
+    is_mirrored::Bool
+end
+
+struct HTInput
+    model::HTModel
+    correspondences::Vector{Int}
+    points::Matrix{Float64}
+    theta::Vector{Float64}
+    "Is present only for 'complicated' kind of problems."
+    us::Union{Vector{Vector{Float64}}, Nothing}
+end
+
+"Turn a vector of rows into the corresponding matrix."
+function vecvecToMatrix(v::Vector{Vector{Float64}}) :: Matrix{Float64}
+    transpose(reduce(hcat, v))
+end
+
+function input_from_json(json)
+    theta = json["theta"]
+    us = json["us"]
+
+    if size(us, 1) == 1
+        us = nothing
+    end
+
+    correspondences = json["data"]["correspondences"]
+    points = vecvecToMatrix(convert(Vector{Vector{Float64}},
+                                    json["data"]["points"]))
+
+    base_positions = vecvecToMatrix(convert(Vector{Vector{Float64}},
+                                            json["data"]["model"]["base_positions"]))
+    weights = vecvecToMatrix(convert(Vector{Vector{Float64}},
+                                     json["data"]["model"]["weights"]))
+    triangles = json["data"]["model"]["triangles"]
+    base_relatives = map(v -> vecvecToMatrix(convert(Vector{Vector{Float64}},v)),
+                         json["data"]["model"]["base_relatives"])
+    inverse_base_absolutes = map(v -> vecvecToMatrix(convert(Vector{Vector{Float64}},v)),
+                                 json["data"]["model"]["inverse_base_absolutes"])
+
+    model = HTModel(json["data"]["model"]["bone_names"],
+                    json["data"]["model"]["parents"] .+ 1, # Julia indexing
+                    base_relatives,
+                    inverse_base_absolutes,
+                    transpose(base_positions),
+                    transpose(weights),
+                    [ triangles[i] .+ 1 for i ∈ 1:size(triangles, 1) ], # Julia indexing
+                    json["data"]["model"]["is_mirrored"])
+
+    HTInput(model,
+            correspondences .+ 1, # Julia indexing
+            transpose(points),
+            theta,
+            us)
+end
+
+# objective
+function angle_axis_to_rotation_matrix(angle_axis::Vector{T1})::Matrix{T1} where{T1}
+    n = sqrt(sum(abs2, angle_axis));
+    if n < .0001
+        return Matrix{T1}(I, 3, 3)
+    end
+
+    x = angle_axis[1] / n
+    y = angle_axis[2] / n
+    z = angle_axis[3] / n
+
+    s = sin(n)
+    c = cos(n)
+
+    [
+        x*x+(1-x*x)*c x*y*(1-c)-z*s x*z*(1-c)+y*s;
+        x*y*(1-c)+z*s y*y+(1-y*y)*c y*z*(1-c)-x*s;
+        x*z*(1-c)-y*s z*y*(1-c)+x*s z*z+(1-z*z)*c
+    ]
+end
+
+function apply_global_transform(pose_params::Vector{Vector{T1}}, positions::Matrix{T2})::Matrix{T2} where {T1, T2}
+    (angle_axis_to_rotation_matrix(pose_params[1]) .* pose_params[2]') * positions .+ pose_params[3]
+end
+
+function relatives_to_absolutes(relatives::Vector{Matrix{T1}}, parents::Vector{Int})::Vector{Matrix{T1}} where {T1}
+    # Zygote does not support array mutation and on every iteration we may need to access
+    # random element created on one of the previous iterations, so, no way to rewrite this
+    # as a comprehension. Hence looped vcat.
+    absolutes = Vector{Matrix{T1}}(undef, 0)
+    for i=1:length(parents)
+        if parents[i] == 0
+            absolutes = vcat(absolutes, [ relatives[i] ])
+        else
+            absolutes = vcat(absolutes, [ absolutes[parents[i]] * relatives[i] ])
+        end
+    end
+    absolutes
+end
+
+function euler_angles_to_rotation_matrix(xyz::Vector{T1})::Matrix{T1} where {T1}
+    tx = xyz[1]
+    ty = xyz[2]
+    tz = xyz[3]
+    costx = cos(tx)
+    sintx = sin(tx)
+    costy = cos(ty)
+    sinty = sin(ty)
+    costz = cos(tz)
+    sintz = sin(tz)
+    # We could define this as a 3x3 matrix and then build a block-diagonal
+    # 4x4 matrix with 1. at (4, 4), but Zygote couldn't differentiate
+    # any way of building that I could come up with.
+    Rx = [ 1. 0. 0. 0.; 0. costx -sintx 0.; 0. sintx costx 0.; 0. 0. 0. 1. ]
+    Ry = [ costy 0. sinty 0.; 0. 1. 0. 0.; -sinty 0. costy 0.; 0. 0. 0. 1. ]
+    Rz = [ costz -sintz 0. 0.; sintz costz 0. 0.; 0. 0. 1. 0.; 0. 0. 0. 1. ]
+    Rz * Ry * Rx
+end
+
+function get_posed_relatives(model::HTModel, pose_params::Vector{Vector{T1}})::Vector{Matrix{T1}} where {T1}
+    # default parametrization xzy # Flexion, Abduction, Twist
+    order = [1, 3, 2]
+    offset = 3
+    n_bones = size(model.bone_names, 1)
+    [
+        model.base_relatives[i_bone] * euler_angles_to_rotation_matrix(pose_params[i_bone + offset][order])
+            for i_bone ∈ 1:n_bones
+    ]
+end
+
+function get_skinned_vertex_positions(model::HTModel, pose_params::Vector{Vector{T1}}, apply_global::Bool = true)::Matrix{T1} where {T1}
+    relatives = get_posed_relatives(model, pose_params)
+    absolutes = relatives_to_absolutes(relatives, model.parents)
+
+    transforms = [ absolutes[i] * model.inverse_base_absolutes[i] for i ∈ 1:size(absolutes, 1) ]
+
+    n_verts = size(model.base_positions, 2)
+    positions = zeros(Float64, 3, n_verts)
+    for i=1:size(transforms, 1)
+        positions = positions +
+            (transforms[i][1:3, :] * model.base_positions) .* model.weights[i, :]'
+    end
+
+    if model.is_mirrored
+        positions = [-positions[1,:]'; positions[2:end, :]]
+    end
+
+    if apply_global
+        positions = apply_global_transform(pose_params, positions)
+    end
+    positions
+end
+
+function to_pose_params(theta::Vector{T1}, n_bones::Int)::Vector{Vector{T1}} where {T1}
+    # fixed order pose_params
+    #       1) global_rotation 2) scale 3) global_translation
+    #       4) wrist
+    #       5) thumb1, 6)thumb2, 7) thumb3, 8) thumb4
+    #       similarly: index, middle, ring, pinky
+    #       end) forearm
+
+    n = 3 + n_bones
+    n_fingers = 5
+    cols = 5 + n_fingers * 4
+    [
+        if i == 1
+            theta[1:3]
+        elseif i == 2
+            [1., 1., 1.]
+        elseif i == 3
+            theta[4:6]
+        elseif i > cols || i == 4 || i % 4 == 1
+            [0., 0., 0.]
+        elseif i % 4 == 2
+            [theta[i + 1], theta[i + 2], 0.]
+        else
+            [theta[i + 2], 0., 0.]
+        end
+            for i ∈ 1:n
+    ]
+end
+
+function objective_simple(model::HTModel, correspondences::Vector{Int}, points::Matrix{T1}, theta::Vector{T2}) where {T1, T2}
+    pose_params = to_pose_params(theta, length(model.bone_names))
+
+    vertex_positions = get_skinned_vertex_positions(model, pose_params)
+
+    n_corr = length(correspondences)
+    vcat([ points[:, i] - vertex_positions[:, correspondences[i]] for i ∈ 1:n_corr ]...)
+end
+
+function objective_complicated(model::HTModel, correspondences::Vector{Int}, points::Matrix{T1}, theta::Vector{T2}, us::Vector{Vector{T3}}) where {T1, T2, T3}
+    pose_params = to_pose_params(theta, length(model.bone_names))
+
+    vertex_positions = get_skinned_vertex_positions(model, pose_params)
+
+    n_corr = length(correspondences)
+    vcat([
+        begin
+            verts = model.triangles[correspondences[i]]
+            u = us[i]
+            hand_point = u[1] * vertex_positions[:, verts[1]] + u[2] * vertex_positions[:, verts[2]] +
+                (1. - u[1] - u[2]) * vertex_positions[:, verts[3]]
+            points[:, i] - hand_point
+        end
+            for i ∈ 1:n_corr
+    ]...)
+end
+
+end

--- a/julia/GradBench/src/benchmarks/lstm.jl
+++ b/julia/GradBench/src/benchmarks/lstm.jl
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 #
-## Based on: https://github.com/microsoft/ADBench/blob/38cb7931303a830c3700ca36ba9520868327ac87/src/julia/modules/Zygote/ZygoteLSTM.jl
+# Based on: https://github.com/microsoft/ADBench/blob/38cb7931303a830c3700ca36ba9520868327ac87/src/julia/modules/Zygote/ZygoteLSTM.jl
 
 module LSTM
 

--- a/julia/GradBench/src/benchmarks/lstm.jl
+++ b/julia/GradBench/src/benchmarks/lstm.jl
@@ -1,0 +1,77 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+#
+## Based on: https://github.com/microsoft/ADBench/blob/38cb7931303a830c3700ca36ba9520868327ac87/src/julia/modules/Zygote/ZygoteLSTM.jl
+
+module LSTM
+
+export LSTMInput, input_from_json, objective
+
+struct LSTMInput
+    main_params::Matrix{Float64}
+    extra_params::Matrix{Float64}
+    state::Matrix{Float64}
+    sequence::Matrix{Float64}
+end
+
+function input_from_json(j)
+    main_params = reduce(hcat, convert(Vector{Vector{Float64}}, j["main_params"]))
+    extra_params = reduce(hcat, convert(Vector{Vector{Float64}}, j["extra_params"]))
+    state = reduce(hcat, convert(Vector{Vector{Float64}}, j["state"]))
+    sequence = reduce(hcat, convert(Vector{Vector{Float64}}, j["sequence"]))
+    return LSTMInput(main_params, extra_params, state, sequence)
+end
+
+function sigmoid(x)
+    1. / (1. + exp(-x))
+end
+
+function lstmmodel(weight::T1, bias::T2, hidden::T3, cell::T4, input::T5)::Tuple{Vector{Float64}, Vector{Float64}} where {T1<:AbstractVector{Float64}, T2<:AbstractVector{Float64}, T3<:AbstractVector{Float64}, T4<:AbstractVector{Float64}, T5<:AbstractVector{Float64}}
+    hsize = size(hidden, 1)
+    forget = sigmoid.(input .* view(weight, 1:hsize) .+ view(bias, 1:hsize))
+    ingate = sigmoid.(hidden .* view(weight, hsize+1:2hsize) .+ view(bias, hsize+1:2hsize))
+    outgate = sigmoid.(input .* view(weight, 2hsize+1:3hsize) .+ view(bias, 2hsize+1:3hsize))
+    change = tanh.(hidden .* view(weight, 3hsize+1:4hsize) .+ view(bias, 3hsize+1:4hsize))
+
+    cell2 = cell .* forget .+ ingate .* change
+    hidden2 = outgate .* tanh.(cell2)
+    hidden2, cell2
+end
+
+function lstmpredict(main_params::Matrix{Float64}, extra_params::Matrix{Float64}, state::Matrix{Float64}, input::T)::Tuple{Vector{Float64}, Matrix{Float64}} where {T<:AbstractVector{Float64}}
+    x1 = input .* view(extra_params, :, 1)
+    x = view(x1, :)
+    lenstate = size(state, 2)
+    s2 = Matrix{Float64}(undef, size(input, 1), 0)
+    for i ∈ 1:2:lenstate
+        h, c = lstmmodel(view(main_params, :, i), view(main_params, :, i + 1), view(state, :, i), view(state, :, i + 1), x)
+        x = h
+        # Zygote does not support mutating arrays
+        # TODO: rewrite as array comprehension - initial attempts
+        # were not successfully differentiated by Zygote
+        s2 = hcat(s2, h, c)
+    end
+    (x .* view(extra_params, :, 2) .+ view(extra_params, :, 3), s2)
+end
+
+function objective(main_params::Matrix{Float64},
+                   extra_params::Matrix{Float64},
+                   state::Matrix{Float64},
+                   sequence::Matrix{Float64})::Float64
+    total = 0.
+    count = 0
+    input = view(sequence, :, 1)
+    b, c = size(sequence)
+    curstate = state
+    for t ∈ 1:c-1
+        ypred, curstate = lstmpredict(main_params, extra_params, curstate, input)
+        ynorm = ypred .- log(sum(exp, ypred) + 2.)
+        ygold = view(sequence, :, t + 1)
+        total += sum(ygold .* ynorm)
+        count += b
+        input = ygold
+    end
+    -total / count
+end
+
+end

--- a/tools/zygote/README.md
+++ b/tools/zygote/README.md
@@ -19,3 +19,11 @@ $ julia --project=tools/zygote tools/zygote/run.jl
 
 [julia]: https://julialang.org/
 [zygote]: https://fluxml.ai/Zygote.jl/
+
+## Commentary
+
+The implementations of the ADBench evals (`gmm`, `ht`, `ba`, `lstm`)
+are generally not very efficient when it comes to computing Jacobians.
+
+The "complicated" variant of `ht` is very slow, but the "simple" one
+is pretty fast.

--- a/tools/zygote/evals.txt
+++ b/tools/zygote/evals.txt
@@ -1,3 +1,4 @@
 gmm timeout
 hello
 lse
+lstm

--- a/tools/zygote/evals.txt
+++ b/tools/zygote/evals.txt
@@ -1,5 +1,6 @@
 ba timeout
 gmm timeout
 hello
+ht timeout
 lse
 lstm

--- a/tools/zygote/evals.txt
+++ b/tools/zygote/evals.txt
@@ -1,3 +1,4 @@
+ba timeout
 gmm timeout
 hello
 lse

--- a/tools/zygote/run.jl
+++ b/tools/zygote/run.jl
@@ -1,5 +1,6 @@
 import GradBench
 
+include("run_ba.jl")
 include("run_gmm.jl")
 include("run_hello.jl")
 include("run_lse.jl")

--- a/tools/zygote/run.jl
+++ b/tools/zygote/run.jl
@@ -3,6 +3,7 @@ import GradBench
 include("run_ba.jl")
 include("run_gmm.jl")
 include("run_hello.jl")
+include("run_ht.jl")
 include("run_lse.jl")
 include("run_lstm.jl")
 

--- a/tools/zygote/run.jl
+++ b/tools/zygote/run.jl
@@ -3,6 +3,7 @@ import GradBench
 include("run_gmm.jl")
 include("run_hello.jl")
 include("run_lse.jl")
+include("run_lstm.jl")
 
 GradBench.main("zygote")
 

--- a/tools/zygote/run_ba.jl
+++ b/tools/zygote/run_ba.jl
@@ -1,0 +1,80 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+#
+# Incorporates code from: https://github.com/microsoft/ADBench/blob/38cb7931303a830c3700ca36ba9520868327ac87/src/julia/modules/Zygote/ZygoteBA.jl
+
+module BA
+
+import Zygote
+import GradBench
+
+# FIXME: it is very expensive to redo all the input parsing here for
+# every run. We absolutely must hoist it out into a "prepare" stage.
+function objective(j)
+    input = GradBench.BA.input_from_json(j)
+    (r_err, w_err) =
+        GradBench.BA.objective(input.cams,
+                               input.X,
+                               input.w,
+                               input.obs,
+                               input.feats)
+    num_r = size(r_err, 2)
+    num_w = size(w_err, 1)
+    Dict("reproj_error" => Dict("elements" => r_err[:,1], "repeated" => num_r),
+         "w_err" => Dict("element" => w_err[1], "repeated" => num_w)
+         )
+end
+
+function pack(cam, X, w)
+    [cam[:]; X[:]; w]
+end
+
+function unpack(packed)
+    packed[1:end-4], packed[end-3:end-1], packed[end]
+end
+
+function compute_w_err(w)
+    1.0 - w * w
+end
+
+compute_w_err_d = x -> Zygote.gradient(compute_w_err, x)[1]
+
+function compute_reproj_err_d(params, feat)
+    cam, X, w = unpack(params)
+    GradBench.BA.compute_reproj_err(cam, X, w, feat)
+end
+
+function compute_ba_J(cams, X, w, obs, feats)
+    n = size(cams, 2)
+    m = size(X, 2)
+    p = size(obs, 2)
+    jacobian = GradBench.BA.SparseMatrix(n, m, p)
+    reproj_err_d = zeros(2 * p, GradBench.BA.N_CAM_PARAMS + 3 + 1)
+    for i in 1:p
+        compute_reproj_err_d_i = x -> compute_reproj_err_d(x, feats[:, i])
+        camIdx =  obs[1, i]
+        ptIdx = obs[2, i]
+        y, back = Zygote._pullback(compute_reproj_err_d_i, pack(cams[:, camIdx], X[:, ptIdx], w[i]))
+        ylen = size(y, 1)
+        J = hcat([ back(1:ylen .== j)[2] for j ∈ 1:ylen ]...)
+        GradBench.BA.insert_reproj_err_block!(jacobian, i, camIdx, ptIdx, J')
+    end
+    for i in 1:p
+        w_err_d_i = compute_w_err_d(w[i])
+        GradBench.BA.insert_w_err_block!(jacobian, i, w_err_d_i)
+    end
+    jacobian
+end
+
+function jacobian(j)
+    input = GradBench.BA.input_from_json(j)
+    J = compute_ba_J(input.cams, input.X, input.w, input.obs, input.feats)
+    GradBench.BA.dedup_jacobian(J)
+end
+
+GradBench.register!("ba", Dict(
+    "objective" => objective,
+    "jacobian" => jacobian
+))
+
+end

--- a/tools/zygote/run_gmm.jl
+++ b/tools/zygote/run_gmm.jl
@@ -3,17 +3,6 @@ module GMM
 import Zygote
 import GradBench
 
-function unpack(input)
-    gmm_input = GradBench.GMM.input_from_json(input)
-
-    d = size(gmm_input.x, 1)
-    k = size(gmm_input.means, 2)
-    Qs = cat([GradBench.GMM.get_Q(d, gmm_input.icfs[:, ik]) for ik in 1:k]...;
-             dims=[3])
-
-    return (gmm_input.alphas, gmm_input.means, Qs, gmm_input.x, gmm_input.wishart)
-end
-
 Zygote.@adjoint function GradBench.GMM.diagsums(Qs)
     GradBench.GMM.diagsums(Qs),
     function (Δ)

--- a/tools/zygote/run_ht.jl
+++ b/tools/zygote/run_ht.jl
@@ -1,0 +1,55 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+#
+# Incorporates code from: https://github.com/microsoft/ADBench/blob/38cb7931303a830c3700ca36ba9520868327ac87/src/julia/modules/Zygote/ZygoteHT.jl
+
+module HT
+
+import Zygote
+import GradBench
+
+# FIXME: it is very expensive to redo all the input parsing here for
+# every run. We absolutely must hoist it out into a "prepare" stage.
+function objective(j)
+    input = GradBench.HT.input_from_json(j)
+    complicated = size(input.us, 1) != 0
+    if complicated
+        GradBench.HT.objective_complicated(input.model,
+                                           input.correspondences,
+                                           input.points,
+                                           input.theta,
+                                           input.us)
+    else
+        GradBench.HT.objective_simple(input.model,
+                                      input.correspondences,
+                                      input.points,
+                                      input.theta)
+    end
+end
+
+function jacobian(j)
+    input = GradBench.HT.input_from_json(j)
+    complicated = size(input.us, 1) != 0
+    if complicated
+        wrapper = theta -> GradBench.HT.objective_complicated(input.model, input.correspondences, input.points, theta, input.us)
+        y, jacobian_theta = Zygote.forward_jacobian(wrapper, input.theta)
+        ylen = size(y, 1)
+        jacobian_us = hcat([
+            begin
+                _, ju = Zygote.forward_jacobian(u -> GradBench.HT.objective_complicated(input.model, input.correspondences, input.points, input.theta, vcat(input.us[1:j-1], [u], input.us[j+1:end])), input.us[j])
+                ju[:, 3j-2:3j]
+            end
+            for j ∈ 1:size(input.us, 1)
+                ]...)
+        vcat(jacobian_us, jacobian_theta)
+    else
+        Zygote.forward_jacobian(theta -> GradBench.HT.objective_simple(input.model, input.correspondences, input.points, theta), input.theta)[2]
+    end
+end
+
+GradBench.register!("ht", Dict(
+    "objective" => objective,
+    "jacobian" => jacobian
+))
+
+end

--- a/tools/zygote/run_lstm.jl
+++ b/tools/zygote/run_lstm.jl
@@ -1,0 +1,36 @@
+module LSTM
+
+import Zygote
+import GradBench
+
+# FIXME: it is very expensive to redo all the input parsing here for
+# every run. We absolutely must hoist it out into a "prepare" stage.
+function objective(j)
+    input = GradBench.LSTM.input_from_json(j)
+    return GradBench.LSTM.objective(input.main_params,
+                                    input.extra_params,
+                                    input.state,
+                                    input.sequence)
+end
+
+function jacobian(j)
+    input = GradBench.LSTM.input_from_json(j)
+    function wrap(main_params, extra_params)
+        GradBench.LSTM.objective(main_params,
+                                 extra_params,
+                                 input.state,
+                                 input.sequence)
+    end
+
+    (d_main_params, d_extra_params) =
+        Zygote.gradient(wrap, input.main_params, input.extra_params)
+    vcat(vec(d_main_params), vec(d_extra_params))
+end
+
+GradBench.register!("lstm", Dict(
+    "objective" => objective,
+    "jacobian" => jacobian
+))
+
+
+end


### PR DESCRIPTION
Based on ADBench. Unfortunately, `ba` and `ht` are not as easy to port (and I won't try), as they depend on `Zygote.forward`, which seems to not exist in newer versions of Zygote.