### PR TITLE
cpp: add common.mk

### DIFF
--- a/cpp/common.mk
+++ b/cpp/common.mk
@@ -1,0 +1,19 @@
+# Common Makefile definitions that are used by many of the C++-based
+# tools. You do not have to use it, but the cpp.py tooling expects an
+# interface that behaves like this.
+#
+# The EXECUTABLES variable (and the 'all' target) is not needed for
+# cpp.py, but only for local testing.
+
+CXX?=c++
+CC?=cc
+CXXFLAGS?=-std=c++17 -O3 -march=native -Wall -I../../cpp
+LDFLAGS?=-lm
+
+all: $(EXECUTABLES)
+
+%: %.cpp $(EXTRA_DEPS)
+	$(CXX) -o $@ $^ $(LDFLAGS) $(CXXFLAGS)
+
+clean:
+	rm -f $(EXECUTABLES)

--- a/shell.nix
+++ b/shell.nix
@@ -81,4 +81,8 @@ in pkgs.stdenv.mkDerivation rec {
   ENZYME_LIB = "${pkgs.enzyme}/lib";
   LD_LIBRARY_PATH =
     "${pkgs.lib.makeLibraryPath buildInputs}:${pkgs.stdenv.cc.cc.lib}/lib";
+
+  # The Nix C/C++ compilers disable -march=native on purity reasons, but we
+  # don't use them to compile Nix derivations.
+  NIX_ENFORCE_NO_NATIVE=0;
 }

--- a/tools/ad-hpp/Makefile
+++ b/tools/ad-hpp/Makefile
@@ -1,18 +1,11 @@
-GIT_TAG=v1.7
-CXX?=c++
-CC?=cc
-CFLAGS=-std=c++17 -O3 -Wall -I../../cpp -Iinclude
-LDFLAGS=-lm
-
 EXECUTABLES=hello llsq
 
-all: $(EXECUTABLES)
+EXTRA_DEPS=include/ad.hpp
 
-%: %.cpp include/ad.hpp
-	$(CXX) -o $@ $< $(LDFLAGS) $(CFLAGS)
+include ../../cpp/common.mk
 
-clean:
-	rm -f $(EXECUTABLES)
+GIT_TAG=v1.7
+CXXFLAGS+=-Iinclude
 
 include/ad.hpp:
 	mkdir -p include

--- a/tools/adept/Makefile
+++ b/tools/adept/Makefile
@@ -1,14 +1,5 @@
-CXX?=c++
-CC?=cc
-CXXFLAGS=-std=c++17 -O2 -Wall -fopenmp -I../../cpp
-LDFLAGS=-lm -ladept -fopenmp
+EXECUTABLES=hello gmm lstm ba ht ode llsq det lse
 
-EXECUTABLES=hello gmm ht ba lstm ode llsq det
+include ../../cpp/common.mk
 
-all: $(EXECUTABLES)
-
-%: %.cpp
-	$(CXX) -o $@ $^ $(LDFLAGS) $(CXXFLAGS)
-
-clean:
-	rm -f $(EXECUTABLES)
+LDFLAGS+=-lm -ladept

--- a/tools/codipack/Makefile
+++ b/tools/codipack/Makefile
@@ -1,18 +1,9 @@
-CXX?=c++
-CC?=cc
-CFLAGS=-std=c++17 -O3 -Wall -march=native -DCODI_ForcedInlines=1 -I../../cpp
-LDFLAGS=-lm
+EXECUTABLES=hello gmm lstm ba ht kmeans ode llsq det lse
+
+include ../../cpp/common.mk
+
+CXXFLAGS+=-DCODI_ForcedInlines=1
 
 ifdef CODI_TYPE
-  CFLAGS+=-DCODI_TYPE=$(CODI_TYPE)
+  CXXFLAGS+=-DCODI_TYPE=$(CODI_TYPE)
 endif
-
-EXECUTABLES=ba det gmm hello ht kmeans llsq lse lstm ode
-
-all: $(EXECUTABLES)
-
-%: %.cpp
-	$(CXX) -o $@ $^ $(LDFLAGS) $(CFLAGS)
-
-clean:
-	rm -f $(EXECUTABLES)

--- a/tools/cppad/Makefile
+++ b/tools/cppad/Makefile
@@ -1,14 +1,6 @@
-CXX?=c++
-CC?=cc
-CXXFLAGS=-std=c++17 -O3 -Wall $(shell pkg-config --cflags cppad) -I../../cpp
-LDFLAGS=-lm $(shell pkg-config --libs cppad)
+EXECUTABLES=hello gmm lstm ba kmeans ode llsq det lse
 
-EXECUTABLES=hello ba gmm lstm kmeans ode llsq det
+include ../../cpp/common.mk
 
-all: $(EXECUTABLES)
-
-%: %.cpp
-	$(CXX) -o $@ $^ $(LDFLAGS) $(CXXFLAGS)
-
-clean:
-	rm -f $(UTIL_OBJECTS) $(EXECUTABLES)
+CXXFLAGS+=$(shell pkg-config --cflags cppad)
+LDFLAGS+=$(shell pkg-config --libs cppad)

--- a/tools/enzyme/Makefile
+++ b/tools/enzyme/Makefile
@@ -1,17 +1,10 @@
-CXX=clang++
-LLD=lld
-CXXFLAGS=-std=c++17 -O3 -fno-math-errno -Wall -flto -I../../cpp
-LDFLAGS=-fuse-ld=$(LLD) -O3 -fno-math-errno -flto -Wl,--load-pass-plugin=$(LLDENZYME) -lm
+EXECUTABLES=hello gmm lstm ba ht kmeans particle saddle ode llsq det lse
 
 ENZYME_LIB?=/gradbench/enzyme-build/Enzyme/
 LLDENZYME=$(ENZYME_LIB)/LLDEnzyme-19.so
 
-EXECUTABLES=hello gmm lstm ba ht kmeans particle saddle ode llsq det lse
+CXX=clang++
+LLD=lld
+LDFLAGS+=-fuse-ld=$(LLD) -O3 -fno-math-errno -flto -Wl,--load-pass-plugin=$(LLDENZYME)
 
-all: $(EXECUTABLES)
-
-%: %.cpp
-	$(CXX) -o $@ $^ $(LDFLAGS) $(CXXFLAGS)
-
-clean:
-	rm -f $(EXECUTABLES)
+include ../../cpp/common.mk

--- a/tools/finite/Makefile
+++ b/tools/finite/Makefile
@@ -1,14 +1,3 @@
-CXX?=c++
-CC?=cc
-CFLAGS=-std=c++17 -O3 -Wall -I../../cpp
-LDFLAGS=-lm
+EXECUTABLES=hello gmm lstm ba ht kmeans particle saddle ode llsq det lse
 
-EXECUTABLES=hello gmm ba lstm ht particle saddle ode llsq det lse
-
-all: $(EXECUTABLES)
-
-%: %.cpp
-	$(CXX) -o $@ $^ $(LDFLAGS) $(CFLAGS)
-
-clean:
-	rm -f $(EXECUTABLES)
+include ../../cpp/common.mk

--- a/tools/futhark/run.py
+++ b/tools/futhark/run.py
@@ -36,6 +36,8 @@ def run(params):
             return {"success": False, "error": str(e)}
 
 
+CFLAGS = '-O3 -march=native -fno-math-errno'
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--backend", type=str, default="c")
@@ -60,6 +62,7 @@ def main():
                     ],
                     stderr=subprocess.STDOUT,
                     text=True,
+                    env=os.environ | {'CFLAGS': CFLAGS}
                 )
             except subprocess.CalledProcessError as e:
                 response["success"] = False

--- a/tools/manual/Makefile
+++ b/tools/manual/Makefile
@@ -1,14 +1,3 @@
-CXX?=c++
-CC?=cc
-CFLAGS=-std=c++17 -O3 -Wall -I../../cpp
-LDFLAGS=-lm
+EXECUTABLES=hello gmm lstm ba ht kmeans ode llsq det lse
 
-EXECUTABLES=hello gmm ba lstm ht kmeans ode llsq det lse
-
-all: $(EXECUTABLES)
-
-%: %.cpp
-	$(CXX) -o $@ $^ $(LDFLAGS) $(CFLAGS)
-
-clean:
-	rm -f $(EXECUTABLES)
+include ../../cpp/common.mk


### PR DESCRIPTION
This adds a common set of Makefile rules that can be used by all C++ tools. This makes it easy to ensure a consistent set of optimisation flags; e.g. using -march-native.

There is no requirement for a tool to use common.mk, or these optimisation flags, if some specialised set happens to work better for some tool. The purpose is just to avoid differences due to arbitrary differences in how the compiler is configured.

(In this regard, let us ignore that enzyme uses a completely different compiler than all other C++ tools...)