### PR TITLE
adept: update to 2.1.3

### DIFF
--- a/tools/adept/Dockerfile
+++ b/tools/adept/Dockerfile
@@ -2,17 +2,12 @@ FROM python:3.11-slim
 WORKDIR /gradbench
 
 # Install build dependencies.
-RUN apt-get update && apt-get install -y automake build-essential wget
+RUN apt-get update && apt-get install -y automake libtool build-essential wget
 
 # Download and compile Adept.
-#
-# We copy in new versions of config.guess and config.sub because the
-# versions in the tarball are obsolete and do not recognise
-# new-fangled architectures such as ARM.
-RUN wget http://www.met.reading.ac.uk/clouds/adept/adept-2.1.1.tar.gz
-RUN tar xvf adept-2.1.1.tar.gz
-RUN cp /usr/share/misc/config.guess /usr/share/misc/config.sub adept-2.1.1
-RUN cd adept-2.1.1 && ./configure && make && make install
+RUN wget https://github.com/rjhogan/Adept-2/archive/refs/tags/v2.1.3.tar.gz
+RUN tar xvf v2.1.3.tar.gz
+RUN cd Adept-2-2.1.3 && autoreconf -i && ./configure && make && make install
 ENV LIBRARY_PATH=/usr/local/lib
 ENV LD_LIBRARY_PATH=/usr/local/lib
 


### PR DESCRIPTION
The important change here is actually that we download the tarball from GitHub, where Robin Hogan has now made it available:
https://github.com/rjhogan/Adept-2/issues/35

Hopefully that should make the Adept build more robust.

Fixes #580.