### PR TITLE
Add CITATION.cff

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,6 +10,7 @@
   },
   "[typescript]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
   "[typescriptreact]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
+  "[yaml]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
   "editor.formatOnSave": true,
   "files.associations": {
     "time.h": "c"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -19,9 +19,10 @@ authors:
     family-names: Henriksen
     email: athas@sigkill.dk
     orcid: "https://orcid.org/0000-0002-1195-9722"
-  - given-names: Sasha
+  - given-names: Alexander
     family-names: Fleming
     email: alexander.fleming@rwth-aachen.de
+    orcid: "https://orcid.org/0009-0004-8591-2558"
   - given-names: Max
     family-names: Sagebaum
     email: max.sagebaum@scicomp.uni-kl.de

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,7 +8,7 @@ authors:
   - given-names: Sam
     family-names: Estep
     email: sam@samestep.com
-    orcid: 'https://orcid.org/0000-0002-7107-7043'
+    orcid: "https://orcid.org/0000-0002-7107-7043"
   - given-names: Maggie
     family-names: Hollis
     email: mhollis@smith.edu
@@ -18,15 +18,15 @@ authors:
   - given-names: Troels
     family-names: Henriksen
     email: athas@sigkill.dk
-    orcid: 'https://orcid.org/0000-0002-1195-9722'
+    orcid: "https://orcid.org/0000-0002-1195-9722"
   - given-names: Sasha
     family-names: Fleming
     email: alexander.fleming@rwth-aachen.de
   - given-names: Max
     family-names: Sagebaum
     email: max.sagebaum@scicomp.uni-kl.de
-repository-code: 'https://github.com/gradbench/gradbench'
-url: 'https://gradben.ch'
+repository-code: "https://github.com/gradbench/gradbench"
+url: "https://gradben.ch"
 abstract: >-
   GradBench is a benchmark suite for differentiable
   programming across languages and domains.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,36 @@
+cff-version: 1.2.0
+title: GradBench
+message: >-
+  If you use this software, please cite it using the
+  metadata from this file.
+type: software
+authors:
+  - given-names: Sam
+    family-names: Estep
+    email: sam@samestep.com
+    orcid: 'https://orcid.org/0000-0002-7107-7043'
+  - given-names: Maggie
+    family-names: Hollis
+    email: mhollis@smith.edu
+  - given-names: Tomáš
+    family-names: Skřivan
+    email: skrivantomas@seznam.cz
+  - given-names: Troels
+    family-names: Henriksen
+    email: athas@sigkill.dk
+    orcid: 'https://orcid.org/0000-0002-1195-9722'
+  - given-names: Sasha
+    family-names: Fleming
+    email: alexander.fleming@rwth-aachen.de
+  - given-names: Max
+    family-names: Sagebaum
+    email: max.sagebaum@scicomp.uni-kl.de
+repository-code: 'https://github.com/gradbench/gradbench'
+url: 'https://gradben.ch'
+abstract: >-
+  GradBench is a benchmark suite for differentiable
+  programming across languages and domains.
+keywords:
+  - autodiff
+  - benchmarks
+license: MIT

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,17 @@
 
 <!-- tocstop -->
 
+GradBench welcomes contributions of every kind - simply issue a pull request
+here on GitHub.
+
+If you make a PR, you can add yourself to [CITATION.cff](/CITATION.cff) if you
+are not already listed. This is however not mandatory if you would rather not be
+listed as an author for some reason. Your name can always be added or removed
+later if you change not mind.
+
+Below you can find technical information on how GradBench is implemented, as
+well as advice for making various kinds of contributions.
+
 ## Setup
 
 First, clone this repo, e.g. with the [GitHub CLI][]:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ here on GitHub.
 If you make a PR, you can add yourself to [CITATION.cff](/CITATION.cff) if you
 are not already listed. This is however not mandatory if you would rather not be
 listed as an author for some reason. Your name can always be added or removed
-later if you change not mind.
+later if you change your mind.
 
 Below you can find technical information on how GradBench is implemented, as
 well as advice for making various kinds of contributions.

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ See <https://gradben.ch> for interactive performance charts generated from our l
       - [Running C++-based tools](#running-c-based-tools)
   - [Multithreading](#multithreading)
   - [Without cloning this repository](#without-cloning-this-repository)
+- [Citing](#citing)
 - [License](#license)
 
 <!-- tocstop -->
@@ -277,6 +278,13 @@ Then, you can use the newly installed `gradbench` CLI to download and run our [n
 DATE=$(curl https://raw.githubusercontent.com/gradbench/gradbench/refs/heads/ci/refs/heads/nightly/summary.json | jq --raw-output .date)
 gradbench run --eval "gradbench eval hello --tag $DATE" --tool "gradbench tool pytorch --tag $DATE"
 ```
+
+## Citing
+
+GradBench is largely developed by academics and we appreciate a citation if you
+find it useful for published work. See the *Cite this repository* button in the
+**About** section of the right GitHub sidebar, or view
+[CITATION.cff](CITATION.cff) directly.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ gradbench run --eval "gradbench eval hello --tag $DATE" --tool "gradbench tool p
 ## Citing
 
 GradBench is largely developed by academics and we appreciate a citation if you
-find it useful for published work. See the *Cite this repository* button in the
+find it useful for published work. See the _Cite this repository_ button in the
 **About** section of the right GitHub sidebar, or view
 [CITATION.cff](CITATION.cff) directly.
 


### PR DESCRIPTION
This add a file containing metadata for citing GradBench. It is relevant because I have some students who will need to cite GradBench properly soon-ish. The citation file only covers GradBench as a software artifact, not any papers that we will likely write based on it.

I simply added everyone who has commits in GradBench as an author, ordered by their first commit. This seems the most fair. It cannot be fully automated, because people will eventually make commits using different names, email addresses, or anonymously. However, I don't expect maintenance of this file to be particularly onerous. It is also not a permanent record, so we can add ORCIDs and such over time.

If this is accepted, a good next step is to also upload GradBench to [Zenodo](https://zenodo.org/). There are GitHub actions for automating this.