### PR TITLE
Pass `--all-targets` to Clippy

### DIFF
--- a/crates/gradbench/src/lint.rs
+++ b/crates/gradbench/src/lint.rs
@@ -168,7 +168,7 @@ pub fn clang_format(cfg: &mut Config) -> anyhow::Result<bool> {
 pub fn clippy(cfg: &mut Config) -> anyhow::Result<bool> {
     cfg.name("Clippy");
     let mut cmd = Command::new("cargo");
-    cmd.args(["clippy", "--", "-Dwarnings"]);
+    cmd.args(["clippy", "--all-targets", "--", "-Dwarnings"]);
     // Ideally we'd optionally add the `--fix` flag, but for some reason that seems to cause
     // `-Dwarnings` to be ignored.
     Ok(cmd.status()?.success())


### PR DESCRIPTION
Previously Clippy was ignoring `#[cfg(test)]` code.