### PR TITLE
Allow multiple eval/tool pairs in a single CI job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -186,37 +186,18 @@ jobs:
         uses: ./.github/actions/space
       - name: Install CLI from artifact
         uses: ./.github/actions/cli
-      - name: Download eval Docker image from artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: eval-${{ matrix.eval }}
-      - name: Download tool Docker image from artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: x86-tool-${{ matrix.tool }}
-      - name: Load eval Docker image
-        run: docker load --input eval-${{ matrix.eval }}.tar
-      - name: Load tool Docker image
-        run: docker load --input tool-${{ matrix.tool }}.tar
-      - name: Run tool on eval
+      - name: Run
         id: run
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          set +e
-          gradbench exit-code ${{ matrix.outcome }}
-          expected=$?
-          gradbench run --eval "gradbench eval ${{ matrix.eval }}" --tool "gradbench tool ${{ matrix.tool }}" --output log.jsonl --timeout 600
-          actual=$?
-          set -e
-          if [ $actual -ne $expected ]; then
-            echo "expected exit code $expected (from outcome ${{ matrix.outcome }}) but got exit code $actual"
-            exit 1
-          fi
-      - name: Upload log as artifact
+          gradbench repo run --download-github ${{ github.run_id }} -o run --timeout 600 ${{ matrix.args }}
+      - name: Upload logs as artifact
         if: success() || steps.run.conclusion == 'failure'
         uses: actions/upload-artifact@v4
         with:
-          name: run-${{ matrix.eval }}-${{ matrix.tool }}
-          path: log.jsonl
+          name: run-${{ matrix.artifact }}
+          path: run
 
   stats:
     needs:
@@ -232,7 +213,8 @@ jobs:
       - name: Download all log artifacts
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh run download ${{ github.run_id }} --dir run --pattern 'run-*'
+        run: |
+          gh run download ${{ github.run_id }} --dir artifacts --pattern 'run-*'
       - name: Checkout stats branch
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -215,6 +215,8 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh run download ${{ github.run_id }} --dir artifacts --pattern 'run-*'
+      - name: Flatten log directory structure
+        run: gradbench repo flatten artifacts -o run
       - name: Checkout stats branch
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -216,7 +216,7 @@ jobs:
         run: |
           gh run download ${{ github.run_id }} --dir artifacts --pattern 'run-*'
       - name: Flatten log directory structure
-        run: gradbench repo flatten artifacts -o run
+        run: gradbench log flatten artifacts -o run
       - name: Checkout stats branch
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -191,7 +191,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gradbench repo run --download-github ${{ github.run_id }} -o run --timeout 600 ${{ matrix.args }}
+          gradbench repo run --download-github ${{ github.run_id }} --check -o run --timeout 600 ${{ matrix.args }}
       - name: Upload logs as artifact
         if: success() || steps.run.conclusion == 'failure'
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -141,7 +141,7 @@ jobs:
           name: eval-${{ matrix.eval }}
           path: eval-${{ matrix.eval }}.tar
 
-  x86-tool:
+  tool-x86:
     needs:
       - cli
       - matrix
@@ -165,7 +165,7 @@ jobs:
       - name: Upload tool Docker image as artifact
         uses: actions/upload-artifact@v4
         with:
-          name: x86-tool-${{ matrix.tool }}
+          name: tool-${{ matrix.tool }}
           path: tool-${{ matrix.tool }}.tar
 
   run:
@@ -173,7 +173,7 @@ jobs:
       - cli
       - matrix
       - eval
-      - x86-tool
+      - tool-x86
     strategy:
       fail-fast: false
       matrix:
@@ -285,14 +285,3 @@ jobs:
         if: ${{ matrix.cross }}
         run: |
           gradbench repo build-tool --platform linux/amd64,linux/arm64 ${{ matrix.tool }}
-          docker save --output tool-${{ matrix.tool }}.tar ghcr.io/gradbench/tool-${{ matrix.tool }}
-      - name: Download x86-only Docker image as a fallback
-        if: ${{ !matrix.cross }}
-        uses: actions/download-artifact@v4
-        with:
-          name: x86-tool-${{ matrix.tool }}
-      - name: Upload tool Docker image as artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: tool-${{ matrix.tool }}
-          path: tool-${{ matrix.tool }}.tar

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -180,7 +180,7 @@ jobs:
         run: |
           gh run download ${{ github.run_id }} --dir artifacts --pattern 'run-*'
       - name: Flatten log directory structure
-        run: gradbench repo flatten artifacts -o run
+        run: gradbench log flatten artifacts -o run
       - name: Checkout nightly stats branch
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -155,7 +155,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gradbench repo run --download-github ${{ github.run_id }} -o run --timeout 600 ${{ matrix.args }}
+          gradbench repo run --download-github ${{ github.run_id }} --check -o run --timeout 600 ${{ matrix.args }}
       - name: Upload log as artifact
         if: success() || steps.run.conclusion == 'failure'
         uses: actions/upload-artifact@v4

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -150,27 +150,18 @@ jobs:
         uses: ./.github/actions/space
       - name: Install CLI from artifact
         uses: ./.github/actions/cli
-      - name: Download eval Docker image from artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: eval-${{ matrix.eval }}
-      - name: Download tool Docker image from artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: tool-${{ matrix.tool }}
-      - name: Load eval Docker image
-        run: docker load --input eval-${{ matrix.eval }}.tar
-      - name: Load tool Docker image
-        run: docker load --input tool-${{ matrix.tool }}.tar
-      - name: Run tool on eval
-        continue-on-error: true
+      - name: Run
+        id: run
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gradbench run --eval "gradbench eval ${{ matrix.eval }}" --tool "gradbench tool ${{ matrix.tool }}" --output log.jsonl --timeout 600
+          gradbench repo run --download-github ${{ github.run_id }} -o run --timeout 600 ${{ matrix.args }}
       - name: Upload log as artifact
+        if: success() || steps.run.conclusion == 'failure'
         uses: actions/upload-artifact@v4
         with:
-          name: run-${{ matrix.eval }}-${{ matrix.tool }}
-          path: log.jsonl
+          name: run-${{ matrix.artifact }}
+          path: run
 
   stats:
     needs:
@@ -186,7 +177,8 @@ jobs:
       - name: Download all log artifacts
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh run download ${{ github.run_id }} --dir run --pattern 'run-*'
+        run: |
+          gh run download ${{ github.run_id }} --dir artifacts --pattern 'run-*'
       - name: Checkout nightly stats branch
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -179,6 +179,8 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh run download ${{ github.run_id }} --dir artifacts --pattern 'run-*'
+      - name: Flatten log directory structure
+        run: gradbench repo flatten artifacts -o run
       - name: Checkout nightly stats branch
         uses: actions/checkout@v4
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@
 *~
 
 # GradBench
-/log.jsonl
+/artifacts/
 /run/
 /stats/
 

--- a/crates/gradbench/src/main.rs
+++ b/crates/gradbench/src/main.rs
@@ -1153,17 +1153,17 @@ struct ToolEntry<'a> {
 /// A single entry in the `run` matrix for GitHub Actions.
 #[derive(Serialize)]
 struct RunEntry {
-    /// The name of the GitHub Actions artifact to produce.
-    artifact: String,
-
     /// CLI args to pass to the `repo run` subcommand.
     args: String,
+
+    /// The name of the GitHub Actions artifact to produce.
+    artifact: String,
 }
 
 impl RunEntry {
     fn new(args: String) -> Self {
         let artifact = mangle(&args);
-        Self { artifact, args }
+        Self { args, artifact }
     }
 }
 

--- a/crates/gradbench/src/main.rs
+++ b/crates/gradbench/src/main.rs
@@ -337,28 +337,36 @@ enum RepoCommands {
 enum LogCommands {
     /// Remove input/output fields from "evaluate" messages and responses.
     ///
-    /// Writes to stdout unless the `--output` option is used. It is
-    /// expected that the input log file is well-formed, but not that
-    /// it corresponds to a successful run. In particular, the final
-    /// message may not have a response - this occurs when the tool
-    /// crashes or times out before it gets to respond.
+    /// Writes to stdout unless the `--output` option is used. It is expected that the input log
+    /// file is well-formed, but not that it corresponds to a successful run. In particular, the
+    /// final message may not have a response - this occurs when the tool crashes or times out
+    /// before it gets to respond.
     Trim {
-        /// The input log file.
+        /// The input log file
         input: Option<PathBuf>,
 
-        /// The output log file.
+        /// The output log file
         #[clap(short, long)]
         output: Option<PathBuf>,
     },
 
-    /// Print a human-readable summary of the log file, including the
-    /// eval, tool, configuration, etc.
+    /// Print a human-readable summary of the log file, including the eval, tool, configuration,
+    /// etc.
     ///
-    /// Will fail with a not necessarily very friendly error if the
-    /// log file is malformed.
+    /// Will fail with a not necessarily very friendly error if the log file is malformed.
     Summary {
-        /// The input log file.
+        /// The input log file
         input: Option<PathBuf>,
+    },
+
+    /// Move log files from a directory with three layers of nesting to a directory with only two.
+    Flatten {
+        /// The input directory
+        input: PathBuf,
+
+        /// The output directory
+        #[clap(short, long)]
+        output: PathBuf,
     },
 }
 
@@ -1210,6 +1218,7 @@ fn log_command(command: LogCommands) -> anyhow::Result<()> {
             run_in_out(log::Trim, input.as_deref(), output.as_deref())
         }
         LogCommands::Summary { input } => run_in_out(log::Summary, input.as_deref(), None),
+        LogCommands::Flatten { input, output } => log::flatten(&input, &output),
     }
 }
 

--- a/crates/gradbench/src/main.rs
+++ b/crates/gradbench/src/main.rs
@@ -313,8 +313,8 @@ enum RepoCommands {
 
     /// Generate summary data files and plots from a directory containing log files.
     ///
-    /// The directory should contain a `run-<EVAL>-<TOOL>/log.jsonl` file for each `<EVAL>` under
-    /// `evals` and each `<TOOL>` under `tools`.
+    /// The directory should contain a `<EVAL>/<TOOL>.jsonl` file for each `<EVAL>` under `evals`
+    /// and each `<TOOL>` under `tools`.
     Stats {
         /// The directory containing log files
         input: PathBuf,

--- a/crates/gradbench/src/outputs/dry_run_download_github.sh
+++ b/crates/gradbench/src/outputs/dry_run_download_github.sh
@@ -1,0 +1,12 @@
+gh run download 15035419296 --name eval-norf --name eval-qux --name tool-bar --name tool-baz --name tool-foo
+docker load --input eval-norf/eval-norf.tar
+docker load --input eval-qux/eval-qux.tar
+docker load --input tool-bar/tool-bar.tar
+docker load --input tool-baz/tool-baz.tar
+docker load --input tool-foo/tool-foo.tar
+gradbench run --eval 'docker run --rm --interactive ghcr.io/gradbench/eval-norf:latest' --tool 'docker run --rm --interactive ghcr.io/gradbench/tool-bar:latest'
+gradbench run --eval 'docker run --rm --interactive ghcr.io/gradbench/eval-norf:latest' --tool 'docker run --rm --interactive ghcr.io/gradbench/tool-baz:latest'
+gradbench run --eval 'docker run --rm --interactive ghcr.io/gradbench/eval-norf:latest' --tool 'docker run --rm --interactive ghcr.io/gradbench/tool-foo:latest'
+gradbench run --eval 'docker run --rm --interactive ghcr.io/gradbench/eval-qux:latest' --tool 'docker run --rm --interactive ghcr.io/gradbench/tool-bar:latest'
+gradbench run --eval 'docker run --rm --interactive ghcr.io/gradbench/eval-qux:latest' --tool 'docker run --rm --interactive ghcr.io/gradbench/tool-baz:latest'
+gradbench run --eval 'docker run --rm --interactive ghcr.io/gradbench/eval-qux:latest' --tool 'docker run --rm --interactive ghcr.io/gradbench/tool-foo:latest'

--- a/crates/gradbench/src/stats.rs
+++ b/crates/gradbench/src/stats.rs
@@ -427,7 +427,7 @@ pub fn generate(input: PathBuf, output: PathBuf, metadata: StatsMetadata) -> any
             let (outcome, score) = match supported.get(tool.as_str()) {
                 None => (Some(BadOutcome::Undefined), None),
                 Some(&outcome) => {
-                    let path = input.join(format!("run-{eval}-{tool}/log.jsonl"));
+                    let path = input.join(format!("{eval}/{tool}.jsonl"));
                     println!("  {}", path.display());
                     let reader = io::BufReader::new(fs::File::open(&path)?);
                     // Always run the `score` method, to gather fine-grained data.

--- a/crates/gradbench/src/stats.rs
+++ b/crates/gradbench/src/stats.rs
@@ -415,25 +415,27 @@ pub fn generate(input: PathBuf, output: PathBuf, metadata: StatsMetadata) -> any
     fs::create_dir_all(&output)?;
     let mut evals = ls("evals")?;
     evals.sort();
-    let mut tools = ls("tools")?;
-    tools.sort();
     let mut table = Vec::new();
     let map = evals_to_tools(evals)?;
     for (eval, supported) in &map {
         println!("{}", eval);
         let mut row = Vec::new();
         let mut scorer = scorer(eval);
-        for tool in &tools {
-            let (outcome, score) = match supported.get(tool.as_str()) {
-                None => (Some(BadOutcome::Undefined), None),
-                Some(&outcome) => {
+        for (tool, &outcome) in supported {
+            let score = match outcome {
+                Some(BadOutcome::Undefined) => None,
+                _ => {
                     let path = input.join(format!("{eval}/{tool}.jsonl"));
                     println!("  {}", path.display());
                     let reader = io::BufReader::new(fs::File::open(&path)?);
                     // Always run the `score` method, to gather fine-grained data.
                     let score = scorer.score(tool, reader)?;
                     // Only give the tool an overall score if it successfully completed the eval.
-                    (outcome, if outcome.is_none() { Some(score) } else { None })
+                    if outcome.is_none() {
+                        Some(score)
+                    } else {
+                        None
+                    }
                 }
             };
             row.push(Col {

--- a/crates/gradbench/src/util.rs
+++ b/crates/gradbench/src/util.rs
@@ -88,6 +88,10 @@ pub fn stringify_cmd(cmd: &Command) -> anyhow::Result<Vec<&str>> {
         .collect()
 }
 
+pub fn shlex_cmd(cmd: &Command) -> anyhow::Result<String> {
+    Ok(shlex::try_join(stringify_cmd(cmd)?)?)
+}
+
 type CtrlCHandlers = HashMap<usize, Box<dyn FnOnce() + Send>>;
 
 pub struct CtrlC {


### PR DESCRIPTION
Resolves #365, resolves #577.

This PR adds flags `--download-github` and `--check` to the `repo run` subcommand so that we can use it in CI to run multiple pairs in a single job, and modifies the `matrix` and `stats` jobs to accommodate this change.