### PR TITLE
cli: add 'log trim' command

### DIFF
--- a/crates/gradbench/src/intermediary.rs
+++ b/crates/gradbench/src/intermediary.rs
@@ -610,7 +610,7 @@ mod tests {
                     id: 2,
                     module: "foo".to_string(),
                     function: "bar".to_string(),
-                    input: json!(PI),
+                    input: Some(json!(PI)),
                     description: None,
                 },
                 Response::Evaluate {
@@ -638,7 +638,7 @@ mod tests {
                     id: 4,
                     module: "foo".to_string(),
                     function: "baz".to_string(),
-                    input: json!({"mynumber": 121}),
+                    input: Some(json!({"mynumber": 121})),
                     description: None,
                 },
                 Response::Evaluate {
@@ -885,7 +885,7 @@ mod tests {
                     id: 2,
                     module: "foo".to_string(),
                     function: "bar".to_string(),
-                    input: json!(42),
+                    input: Some(json!(42)),
                     description: None,
                 },
                 Response::Evaluate {
@@ -937,7 +937,7 @@ mod tests {
                     id: 2,
                     module: "foo".to_string(),
                     function: "bar".to_string(),
-                    input: json!(42),
+                    input: Some(json!(42)),
                     description: None,
                 },
                 Response::Evaluate {
@@ -989,7 +989,7 @@ mod tests {
                     id: 2,
                     module: "foo".to_string(),
                     function: "bar".to_string(),
-                    input: json!(42),
+                    input: Some(json!(42)),
                     description: None,
                 },
                 Response::Evaluate {
@@ -1041,7 +1041,7 @@ mod tests {
                     id: 2,
                     module: "foo".to_string(),
                     function: "bar".to_string(),
-                    input: json!(42),
+                    input: Some(json!(42)),
                     description: None,
                 },
                 Response::Evaluate {
@@ -1093,7 +1093,7 @@ mod tests {
                     id: 2,
                     module: "foo".to_string(),
                     function: "null".to_string(),
-                    input: json!(null),
+                    input: Some(json!(null)),
                     description: None,
                 },
                 Response::Evaluate {

--- a/crates/gradbench/src/intermediary.rs
+++ b/crates/gradbench/src/intermediary.rs
@@ -15,6 +15,7 @@ use crate::{
     protocol::{
         AnalysisResponse, DefineResponse, EvaluateResponse, Id, Message, StartResponse, Timing,
     },
+    util::try_read_line,
     BadOutcome,
 };
 
@@ -175,14 +176,7 @@ impl<
         let mut failure = 0;
         let mut invalid = 0;
         let mut line = Line::new();
-        while let Some(eval_line) = {
-            let mut s = String::new();
-            if self.eval_out.read_line(&mut s)? == 0 {
-                None
-            } else {
-                Some(s)
-            }
-        } {
+        while let Some(eval_line) = try_read_line(&mut self.eval_out)? {
             let message_time = (self.clock)();
             writeln!(
                 self.log,

--- a/crates/gradbench/src/log.rs
+++ b/crates/gradbench/src/log.rs
@@ -1,0 +1,43 @@
+use crate::{
+    protocol::{EvaluateResponse, LogMessage, LogResponse, Message},
+    util::try_read_line,
+};
+
+use std::io::{BufRead, Write};
+
+pub fn trim(input: &mut impl BufRead, out: &mut impl Write) -> anyhow::Result<()> {
+    while let Some(line) = try_read_line(input)? {
+        let mut message: LogMessage = serde_json::from_str(&line)?;
+        match message.message {
+            Message::Evaluate {
+                id,
+                module,
+                function,
+                input: _,
+                description,
+            } => {
+                if let Some(response_line) = try_read_line(input)? {
+                    let mut response: LogResponse<EvaluateResponse> =
+                        serde_json::from_str(&response_line)?;
+                    message.message = Message::Evaluate {
+                        id,
+                        module,
+                        function,
+                        input: serde_json::Value::Null,
+                        description,
+                    };
+                    response.response.output = Some(serde_json::Value::Null);
+                    writeln!(out, "{}", serde_json::to_string(&message)?)?;
+                    writeln!(out, "{}", serde_json::to_string(&response)?)?;
+                }
+            }
+            _ => {
+                write!(out, "{}", line)?;
+                if let Some(response_line) = try_read_line(input)? {
+                    write!(out, "{}", response_line)?;
+                }
+            }
+        }
+    }
+    Ok(())
+}

--- a/crates/gradbench/src/log.rs
+++ b/crates/gradbench/src/log.rs
@@ -23,10 +23,10 @@ pub fn trim(input: &mut impl BufRead, out: &mut impl Write) -> anyhow::Result<()
                         id,
                         module,
                         function,
-                        input: serde_json::Value::Null,
+                        input: None,
                         description,
                     };
-                    response.response.output = Some(serde_json::Value::Null);
+                    response.response.output = None;
                     writeln!(out, "{}", serde_json::to_string(&message)?)?;
                     writeln!(out, "{}", serde_json::to_string(&response)?)?;
                 }

--- a/crates/gradbench/src/log.rs
+++ b/crates/gradbench/src/log.rs
@@ -29,6 +29,8 @@ pub fn trim(input: &mut impl BufRead, out: &mut impl Write) -> anyhow::Result<()
                     response.response.output = None;
                     writeln!(out, "{}", serde_json::to_string(&message)?)?;
                     writeln!(out, "{}", serde_json::to_string(&response)?)?;
+                } else {
+                    write!(out, "{}", line)?;
                 }
             }
             _ => {

--- a/crates/gradbench/src/main.rs
+++ b/crates/gradbench/src/main.rs
@@ -218,7 +218,7 @@ enum RepoCommands {
 
 #[derive(Debug, Subcommand)]
 enum LogCommands {
-    /// Change input/output fields of "evaluate" messages to null.
+    /// Remove input/output fields from "evaluate" messages and responses.
     ///
     /// Writes to stdout unless the `--output` option is used. It is
     /// expected that the input log file is well-formed, but not that

--- a/crates/gradbench/src/main.rs
+++ b/crates/gradbench/src/main.rs
@@ -704,16 +704,13 @@ fn cli() -> Result<(), ExitCode> {
         Commands::Log { command } => match command {
             LogCommands::Trim { input, output } => {
                 let input_file = fs::File::open(input).map_err(|err| err_fail(anyhow!(err)))?;
-                let mut output_file : Box<dyn std::io::Write> = match output {
+                let mut output_file: Box<dyn std::io::Write> = match output {
                     Some(path) => {
                         Box::new(fs::File::create(&path).map_err(|err| err_fail(anyhow!(err)))?)
                     }
-                    None => {
-                        Box::new(io::stdout())
-                    }
+                    None => Box::new(io::stdout()),
                 };
-                log::trim(&mut io::BufReader::new(input_file), &mut output_file)
-                    .map_err(err_fail)
+                log::trim(&mut io::BufReader::new(input_file), &mut output_file).map_err(err_fail)
             }
         },
     }

--- a/crates/gradbench/src/main.rs
+++ b/crates/gradbench/src/main.rs
@@ -593,6 +593,7 @@ fn matrix() -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Run a subcommand from the "Log" command group.
 fn log_command(command: LogCommands) -> anyhow::Result<()> {
     match command {
         LogCommands::Trim { input, output } => match (input, output) {

--- a/crates/gradbench/src/main.rs
+++ b/crates/gradbench/src/main.rs
@@ -728,7 +728,7 @@ fn cli() -> Result<(), ExitCode> {
                 }
             }
         }
-        Commands::Log { command } => log_command(command).map_err(|err| err_fail(anyhow!(err))),
+        Commands::Log { command } => log_command(command).map_err(err_fail),
     }
 }
 

--- a/crates/gradbench/src/main.rs
+++ b/crates/gradbench/src/main.rs
@@ -112,6 +112,12 @@ enum Commands {
         outcome: String,
     },
 
+    /// Perform useful operations on the log files produced by `gradbench run`.
+    Log {
+        #[command(subcommand)]
+        command: LogCommands,
+    },
+
     /// Perform a task in a clone of the https://github.com/gradbench/gradbench repository.
     ///
     /// These subcommands will first attempt to check that the current working directory is the root
@@ -119,12 +125,6 @@ enum Commands {
     Repo {
         #[command(subcommand)]
         command: RepoCommands,
-    },
-
-    /// Perform useful operations on the log files produced by `gradbench run`.
-    Log {
-        #[command(subcommand)]
-        command: LogCommands,
     },
 }
 

--- a/crates/gradbench/src/outputs/trim_basic.jsonl
+++ b/crates/gradbench/src/outputs/trim_basic.jsonl
@@ -1,0 +1,2 @@
+{"elapsed":{"nanoseconds":3528846445},"message":{"kind":"evaluate","id":2,"module":"hello","function":"square","description":null}}
+{"elapsed":{"nanoseconds":3543823169},"response":{"id":2,"success":true,"timings":[{"name":"evaluate","nanoseconds":0}],"error":null}}

--- a/crates/gradbench/src/outputs/trim_basic.jsonl
+++ b/crates/gradbench/src/outputs/trim_basic.jsonl
@@ -1,2 +1,2 @@
-{"elapsed":{"nanoseconds":3528846445},"message":{"kind":"evaluate","id":2,"module":"hello","function":"square","description":null}}
-{"elapsed":{"nanoseconds":3543823169},"response":{"id":2,"success":true,"timings":[{"name":"evaluate","nanoseconds":0}],"error":null}}
+{"elapsed":{"nanoseconds":3528846445},"message":{"kind":"evaluate","id":2,"module":"hello","function":"square"}}
+{"elapsed":{"nanoseconds":3543823169},"response":{"id":2,"success":true,"timings":[{"name":"evaluate","nanoseconds":0}]}}

--- a/crates/gradbench/src/outputs/trim_idempotence.jsonl
+++ b/crates/gradbench/src/outputs/trim_idempotence.jsonl
@@ -1,0 +1,2 @@
+{"elapsed":{"nanoseconds":3528846445},"message":{"kind":"evaluate","id":2,"module":"hello","function":"square","description":null}}
+{"elapsed":{"nanoseconds":3543823169},"response":{"id":2,"success":true,"timings":[{"name":"evaluate","nanoseconds":0}],"error":null}}

--- a/crates/gradbench/src/outputs/trim_idempotence.jsonl
+++ b/crates/gradbench/src/outputs/trim_idempotence.jsonl
@@ -1,2 +1,2 @@
-{"elapsed":{"nanoseconds":3528846445},"message":{"kind":"evaluate","id":2,"module":"hello","function":"square","description":null}}
-{"elapsed":{"nanoseconds":3543823169},"response":{"id":2,"success":true,"timings":[{"name":"evaluate","nanoseconds":0}],"error":null}}
+{"elapsed":{"nanoseconds":3528846445},"message":{"kind":"evaluate","id":2,"module":"hello","function":"square"}}
+{"elapsed":{"nanoseconds":3543823169},"response":{"id":2,"success":true,"timings":[{"name":"evaluate","nanoseconds":0}]}}

--- a/crates/gradbench/src/outputs/trim_missing_response.jsonl
+++ b/crates/gradbench/src/outputs/trim_missing_response.jsonl
@@ -1,0 +1,1 @@
+{ "elapsed": { "nanoseconds": 3528846445 }, "message": {"id": 2, "kind": "evaluate", "module": "hello", "function": "square"} }

--- a/crates/gradbench/src/protocol.rs
+++ b/crates/gradbench/src/protocol.rs
@@ -21,6 +21,10 @@ pub enum Message {
         id: Id,
 
         /// The eval name.
+        #[serde(
+            default, // Deserialize as `None` if missing.
+            skip_serializing_if = "Option::is_none" // Serialize as missing if `None`.
+        )]
         eval: Option<String>,
     },
 
@@ -52,7 +56,11 @@ pub enum Message {
         )]
         input: Option<serde_json::Value>,
 
-        /// A short human-readable description of the input.
+        /// An optional and short human-readable description of the input.
+        #[serde(
+            default, // Deserialize as `None` if missing.
+            skip_serializing_if = "Option::is_none" // Serialize as missing if `None`.
+        )]
         description: Option<String>,
     },
 
@@ -68,6 +76,10 @@ pub enum Message {
         valid: bool,
 
         /// An optional error message if the tool's response was invalid.
+        #[serde(
+            default, // Deserialize as `None` if missing.
+            skip_serializing_if = "Option::is_none" // Serialize as missing if `None`.
+        )]
         error: Option<String>,
     },
 }
@@ -89,6 +101,10 @@ pub struct StartResponse {
     pub id: Id,
 
     /// The tool name.
+    #[serde(
+        default, // Deserialize as `None` if missing.
+        skip_serializing_if = "Option::is_none" // Serialize as missing if `None`.
+    )]
     pub tool: Option<String>,
 }
 
@@ -102,9 +118,17 @@ pub struct DefineResponse {
     pub success: bool,
 
     /// Subtask timings.
+    #[serde(
+        default, // Deserialize as `None` if missing.
+        skip_serializing_if = "Option::is_none" // Serialize as missing if `None`.
+    )]
     pub timings: Option<Vec<Timing>>,
 
     /// An optional error message, if definition failed.
+    #[serde(
+        default, // Deserialize as `None` if missing.
+        skip_serializing_if = "Option::is_none" // Serialize as missing if `None`.
+    )]
     pub error: Option<String>,
 }
 
@@ -129,6 +153,10 @@ pub struct EvaluateResponse {
     pub timings: Option<Vec<Timing>>,
 
     /// An optional error message, if evaluation failed.
+    #[serde(
+        default, // Deserialize as `None` if missing.
+        skip_serializing_if = "Option::is_none" // Serialize as missing if `None`.
+    )]
     pub error: Option<String>,
 }
 

--- a/crates/gradbench/src/protocol.rs
+++ b/crates/gradbench/src/protocol.rs
@@ -45,7 +45,12 @@ pub enum Message {
         function: String,
 
         /// The input to the function.
-        input: serde_json::Value,
+        #[serde(
+            default, // Deserialize as `None` if missing.
+            deserialize_with = "deserialize_optional_json", // Deserialize as `Some` if present.
+            skip_serializing_if = "Option::is_none" // Serialize as missing if `None`.
+        )]
+        input: Option<serde_json::Value>,
 
         /// A short human-readable description of the input.
         description: Option<String>,

--- a/crates/gradbench/src/protocol.rs
+++ b/crates/gradbench/src/protocol.rs
@@ -133,3 +133,29 @@ pub struct AnalysisResponse {
     /// The message ID.
     pub id: Id,
 }
+
+/// A nanoseconds object.
+#[derive(Debug, Deserialize, Serialize)]
+pub struct Nanoseconds {
+    pub nanoseconds: u128,
+}
+
+/// A message entry in a log file.
+#[derive(Debug, Deserialize, Serialize)]
+pub struct LogMessage {
+    /// The timestamp in nanoseconds.
+    pub elapsed: Nanoseconds,
+
+    /// The contained message.
+    pub message: Message,
+}
+
+/// A response entry in a log file.
+#[derive(Debug, Deserialize, Serialize)]
+pub struct LogResponse<T> {
+    /// The timestamp in nanoseconds.
+    pub elapsed: Nanoseconds,
+
+    /// The contained response.
+    pub response: T,
+}

--- a/crates/gradbench/src/util.rs
+++ b/crates/gradbench/src/util.rs
@@ -1,3 +1,4 @@
+use std::io::BufRead;
 use std::time::Duration;
 
 use anyhow::Context;
@@ -9,6 +10,15 @@ pub fn nanos_duration(nanoseconds: u128) -> anyhow::Result<Duration> {
         u64::try_from(nanoseconds / BILLION).context("too many seconds")?,
         u32::try_from(nanoseconds % BILLION).unwrap(),
     ))
+}
+
+pub fn try_read_line(file: &mut impl BufRead) -> anyhow::Result<Option<String>> {
+    let mut s = String::new();
+    if file.read_line(&mut s)? == 0 {
+        Ok(None)
+    } else {
+        Ok(Some(s))
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This PR adds a new command to the gradbench CLI that sets the 'input' and 'output' fields of a log file to null. The purpose of this is to trim the often very large log files produced by GradBench, in the interest of saving on storage space and reading time. For example, the log file for gmm-futhark is reduced in size by about 95% after trimming. Most of the remaining space is taken up by timings.

The use of null allows us to distinguish trimmed log files, as presumably this value will never originally occur.

Although the command implementation is pretty short, I have factored it into a separate file 'log.rs', because I envision that we will eventually have a bunch of such log manipulation commands.

I am not a particularly experienced Rust programmer, so I would like feedback on my approach before I start adding more subcommands.