### PR TITLE
Write intermediary test inputs as `*.jsonl`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -288,11 +288,11 @@ protocol, as captured and reported by the intermediary:
 { "elapsed": { "nanoseconds": 200000 }, "message": { "id": 1, "kind": "define", "module": "foo" } }
 { "elapsed": { "nanoseconds": 250000 }, "response": { "id": 1, "success": true } }
 { "elapsed": { "nanoseconds": 300000 }, "message": { "id": 2, "kind": "evaluate", "module": "foo", "function": "bar", "input": 3.14159 } }
-{ "elapsed": { "nanoseconds": 350000 }, "response": { "id": 2, "success": true, "output": 2.71828, "timings": [{ "name": "evaluate", "nanoseconds": 45678 }] } }
-{ "elapsed": { "nanoseconds": 400000 }, "message": { "id": 3, "kind": "analysis", "of": 2, "valid": false, "message": "Expected tau, got e." } }
+{ "elapsed": { "nanoseconds": 350000 }, "response": { "id": 2, "success": true, "output": 2.71828, "timings": [{ "name": "evaluate", "nanoseconds": 5000000 }] } }
+{ "elapsed": { "nanoseconds": 400000 }, "message": { "id": 3, "kind": "analysis", "of": 2, "valid": false, "error": "Expected tau, got e." } }
 { "elapsed": { "nanoseconds": 450000 }, "response": { "id": 3 } }
 { "elapsed": { "nanoseconds": 500000 }, "message": { "id": 4, "kind": "evaluate", "module": "foo", "function": "baz", "input": { "mynumber": 121 } } }
-{ "elapsed": { "nanoseconds": 550000 }, "response": { "id": 4, "success": true, "output": { "yournumber": 342 }, "timings": [{ "name": "evaluate", "nanoseconds": 23456 }] } }
+{ "elapsed": { "nanoseconds": 550000 }, "response": { "id": 4, "success": true, "output": { "yournumber": 342 }, "timings": [{ "name": "evaluate", "nanoseconds": 7000000 }] } }
 { "elapsed": { "nanoseconds": 600000 }, "message": { "id": 5, "kind": "analysis", "of": 4, "valid": true } }
 { "elapsed": { "nanoseconds": 650000 }, "response": { "id": 5 } }
 ```
@@ -304,7 +304,7 @@ Here is that example from the perspectives of the eval and the tool.
   { "id": 0, "kind": "start" }
   { "id": 1, "kind": "define", "module": "foo" }
   { "id": 2, "kind": "evaluate", "module": "foo", "function": "bar", "input": 3.14159 }
-  { "id": 3, "kind": "analysis", "of": 2, "valid": false, "message": "Expected tau, got e." }
+  { "id": 3, "kind": "analysis", "of": 2, "valid": false, "error": "Expected tau, got e." }
   { "id": 4, "kind": "evaluate", "module": "foo", "function": "baz", "input": { "mynumber": 121 } }
   { "id": 5, "kind": "analysis", "of": 4, "valid": true }
   ```
@@ -312,9 +312,9 @@ Here is that example from the perspectives of the eval and the tool.
   ```jsonl
   { "id": 0 }
   { "id": 1, "success": true }
-  { "id": 2, "success": true, "output": 2.71828, "timings": [{ "name": "evaluate", "nanoseconds": 45678 }] }
+  { "id": 2, "success": true, "output": 2.71828, "timings": [{ "name": "evaluate", "nanoseconds": 5000000 }] }
   { "id": 3 }
-  { "id": 4, "success": true, "output": { "yournumber": 342 }, "timings": [{ "name": "evaluate", "nanoseconds": 23456 }] }
+  { "id": 4, "success": true, "output": { "yournumber": 342 }, "timings": [{ "name": "evaluate", "nanoseconds": 7000000 }] }
   { "id": 5 }
   ```
 

--- a/crates/gradbench/src/inputs/eval/contributing_md_example.jsonl
+++ b/crates/gradbench/src/inputs/eval/contributing_md_example.jsonl
@@ -1,0 +1,6 @@
+{ "id": 0, "kind": "start" }
+{ "id": 1, "kind": "define", "module": "foo" }
+{ "id": 2, "kind": "evaluate", "module": "foo", "function": "bar", "input": 3.14159 }
+{ "id": 3, "kind": "analysis", "of": 2, "valid": false, "error": "Expected tau, got e." }
+{ "id": 4, "kind": "evaluate", "module": "foo", "function": "baz", "input": { "mynumber": 121 } }
+{ "id": 5, "kind": "analysis", "of": 4, "valid": true }

--- a/crates/gradbench/src/inputs/eval/define_error.jsonl
+++ b/crates/gradbench/src/inputs/eval/define_error.jsonl
@@ -1,0 +1,2 @@
+{ "id": 0, "kind": "start" }
+{ "id": 1, "kind": "define", "module": "foo" }

--- a/crates/gradbench/src/inputs/eval/define_success_error.jsonl
+++ b/crates/gradbench/src/inputs/eval/define_success_error.jsonl
@@ -1,0 +1,2 @@
+{ "id": 0, "kind": "start" }
+{ "id": 1, "kind": "define", "module": "foo" }

--- a/crates/gradbench/src/inputs/eval/define_timings.jsonl
+++ b/crates/gradbench/src/inputs/eval/define_timings.jsonl
@@ -1,0 +1,2 @@
+{ "id": 0, "kind": "start" }
+{ "id": 1, "kind": "define", "module": "foo" }

--- a/crates/gradbench/src/inputs/eval/evaluate.jsonl
+++ b/crates/gradbench/src/inputs/eval/evaluate.jsonl
@@ -1,0 +1,3 @@
+{ "id": 0, "kind": "start" }
+{ "id": 1, "kind": "define", "module": "foo" }
+{ "id": 2, "kind": "evaluate", "module": "foo", "function": "bar", "input": 42 }

--- a/crates/gradbench/src/inputs/eval/evaluate_null_output.jsonl
+++ b/crates/gradbench/src/inputs/eval/evaluate_null_output.jsonl
@@ -1,0 +1,4 @@
+{ "id": 0, "kind": "start" }
+{ "id": 1, "kind": "define", "module": "foo" }
+{ "id": 2, "kind": "evaluate", "module": "foo", "function": "null", "input": null }
+{ "id": 3, "kind": "analysis", "of": 2, "valid": true }

--- a/crates/gradbench/src/inputs/eval/intermediary_timeout.jsonl
+++ b/crates/gradbench/src/inputs/eval/intermediary_timeout.jsonl
@@ -1,0 +1,3 @@
+{ "id": 0, "kind": "start" }
+{ "id": 1, "kind": "define", "module": "foo" }
+{ "id": 2, "kind": "evaluate", "module": "foo", "function": "bar", "input": null }

--- a/crates/gradbench/src/inputs/eval/start_names.jsonl
+++ b/crates/gradbench/src/inputs/eval/start_names.jsonl
@@ -1,0 +1,1 @@
+{ "id": 0, "kind": "start", "eval": "foo" }

--- a/crates/gradbench/src/inputs/tool/contributing_md_example.jsonl
+++ b/crates/gradbench/src/inputs/tool/contributing_md_example.jsonl
@@ -1,0 +1,6 @@
+{ "id": 0 }
+{ "id": 1, "success": true }
+{ "id": 2, "success": true, "output": 2.71828, "timings": [{ "name": "evaluate", "nanoseconds": 5000000 }] }
+{ "id": 3 }
+{ "id": 4, "success": true, "output": { "yournumber": 342 }, "timings": [{ "name": "evaluate", "nanoseconds": 7000000 }] }
+{ "id": 5 }

--- a/crates/gradbench/src/inputs/tool/define_error.jsonl
+++ b/crates/gradbench/src/inputs/tool/define_error.jsonl
@@ -1,0 +1,2 @@
+{ "id": 0 }
+{ "id": 1, "success": false, "error": "never heard of foo" }

--- a/crates/gradbench/src/inputs/tool/define_success_error.jsonl
+++ b/crates/gradbench/src/inputs/tool/define_success_error.jsonl
@@ -1,0 +1,2 @@
+{ "id": 0 }
+{ "id": 1, "success": true, "error": "all good!" }

--- a/crates/gradbench/src/inputs/tool/define_timings.jsonl
+++ b/crates/gradbench/src/inputs/tool/define_timings.jsonl
@@ -1,0 +1,2 @@
+{ "id": 0 }
+{ "id": 1, "success": true, "timings": [{ "name": "busywork", "nanoseconds": 10000000 }] }

--- a/crates/gradbench/src/inputs/tool/evaluate_error.jsonl
+++ b/crates/gradbench/src/inputs/tool/evaluate_error.jsonl
@@ -1,0 +1,3 @@
+{ "id": 0 }
+{ "id": 1, "success": true }
+{ "id": 2, "success": false, "error": "foobar failure" }

--- a/crates/gradbench/src/inputs/tool/evaluate_failure_no_error.jsonl
+++ b/crates/gradbench/src/inputs/tool/evaluate_failure_no_error.jsonl
@@ -1,0 +1,3 @@
+{ "id": 0 }
+{ "id": 1, "success": true }
+{ "id": 2, "success": false }

--- a/crates/gradbench/src/inputs/tool/evaluate_null_output.jsonl
+++ b/crates/gradbench/src/inputs/tool/evaluate_null_output.jsonl
@@ -1,0 +1,4 @@
+{ "id": 0 }
+{ "id": 1, "success": true }
+{ "id": 2, "success": true, "output": null }
+{ "id": 3 }

--- a/crates/gradbench/src/inputs/tool/evaluate_success_error.jsonl
+++ b/crates/gradbench/src/inputs/tool/evaluate_success_error.jsonl
@@ -1,0 +1,3 @@
+{ "id": 0 }
+{ "id": 1, "success": true }
+{ "id": 2, "success": true, "output": "done!", "error": "foobar all good" }

--- a/crates/gradbench/src/inputs/tool/evaluate_success_no_output.jsonl
+++ b/crates/gradbench/src/inputs/tool/evaluate_success_no_output.jsonl
@@ -1,0 +1,3 @@
+{ "id": 0 }
+{ "id": 1, "success": true }
+{ "id": 2, "success": true }

--- a/crates/gradbench/src/inputs/tool/intermediary_timeout.jsonl
+++ b/crates/gradbench/src/inputs/tool/intermediary_timeout.jsonl
@@ -1,0 +1,2 @@
+{ "id": 0 }
+{ "id": 1, "success": true }

--- a/crates/gradbench/src/inputs/tool/start_names.jsonl
+++ b/crates/gradbench/src/inputs/tool/start_names.jsonl
@@ -1,0 +1,1 @@
+{ "id": 0, "kind": "start", "tool": "bar" }

--- a/crates/gradbench/src/outputs/contributing_md_example.txt
+++ b/crates/gradbench/src/outputs/contributing_md_example.txt
@@ -1,5 +1,5 @@
   [0] start
   [1] def   foo                                     4ms ✓
-  [2] eval  foo::bar        3.1415926535...         6ms ~         5ms evaluate ✗
+  [2] eval  foo::bar        3.14159                 6ms ~         5ms evaluate ✗
 Expected tau, got e.
   [4] eval  foo::baz        {"mynumber":...        10ms ~         7ms evaluate ✓


### PR DESCRIPTION
This PR greatly reduces the amount of code needed to write the tests for the intermediary.