### PR TITLE
lse.hpp: also parallelise second loop

### DIFF
--- a/cpp/gradbench/evals/lse.hpp
+++ b/cpp/gradbench/evals/lse.hpp
@@ -42,16 +42,19 @@ void primal(size_t n, const double* __restrict__ x, double* __restrict__ out) {
     As[thread_num()] = priv_A;
   }
   double A =
-      std::accumulate(std::begin(As), std::end(As), 0, std::plus<double>());
+    std::accumulate(std::begin(As), std::end(As), 0, std::plus<double>());
 
-  double s = 0;
+  std::vector<double> Ss(num_threads());
+#pragma omp parallel
   {
     double priv_s = 0;
+#pragma omp for
     for (size_t i = 0; i < n; i++) {
       priv_s += exp(x[i] - A);
     }
-    s += priv_s;
+    Ss[thread_num()] += priv_s;
   }
+  double s = std::accumulate(std::begin(Ss), std::end(Ss), 0, std::plus<double>());
   *out = log(s) + A;
 }
 

--- a/cpp/gradbench/evals/lse.hpp
+++ b/cpp/gradbench/evals/lse.hpp
@@ -42,7 +42,7 @@ void primal(size_t n, const double* __restrict__ x, double* __restrict__ out) {
     As[thread_num()] = priv_A;
   }
   double A =
-    std::accumulate(std::begin(As), std::end(As), 0, std::plus<double>());
+      std::accumulate(std::begin(As), std::end(As), 0, std::plus<double>());
 
   std::vector<double> Ss(num_threads());
 #pragma omp parallel
@@ -54,7 +54,8 @@ void primal(size_t n, const double* __restrict__ x, double* __restrict__ out) {
     }
     Ss[thread_num()] += priv_s;
   }
-  double s = std::accumulate(std::begin(Ss), std::end(Ss), 0, std::plus<double>());
+  double s =
+      std::accumulate(std::begin(Ss), std::end(Ss), 0, std::plus<double>());
   *out = log(s) + A;
 }
 

--- a/cpp/gradbench/evals/lse.hpp
+++ b/cpp/gradbench/evals/lse.hpp
@@ -41,8 +41,10 @@ void primal(size_t n, const double* __restrict__ x, double* __restrict__ out) {
     }
     As[thread_num()] = priv_A;
   }
-  double A =
-      std::accumulate(std::begin(As), std::end(As), 0, std::plus<double>());
+  double A = 0;
+  for (int i = 0; i < num_threads(); i++) {
+    A = std::max(A, As[i]);
+  }
 
   std::vector<double> Ss(num_threads());
 #pragma omp parallel
@@ -52,10 +54,13 @@ void primal(size_t n, const double* __restrict__ x, double* __restrict__ out) {
     for (size_t i = 0; i < n; i++) {
       priv_s += exp(x[i] - A);
     }
-    Ss[thread_num()] += priv_s;
+    Ss[thread_num()] = priv_s;
   }
-  double s =
-      std::accumulate(std::begin(Ss), std::end(Ss), 0, std::plus<double>());
+  double s = 0;
+  for (int i = 0; i < num_threads(); i++) {
+    s += Ss[i];
+  }
+
   *out = log(s) + A;
 }
 

--- a/evals/lse/README.md
+++ b/evals/lse/README.md
@@ -70,9 +70,8 @@ This is a _very_ simple benchmark, and a good first one to implement.
 
 ### Parallel execution
 
-The `primal` function can be implemented as a parallel reduction, and this is
-done in [lse.hpp][]. On most workloads, multithreaded execution does not lead to
-a significant speedup.
+The `primal` function can be implemented as two parallel reductions, and this is
+done in [lse.hpp][]. This results in good speedup.
 
 [the LogSumExp trick]: https://gregorygundersen.com/blog/2020/02/09/log-sum-exp/
 [protocol]: /CONTRIBUTING.md#types


### PR DESCRIPTION
No idea how I forgot to do that, especially since I even documented the resulting bad performance.