### PR TITLE
ci: migrate linting into scripts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,9 +17,13 @@ jobs:
         uses: actions/checkout@v4
       - name: Install clang-format 19
         run: sudo apt-get install -y clang-format-19
+      - name: Set clang-format-19 as clang-format
+        run:
+          sudo update-alternatives --install /usr/bin/clang-format clang-format
+          /usr/bin/clang-format-19 100
       - name: Check C/C++ formatting
         run: |
-          git ls-files '*.c' '*.cpp' '*.h' '*.hpp' | xargs clang-format-19 --dry-run -Werror
+          scripts/lint/cpp.sh
 
   check-js:
     runs-on: ubuntu-24.04
@@ -38,9 +42,9 @@ jobs:
           git diff
           [ -z "$CHANGES" ]
       - name: Check Prettier formatting
-        run: bun run prettier --check .
+        run: scripts/lint/prettier.sh
       - name: Run TypeScript
-        run: bun run --filter='*' typecheck
+        run: scripts/lint/typescript.sh
 
   check-py:
     runs-on: ubuntu-24.04
@@ -51,10 +55,8 @@ jobs:
         uses: actions/setup-python@v5
       - name: Install uv
         uses: astral-sh/setup-uv@v5
-      - name: Lint Python code
-        run: uv run ruff check
       - name: Check Python formatting
-        run: uv run ruff format --check
+        run: scripts/lint/python.sh
 
   check-rs:
     runs-on: ubuntu-24.04
@@ -62,7 +64,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Lint Rust code
-        run: cargo clippy -- -Dwarnings
+        run: scripts/lint/rust.sh
       - name: Test Rust code
         run: cargo test
 
@@ -76,7 +78,7 @@ jobs:
       - name: Install npm dependencies
         run: bun install
       - name: Lint website
-        run: bun run --filter=@gradbench/website lint
+        run: scripts/lint/website.sh
       - name: Build website
         run: bun run --filter=@gradbench/website build
       - name: Upload website artifact

--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -1,0 +1,24 @@
+#!/bin/sh
+#
+# Pre-commit hook for quality-checking the commit. Currently checks all files,
+# not just the ones touched by the commit. You can also run this script
+# directly.
+#
+# Install this hook by:
+#
+# $ ln -s ../../scripts/hooks/pre-commit .git/hooks/pre-commit
+
+fail() {
+    echo "Aborting commit due to verification errors."
+    echo "If you disagree, use git commit --no-verify."
+    exit 1
+}
+
+echo Quality-checking commit...
+echo
+
+for l in scripts/lint/*.sh; do
+  echo $l
+  sh $l || exit 1
+done
+

--- a/scripts/lint/README.md
+++ b/scripts/lint/README.md
@@ -1,0 +1,4 @@
+# Linting
+
+This directory contains the various scripts for linting that are used by CI and
+Git hooks. They all expect to be run from the repository root.

--- a/scripts/lint/cpp.sh
+++ b/scripts/lint/cpp.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+git ls-files '*.c' '*.cpp' '*.h' '*.hpp' | xargs clang-format --dry-run -Werror

--- a/scripts/lint/prettier.sh
+++ b/scripts/lint/prettier.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+bun run prettier --check .

--- a/scripts/lint/python.sh
+++ b/scripts/lint/python.sh
@@ -1,0 +1,2 @@
+uv run ruff check
+uv run ruff format --check

--- a/scripts/lint/rust.sh
+++ b/scripts/lint/rust.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+cargo clippy -- -Dwarnings

--- a/scripts/lint/typescript.sh
+++ b/scripts/lint/typescript.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+bun run --filter='*' typecheck

--- a/scripts/lint/website.sh
+++ b/scripts/lint/website.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+bun run --filter=@gradbench/website lint


### PR DESCRIPTION
This makes it easier to run the various linters outside of CI. In particular, I have added a pre-commit hook that does so.