### PR TITLE
julia: begin work on multithreading

### DIFF
--- a/julia/GradBench/Project.toml
+++ b/julia/GradBench/Project.toml
@@ -4,6 +4,7 @@ authors = []
 version = "0.1.0"
 
 [deps]
+ArgParse = "c7e460c6-2fb9-53a9-8c5b-16f535851c63"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"

--- a/julia/GradBench/src/GradBench.jl
+++ b/julia/GradBench/src/GradBench.jl
@@ -1,6 +1,7 @@
 module GradBench
 
 import JSON
+using ArgParse
 
 """
     Experiment
@@ -72,7 +73,24 @@ function run(params)
     return Dict("success" => true, "output" => output, "timings" => timings)
 end
 
+
+function parse_commandline()
+    s = ArgParseSettings()
+
+    @add_arg_table s begin
+        "--multithreaded"
+        help = "Enable multithreading"
+        action = :store_true
+    end
+
+    return parse_args(s)
+end
+
+OPTIONS = Dict{String,Any}()
+
 function main(tool)
+    global OPTIONS
+    OPTIONS = parse_commandline()
     while !eof(stdin)
         message = JSON.parse(readline(stdin))
         response = Dict()

--- a/julia/GradBench/src/benchmarks/lse.jl
+++ b/julia/GradBench/src/benchmarks/lse.jl
@@ -1,15 +1,10 @@
 module LSE
 
+import ..GradBench
+
 struct Input
     x::Vector{Float64}
 end
-
-function logsumexp(x::Vector{T}) where {T}
-    xmax = maximum(x)
-    return xmax + log(sum(exp.(x .- xmax)))
-end
-
-import ..GradBench
 
 abstract type AbstractLSE <: GradBench.Experiment end
 
@@ -17,8 +12,53 @@ function GradBench.preprocess(::AbstractLSE, message)
     (Input(convert(Vector{Float64}, message["x"])),)
 end
 
-struct PrimalLSE <: AbstractLSE end
+# A sequential implementation in a pure and vectorised style.
+module Pure
+
+using ..LSE
+
+function logsumexp(x::Vector{T}) where {T}
+    xmax = maximum(x)
+    return xmax + log(sum(exp.(x .- xmax)))
+end
+
+struct PrimalLSE <: LSE.AbstractLSE end
 (::PrimalLSE)(input) = logsumexp(input.x)
 
+end # Pure
+
+# A multithreaded implementation that uses side effects.
+module Impure
+
+using ..LSE
+
+using Base.Threads
+
+"Explicitly loopy with @threads annotations for parallel execution."
+function logsumexp(x::Vector{T}) where {T}
+    n = length(x)
+    nt = nthreads()
+
+    local_max = fill(x[1], nt)
+    Threads.@threads for i in 1:n
+        tid = threadid()
+        local_max[tid] = max(local_max[tid], x[i])
+    end
+    xmax = maximum(local_max)
+
+    local_sum = zeros(T, nt)
+    Threads.@threads for i in 1:n
+        tid = threadid()
+        local_sum[tid] += exp(x[i] - xmax)
+    end
+    total = sum(local_sum)
+
+    return xmax + log(total)
+end
+
+struct PrimalLSE <: LSE.AbstractLSE end
+(::PrimalLSE)(input) = logsumexp(input.x)
+
+end # module Impure
 
 end # module lse

--- a/shell.nix
+++ b/shell.nix
@@ -79,6 +79,7 @@ in pkgs.stdenv.mkDerivation rec {
   ENZYME_LIB = "${pkgs.enzyme}/lib";
   LD_LIBRARY_PATH =
     "${pkgs.lib.makeLibraryPath buildInputs}:${pkgs.stdenv.cc.cc.lib}/lib";
+  JULIA_NUM_THREADS = "auto";
 
   # The Nix C/C++ compilers disable -march=native on purity reasons, but we
   # don't use them to compile Nix derivations.

--- a/tools/enzyme-jl/Manifest.toml
+++ b/tools/enzyme-jl/Manifest.toml
@@ -4,6 +4,12 @@ julia_version = "1.10.9"
 manifest_format = "2.0"
 project_hash = "f3937c14ef4dea41e32def0d8571d3d1e503ceb8"
 
+[[deps.ArgParse]]
+deps = ["Logging", "TextWrap"]
+git-tree-sha1 = "22cf435ac22956a7b45b0168abbc871176e7eecc"
+uuid = "c7e460c6-2fb9-53a9-8c5b-16f535851c63"
+version = "1.2.0"
+
 [[deps.ArgTools]]
 uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
 version = "1.1.1"
@@ -92,7 +98,7 @@ uuid = "61eb1bfa-7361-4325-ad38-22787b887f55"
 version = "1.2.0"
 
 [[deps.GradBench]]
-deps = ["JSON", "LinearAlgebra", "SpecialFunctions"]
+deps = ["ArgParse", "JSON", "LinearAlgebra", "SpecialFunctions"]
 path = "../../julia/GradBench"
 uuid = "b8d9ff47-6a34-4c60-b82b-acd435921e41"
 version = "0.1.0"
@@ -324,6 +330,11 @@ version = "1.0.3"
 deps = ["ArgTools", "SHA"]
 uuid = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
 version = "1.10.0"
+
+[[deps.TextWrap]]
+git-tree-sha1 = "43044b737fa70bc12f6105061d3da38f881a3e3c"
+uuid = "b718987f-49a8-5099-9789-dcd902bef87d"
+version = "1.0.2"
 
 [[deps.TimerOutputs]]
 deps = ["ExprTools", "Printf"]

--- a/tools/enzyme-jl/README.md
+++ b/tools/enzyme-jl/README.md
@@ -3,5 +3,27 @@
 [Enzyme.jl][] is a differentiable programming library for the [Julia][]
 programming language.
 
+## Running outside of Docker
+
+Make sure the `julia` executable is on your `PATH`. Then run the following
+command to download and install all packages:
+
+```
+$ julia -t auto --project=tools/enzyme-jl -e 'import Pkg; Pkg.instantiate()'
+```
+
+Then you can run the tool as follows:
+
+```
+$ julia -t auto --project=tools/enzyme-jl tools/enzyme-jl/run.jl
+```
+
+## Commentary
+
+### Multithreading
+
+As with [plain Enzyme](/tools/enzyme/README.md), Enzyme.jl supports
+multithreaded execution when the underlying primal function is multithreaded.
+
 [julia]: https://julialang.org/
 [Enzyme.jl]: https://enzyme.mit.edu/

--- a/tools/enzyme-jl/run_lse.jl
+++ b/tools/enzyme-jl/run_lse.jl
@@ -8,16 +8,33 @@ struct GradientLSE <: GradBench.LSE.AbstractLSE end
 function (::GradientLSE)(input)
     dx = Enzyme.make_zero(input.x)
 
-    Enzyme.autodiff(
-        Reverse, GradBench.LSE.logsumexp, Active,
-        Duplicated(input.x, dx)
-    )
+    if GradBench.OPTIONS["multithreaded"]
+        Enzyme.autodiff(
+            Reverse, GradBench.LSE.Impure.logsumexp, Active,
+            Duplicated(input.x, dx)
+        )
+    else
+        Enzyme.autodiff(
+            Reverse, GradBench.LSE.Pure.logsumexp, Active,
+            Duplicated(input.x, dx)
+        )
+    end
     return dx
+end
+
+struct PrimalLSE <: GradBench.LSE.AbstractLSE end
+
+function (::PrimalLSE)(input)
+    if GradBench.OPTIONS["multithreaded"]
+        return GradBench.LSE.Impure.logsumexp(input.x)
+    else
+        return GradBench.LSE.Pure.logsumexp(input.x)
+    end
 end
 
 GradBench.register!(
     "lse", Dict(
-        "primal" => GradBench.LSE.PrimalLSE(),
+        "primal" => PrimalLSE(),
         "gradient" => GradientLSE()
     )
 )

--- a/tools/zygote/Manifest.toml
+++ b/tools/zygote/Manifest.toml
@@ -32,6 +32,12 @@ version = "4.2.0"
     SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
     StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
+[[deps.ArgParse]]
+deps = ["Logging", "TextWrap"]
+git-tree-sha1 = "22cf435ac22956a7b45b0168abbc871176e7eecc"
+uuid = "c7e460c6-2fb9-53a9-8c5b-16f535851c63"
+version = "1.2.0"
+
 [[deps.ArgTools]]
 uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
 version = "1.1.1"
@@ -184,7 +190,7 @@ uuid = "46192b85-c4d5-4398-a991-12ede77f4527"
 version = "0.1.6"
 
 [[deps.GradBench]]
-deps = ["JSON", "LinearAlgebra", "SpecialFunctions"]
+deps = ["ArgParse", "JSON", "LinearAlgebra", "SpecialFunctions"]
 path = "../../julia/GradBench"
 uuid = "b8d9ff47-6a34-4c60-b82b-acd435921e41"
 version = "0.1.0"
@@ -486,6 +492,11 @@ version = "1.12.0"
 deps = ["ArgTools", "SHA"]
 uuid = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
 version = "1.10.0"
+
+[[deps.TextWrap]]
+git-tree-sha1 = "43044b737fa70bc12f6105061d3da38f881a3e3c"
+uuid = "b718987f-49a8-5099-9789-dcd902bef87d"
+version = "1.0.2"
 
 [[deps.UUIDs]]
 deps = ["Random", "SHA"]

--- a/tools/zygote/README.md
+++ b/tools/zygote/README.md
@@ -35,3 +35,5 @@ have been improved compared to the original implementations.
   of AD.
 
 - `ba` has been lightly micro-optimised, but but impact is not major.
+
+### Multithreading

--- a/tools/zygote/run_lse.jl
+++ b/tools/zygote/run_lse.jl
@@ -5,12 +5,12 @@ import GradBench
 
 struct GradientLSE <: GradBench.LSE.AbstractLSE end
 function (::GradientLSE)(input)
-    z, = Zygote.gradient(GradBench.LSE.logsumexp, input.x)
+    z, = Zygote.gradient(GradBench.LSE.Pure.logsumexp, input.x)
     return z
 end
 
 GradBench.register!("lse", Dict(
-    "primal" => GradBench.LSE.PrimalLSE(),
+    "primal" => GradBench.LSE.Pure.PrimalLSE(),
     "gradient" => GradientLSE()
 ))
 


### PR DESCRIPTION
Currently only `lse` is threaded.

I am somewhat dissatisfied with how the --multithreading argument is handled. It is not available until runtime, but ideally it would affect which structs are registered.