### PR TITLE
Fix #465

### DIFF
--- a/crates/gradbench/src/main.rs
+++ b/crates/gradbench/src/main.rs
@@ -328,8 +328,11 @@ fn docker_build_quiet(color: Color, mut cmd: Command) -> anyhow::Result<ExitStat
             eprintln!("{}", line.color(color));
         }
     }
-    eprint!("{}", take(&mut buffer).color(color));
-    Ok(child.wait()?)
+    let status = child.wait()?;
+    if !status.success() {
+        eprint!("{}", take(&mut buffer).color(color));
+    }
+    return Ok(status);
 }
 
 /// Build the Docker image for an eval.

--- a/crates/gradbench/src/main.rs
+++ b/crates/gradbench/src/main.rs
@@ -328,6 +328,7 @@ fn docker_build_quiet(color: Color, mut cmd: Command) -> anyhow::Result<ExitStat
             eprintln!("{}", line.color(color));
         }
     }
+    eprint!("{}", take(&mut buffer).color(color));
     Ok(child.wait()?)
 }
 

--- a/crates/gradbench/src/main.rs
+++ b/crates/gradbench/src/main.rs
@@ -332,7 +332,7 @@ fn docker_build_quiet(color: Color, mut cmd: Command) -> anyhow::Result<ExitStat
     if !status.success() {
         eprint!("{}", take(&mut buffer).color(color));
     }
-    return Ok(status);
+    Ok(status)
 }
 
 /// Build the Docker image for an eval.


### PR DESCRIPTION
This turned out to have a rather pedestrian cause: if no true build output is encountered, then the buffer is never printed.

Fixes #465.