### PR TITLE
Refactor input/output polymorphism for `log trim`

### DIFF
--- a/crates/gradbench/src/main.rs
+++ b/crates/gradbench/src/main.rs
@@ -272,8 +272,8 @@ enum LogCommands {
     /// message may not have a response - this occurs when the tool
     /// crashes or times out before it gets to respond.
     Trim {
-        /// The input log file, or `-` to read from stdin.
-        input: PathBuf,
+        /// The input log file.
+        input: Option<PathBuf>,
 
         /// The output log file.
         #[clap(short, long)]
@@ -1032,7 +1032,9 @@ fn matrix() -> anyhow::Result<()> {
 /// Run a subcommand from the "Log" command group.
 fn log_command(command: LogCommands) -> anyhow::Result<()> {
     match command {
-        LogCommands::Trim { input, output } => run_in_out(log::Trim, &input, output.as_deref()),
+        LogCommands::Trim { input, output } => {
+            run_in_out(log::Trim, input.as_deref(), output.as_deref())
+        }
     }
 }
 

--- a/crates/gradbench/src/main.rs
+++ b/crates/gradbench/src/main.rs
@@ -25,7 +25,7 @@ use regex::Regex;
 use serde::Serialize;
 use stats::StatsMetadata;
 use strum::{EnumIter, EnumString, IntoStaticStr};
-use util::{stringify_cmd, CtrlC};
+use util::{run_in_out, stringify_cmd, CtrlC};
 
 /// CLI utilities for GradBench, a benchmark suite for differentiable programming across languages
 /// and domains.
@@ -272,8 +272,8 @@ enum LogCommands {
     /// message may not have a response - this occurs when the tool
     /// crashes or times out before it gets to respond.
     Trim {
-        /// The input log file.
-        input: Option<PathBuf>,
+        /// The input log file, or `-` to read from stdin.
+        input: PathBuf,
 
         /// The output log file.
         #[clap(short, long)]
@@ -1032,28 +1032,7 @@ fn matrix() -> anyhow::Result<()> {
 /// Run a subcommand from the "Log" command group.
 fn log_command(command: LogCommands) -> anyhow::Result<()> {
     match command {
-        LogCommands::Trim { input, output } => match (input, output) {
-            (Some(input_path), Some(output_path)) => {
-                let input_file = fs::File::open(input_path)?;
-                let mut output_file = fs::File::create(&output_path)?;
-                log::trim(&mut io::BufReader::new(input_file), &mut output_file)?;
-                Ok(())
-            }
-            (Some(input_path), None) => {
-                let input_file = fs::File::open(input_path)?;
-                log::trim(&mut io::BufReader::new(input_file), &mut io::stdout())?;
-                Ok(())
-            }
-            (None, Some(output_path)) => {
-                let mut output_file = fs::File::create(&output_path)?;
-                log::trim(&mut io::BufReader::new(io::stdin()), &mut output_file)?;
-                Ok(())
-            }
-            (None, None) => {
-                log::trim(&mut io::BufReader::new(io::stdin()), &mut io::stdout())?;
-                Ok(())
-            }
-        },
+        LogCommands::Trim { input, output } => run_in_out(log::Trim, &input, output.as_deref()),
     }
 }
 

--- a/crates/gradbench/src/util.rs
+++ b/crates/gradbench/src/util.rs
@@ -21,20 +21,19 @@ fn run_out(
     output: Option<&Path>,
 ) -> anyhow::Result<()> {
     match output {
-        Some(out) => f.run(input, fs::File::create(out)?),
+        Some(path) => f.run(input, fs::File::create(path)?),
         None => f.run(input, io::stdout()),
     }
 }
 
 pub fn run_in_out(
     f: impl InOut<anyhow::Result<()>>,
-    input: &Path,
+    input: Option<&Path>,
     output: Option<&Path>,
 ) -> anyhow::Result<()> {
-    if input.to_str() == Some("-") {
-        run_out(f, io::stdin(), output)
-    } else {
-        run_out(f, fs::File::open(input)?, output)
+    match input {
+        Some(path) => run_out(f, fs::File::open(path)?, output),
+        None => run_out(f, io::stdin(), output),
     }
 }
 


### PR DESCRIPTION
To address the concerns of code duplication from #529, this PR creates an `InOut` trait with a helper function that should make it easy to handle this pattern in the future, e.g. for #533.