### PR TITLE
Don't skip validation for `"output": null`

### DIFF
--- a/python/gradbench/gradbench/eval.py
+++ b/python/gradbench/gradbench/eval.py
@@ -135,9 +135,8 @@ class SingleModuleValidatedEval:
             message["description"] = description
         id = self.id
         response = EvaluateResponse.model_validate(self.send(message))
-        output = response.output
-        if output is not None:
-            analysis = self.validator(function, input, output)
+        if response.success:
+            analysis = self.validator(function, input, response.output)
             self.analysis(of=id, valid=analysis.valid, error=analysis.error)
         return response
 


### PR DESCRIPTION
This fixes a bug leftover from #213, in which evals would simply not run the validator at all if the tool returned `"output": null`. I ran into this while working on #568, since I set the TensorFlow `jacobian` function to just `return None` while I was working on the `objective`, and I was surprised to see that that caused everything to just pass.