### PR TITLE
llsq: strength reduction

### DIFF
--- a/cpp/gradbench/evals/llsq.hpp
+++ b/cpp/gradbench/evals/llsq.hpp
@@ -26,8 +26,10 @@ void primal(size_t n, size_t m, const T* __restrict__ x, T* __restrict__ out) {
   for (size_t i = 0; i < n; i++) {
     T ti        = t(i, n);
     T inner_sum = s(ti);
+    T acc = 1;
     for (size_t j = 0; j < m; j++) {
-      inner_sum -= x[j] * pow(ti, j);
+      inner_sum -= x[j] * acc;
+      acc *= ti;
     }
     sum += inner_sum * inner_sum;
   }

--- a/cpp/gradbench/evals/llsq.hpp
+++ b/cpp/gradbench/evals/llsq.hpp
@@ -26,7 +26,7 @@ void primal(size_t n, size_t m, const T* __restrict__ x, T* __restrict__ out) {
   for (size_t i = 0; i < n; i++) {
     T ti        = t(i, n);
     T inner_sum = s(ti);
-    T acc = 1;
+    T acc       = 1;
     for (size_t j = 0; j < m; j++) {
       inner_sum -= x[j] * acc;
       acc *= ti;

--- a/tools/futhark/Dockerfile
+++ b/tools/futhark/Dockerfile
@@ -1,5 +1,5 @@
 FROM ghcr.io/astral-sh/uv:python3.11-bookworm-slim
-ARG FUTHARK_VER=0.25.29
+ARG FUTHARK_VER=0.25.30
 WORKDIR /gradbench
 
 # Install build dependencies.

--- a/tools/futhark/llsq.fut
+++ b/tools/futhark/llsq.fut
@@ -3,8 +3,9 @@ def t (i: i64) (n: i64) = -1 + f64.i64 i * 2 / (f64.i64 n - 1)
 entry primal [m] (x: [m]f64) (n: i64) =
   let f i =
     let ti = t i n
-    let g j xj = -(xj * ti ** f64.i64 j)
-    in (f64.sgn ti + f64.sum (map2 g (indices x) x)) ** 2
+    let muls = scan (*) 1 (replicate m ti with [0] = 1)
+    let g mul xj = -(xj * mul)
+    in (f64.sgn ti + f64.sum (map2 g muls x)) ** 2
   in f64.sum (tabulate n f) / 2
 
 entry gradient [m] (x: [m]f64) (n: i64) =


### PR DESCRIPTION
This replaces the pow with an accumulator, like in the Floretta implementation. The speedup is pretty dramatic.

The Futhark tool probably fails, as it depends on a compiler version that isn't going to be released until about 30 minutes from now.