### PR TITLE
Implement GMM objective function in Rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,6 +83,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b964d184e89d9b6b67dd2715bc8e74cf3107fb2b529990c90cf517326150bf4"
 
 [[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -110,6 +119,12 @@ name = "bumpalo"
 version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+
+[[package]]
+name = "bytemuck"
+version = "1.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9134a6ef01ce4b366b50689c94f82c14bc72bc5d0386829828a2e2752ef7958c"
 
 [[package]]
 name = "cc"
@@ -271,13 +286,24 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "getrandom"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.13.3+wasi-0.2.2",
  "windows-targets",
 ]
 
@@ -323,6 +349,7 @@ version = "0.0.0"
 dependencies = [
  "serde",
  "serde_json",
+ "statrs",
 ]
 
 [[package]]
@@ -409,6 +436,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "875b3680cb2f8f71bdcf9a30f38d48282f5d3c95cbf9b3fa57269bb5d5c06828"
 
 [[package]]
+name = "libm"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -421,10 +454,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
 
 [[package]]
+name = "matrixmultiply"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
+dependencies = [
+ "autocfg",
+ "rawpointer",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "nalgebra"
+version = "0.33.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26aecdf64b707efd1310e3544d709c5c0ac61c13756046aaaba41be5c4f66a3b"
+dependencies = [
+ "approx",
+ "matrixmultiply",
+ "num-complex",
+ "num-rational",
+ "num-traits",
+ "rand",
+ "rand_distr",
+ "simba",
+ "typenum",
+]
 
 [[package]]
 name = "nix"
@@ -439,12 +499,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -452,6 +552,21 @@ name = "once_cell"
 version = "1.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "pretty_assertions"
@@ -480,6 +595,52 @@ checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.16",
+]
+
+[[package]]
+name = "rand_distr"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
+dependencies = [
+ "num-traits",
+ "rand",
+]
+
+[[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "regex"
@@ -536,6 +697,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
 
 [[package]]
+name = "safe_arch"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -580,6 +750,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "simba"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3a386a501cd104797982c15ae17aafe8b9261315b5d07e3ec803f2ea26be0fa"
+dependencies = [
+ "approx",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "wide",
+]
+
+[[package]]
 name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -597,6 +780,18 @@ checksum = "b5b441962c817e33508847a22bd82f03a30cff43642dc2fae8b050566121eb9a"
 dependencies = [
  "console",
  "similar",
+]
+
+[[package]]
+name = "statrs"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a3fe7c28c6512e766b0874335db33c94ad7b8f9054228ae1c2abd47ce7d335e"
+dependencies = [
+ "approx",
+ "nalgebra",
+ "num-traits",
+ "rand",
 ]
 
 [[package]]
@@ -646,7 +841,7 @@ checksum = "22e5a0acb1f3f55f65cc4a866c361b2fb2a0ff6366785ae6fbb5f85df07ba230"
 dependencies = [
  "cfg-if",
  "fastrand",
- "getrandom",
+ "getrandom 0.3.1",
  "once_cell",
  "rustix",
  "windows-sys",
@@ -660,6 +855,12 @@ checksum = "7f99014ef5f7ad8fb986e0885b612ac6bd74a87c8df9816c27de5dcc49029646"
 dependencies = [
  "nix",
 ]
+
+[[package]]
+name = "typenum"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
 name = "unicode-ident"
@@ -678,6 +879,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasi"
@@ -744,6 +951,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wide"
+version = "0.7.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41b5576b9a81633f3e8df296ce0063042a73507636cbe956c61133dd7034ab22"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
 ]
 
 [[package]]
@@ -848,3 +1065,23 @@ name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
+
+[[package]]
+name = "zerocopy"
+version = "0.8.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -318,6 +318,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "gradbench-rust"
+version = "0.0.0"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/crates/gradbench-rust/Cargo.toml
+++ b/crates/gradbench-rust/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "gradbench-rust"
+version = "0.0.0"
+publish = false
+edition = "2021"
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/crates/gradbench-rust/Cargo.toml
+++ b/crates/gradbench-rust/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2021"
 [dependencies]
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+statrs = "0.18"

--- a/crates/gradbench-rust/src/main.rs
+++ b/crates/gradbench-rust/src/main.rs
@@ -253,13 +253,13 @@ fn logsumexp(x: &[f64]) -> f64 {
     a + sum.ln()
 }
 
-fn quadratic_form_element(mu: &[f64], r: &[f64], l: &[f64], x: &[f64], i: usize) -> f64 {
+fn quadratic_form_element(r: &[f64], l: &[f64], y: &[f64], i: usize) -> f64 {
     let k = (i * (i - 1)) / 2;
     let mut e = 0.;
     for j in 0..i {
-        e += l[k + j] * (x[j] - mu[j]);
+        e += l[k + j] * y[j];
     }
-    e + r[i] * (x[i] - mu[i])
+    e + r[i] * y[i]
 }
 
 fn gmm(
@@ -284,16 +284,20 @@ fn gmm(
     let mut log_likelihood =
         -(N as f64) * (((D as f64) / 2.0) * (2.0 * PI).ln() + logsumexp(alpha));
     for i in 0..N {
-        let x_i = x.row(i);
         let mut beta = vec![0.; K];
         for k in 0..K {
-            let mu_k = mu.row(k);
             let r_k = r.row(k);
             let l_k = l.row(k);
+            let y: Vec<f64> = x
+                .row(i)
+                .iter()
+                .zip(mu.row(k))
+                .map(|(x_ij, mu_kj)| x_ij - mu_kj)
+                .collect();
             let mut normsq = 0.;
             let mut sum = 0.;
             for j in 0..D {
-                let e = quadratic_form_element(mu_k, r_k, l_k, x_i, j);
+                let e = quadratic_form_element(r_k, l_k, &y, j);
                 normsq += e * e;
                 sum += q[(k, j)];
             }

--- a/crates/gradbench-rust/src/main.rs
+++ b/crates/gradbench-rust/src/main.rs
@@ -1,0 +1,309 @@
+mod matrix;
+
+use std::{
+    collections::HashMap,
+    f64::consts::PI,
+    io,
+    time::{Duration, Instant},
+};
+
+use matrix::Matrix;
+use serde::{Deserialize, Serialize};
+
+type Id = i64;
+
+#[derive(Deserialize)]
+struct Message {
+    id: Id,
+    kind: String,
+    module: Option<String>,
+}
+
+#[derive(Serialize)]
+struct Response {
+    id: Id,
+}
+
+#[derive(Serialize)]
+struct Timing {
+    name: &'static str,
+    nanoseconds: u128,
+}
+
+#[derive(Serialize)]
+struct DefineResponse {
+    id: Id,
+    success: bool,
+}
+
+#[derive(Serialize)]
+struct EvaluateResponse<'a, T> {
+    id: Id,
+    success: bool,
+    output: T,
+    timings: &'a [Timing],
+}
+
+fn print_jsonl(value: &impl Serialize) {
+    serde_json::to_writer(&mut io::stdout(), value).unwrap();
+    println!();
+}
+
+fn start(line: &str) {
+    let Message { kind, id, .. } = serde_json::from_str(line).unwrap();
+    assert_eq!(kind, "start");
+    print_jsonl(&Response { id });
+}
+
+fn respond<T: Serialize>(id: Id, output: T, durations: &[Duration]) {
+    let timings: Vec<Timing> = durations
+        .iter()
+        .map(|duration| Timing {
+            name: "evaluate",
+            nanoseconds: duration.as_nanos(),
+        })
+        .collect();
+    print_jsonl(&EvaluateResponse {
+        id,
+        success: true,
+        output,
+        timings: &timings,
+    });
+}
+
+struct Context {}
+
+trait GradBenchModule {
+    fn evaluate(&self, context: &mut Context, id: Id, line: &str);
+}
+
+fn main() {
+    let mut context = Context {};
+    let mut modules = HashMap::<String, Box<dyn GradBenchModule>>::new();
+    let mut lines = io::stdin().lines();
+    start(&lines.next().unwrap().unwrap());
+    for result in lines {
+        let line = result.unwrap();
+        let message: Message = serde_json::from_str(&line).unwrap();
+        let id = message.id;
+        match message.kind.as_str() {
+            "define" => {
+                let module = message.module.unwrap();
+                let mut defining = Defining::new();
+                let success = defining
+                    .module(&module)
+                    .map(|defined| modules.insert(module, defined))
+                    .is_some();
+                print_jsonl(&DefineResponse { id, success });
+            }
+            "evaluate" => modules[&message.module.unwrap()].evaluate(&mut context, id, &line),
+            _ => print_jsonl(&Response { id }),
+        }
+    }
+}
+
+struct Defining {}
+
+impl Defining {
+    fn new() -> Self {
+        Self {}
+    }
+
+    fn module(&mut self, name: &str) -> Option<Box<dyn GradBenchModule>> {
+        match name {
+            "hello" => Some(Box::new(Hello {})),
+            "gmm" => Some(Box::new(Gmm {})),
+            _ => None,
+        }
+    }
+}
+
+struct Hello {}
+
+#[derive(Deserialize)]
+#[serde(tag = "function", rename_all = "snake_case")]
+enum HelloMessage {
+    Square { input: f64 },
+    Double { input: f64 },
+}
+
+impl GradBenchModule for Hello {
+    fn evaluate(&self, _: &mut Context, id: Id, line: &str) {
+        match serde_json::from_str::<HelloMessage>(line).unwrap() {
+            HelloMessage::Square { input } => {
+                let start = Instant::now();
+                let output = input * input;
+                respond(id, output, &[start.elapsed()]);
+            }
+            HelloMessage::Double { input } => {
+                let start = Instant::now();
+                let output = input + input;
+                respond(id, output, &[start.elapsed()]);
+            }
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct GmmInput {
+    min_runs: usize,
+    min_seconds: u64,
+    d: usize,
+    k: usize,
+    n: usize,
+    x: Matrix,
+    m: usize,
+    gamma: f64,
+    alpha: Vec<f64>,
+    mu: Matrix,
+    q: Matrix,
+    l: Matrix,
+}
+
+struct Gmm {}
+
+#[derive(Deserialize)]
+#[serde(tag = "function", rename_all = "snake_case")]
+enum GmmMessage {
+    Objective { input: GmmInput },
+    Jacobian { input: GmmInput },
+}
+
+impl GradBenchModule for Gmm {
+    fn evaluate(&self, _: &mut Context, id: Id, line: &str) {
+        match serde_json::from_str::<GmmMessage>(line).unwrap() {
+            GmmMessage::Objective {
+                input:
+                    GmmInput {
+                        min_runs,
+                        min_seconds,
+                        d,
+                        k,
+                        n,
+                        x,
+                        m,
+                        gamma,
+                        alpha,
+                        mu,
+                        q,
+                        l,
+                    },
+            } => {
+                let mut total = Duration::ZERO;
+                let mut durations = Vec::new();
+                loop {
+                    let start = Instant::now();
+                    let output = gmm(d, k, n, &x, m, gamma, &alpha, &mu, &q, &l);
+                    let duration = start.elapsed();
+                    total += duration;
+                    durations.push(duration);
+                    if durations.len() >= min_runs && total >= Duration::from_secs(min_seconds) {
+                        respond(id, output, &durations);
+                        return;
+                    }
+                }
+            }
+            GmmMessage::Jacobian { .. } => {
+                let start = Instant::now();
+                let output = ();
+                respond(id, output, &[start.elapsed()]);
+            }
+        }
+    }
+}
+
+fn multigammaln(p: usize, a: f64) -> f64 {
+    1.5963125911388552 // TODO
+}
+
+fn maximum(x: &[f64]) -> f64 {
+    let mut max = f64::NEG_INFINITY;
+    for &xi in x {
+        if xi > max {
+            max = xi;
+        }
+    }
+    max
+}
+
+fn logsumexp(x: &[f64]) -> f64 {
+    let mut sum = 0.;
+    let a = maximum(x);
+    for &xi in x {
+        sum += (xi - a).exp();
+    }
+    a + sum.ln()
+}
+
+fn quadratic_form_element(mu: &[f64], r: &[f64], l: &[f64], x: &[f64], i: usize) -> f64 {
+    let k = (i * (i - 1)) / 2;
+    let mut e = 0.;
+    for j in 0..i {
+        e += l[k + j] * (x[j] - mu[j]);
+    }
+    e + r[i] * (x[i] - mu[i])
+}
+
+fn gmm(
+    D: usize,
+    K: usize,
+    N: usize,
+    x: &Matrix,
+    m: usize,
+    gamma: f64,
+    alpha: &[f64],
+    mu: &Matrix,
+    q: &Matrix,
+    l: &Matrix,
+) -> f64 {
+    let mut r = Matrix::new(K, D);
+    for k in 0..K {
+        for j in 0..D {
+            r[(k, j)] = q[(k, j)].exp();
+        }
+    }
+
+    let mut log_likelihood =
+        -(N as f64) * (((D as f64) / 2.0) * (2.0 * PI).ln() + logsumexp(alpha));
+    for i in 0..N {
+        let x_i = x.row(i);
+        let mut beta = vec![0.; K];
+        for k in 0..K {
+            let mu_k = mu.row(k);
+            let r_k = r.row(k);
+            let l_k = l.row(k);
+            let mut normsq = 0.;
+            let mut sum = 0.;
+            for j in 0..D {
+                let e = quadratic_form_element(mu_k, r_k, l_k, x_i, j);
+                normsq += e * e;
+                sum += q[(k, j)];
+            }
+            beta[k] = alpha[k] - 0.5 * normsq + sum;
+        }
+        log_likelihood += logsumexp(&beta);
+    }
+
+    let mut frobenius = 0.;
+    let mut sum_q = 0.;
+    for k in 0..K {
+        for j in 0..D {
+            let r_kj = r[(k, j)];
+            frobenius += r_kj * r_kj;
+            let q_kj = q[(k, j)];
+            sum_q += q_kj * q_kj;
+        }
+        let s = l.cols();
+        for j in 0..s {
+            let l_kj = l[(k, j)];
+            frobenius += l_kj * l_kj;
+        }
+    }
+    let n = D + m + 1;
+    let log_prior = (K as f64)
+        * (((n * D) as f64) * (gamma / (2f64).sqrt()).ln() - multigammaln(D, (n as f64) / 2.))
+        - (gamma * gamma / 2.) * frobenius
+        + (m as f64) * sum_q;
+
+    log_likelihood + log_prior
+}

--- a/crates/gradbench-rust/src/matrix.rs
+++ b/crates/gradbench-rust/src/matrix.rs
@@ -1,0 +1,67 @@
+use std::ops::{Index, IndexMut};
+
+use serde::{de::Error as _, Deserialize, Deserializer};
+
+#[derive(Debug)]
+pub struct Matrix {
+    cols: usize,
+    data: Vec<f64>,
+}
+
+impl Matrix {
+    pub fn new(rows: usize, cols: usize) -> Self {
+        let data = vec![0.; rows * cols];
+        Self { cols, data }
+    }
+
+    pub fn cols(&self) -> usize {
+        self.cols
+    }
+
+    pub fn row(&self, row: usize) -> &[f64] {
+        let i = row * self.cols;
+        &self.data[i..i + self.cols]
+    }
+}
+
+impl Index<(usize, usize)> for Matrix {
+    type Output = f64;
+
+    fn index(&self, (row, col): (usize, usize)) -> &Self::Output {
+        debug_assert!(col < self.cols);
+        &self.data[row * self.cols + col]
+    }
+}
+
+impl IndexMut<(usize, usize)> for Matrix {
+    fn index_mut(&mut self, (row, col): (usize, usize)) -> &mut Self::Output {
+        debug_assert!(col < self.cols);
+        &mut self.data[row * self.cols + col]
+    }
+}
+
+impl<'de> Deserialize<'de> for Matrix {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let rows_vec = Vec::<Vec<f64>>::deserialize(deserializer)?;
+        if rows_vec.is_empty() {
+            return Ok(Matrix {
+                cols: 0,
+                data: Vec::new(),
+            });
+        }
+        let cols = rows_vec[0].len();
+        if cols == 0 {
+            return Err(D::Error::custom("matrix has zero columns"));
+        }
+        if rows_vec.iter().any(|r| r.len() != cols) {
+            return Err(D::Error::custom(
+                "all rows must have the same number of columns",
+            ));
+        }
+        let data: Vec<f64> = rows_vec.into_iter().flatten().collect();
+        Ok(Matrix { cols, data })
+    }
+}

--- a/crates/gradbench-rust/src/matrix.rs
+++ b/crates/gradbench-rust/src/matrix.rs
@@ -5,13 +5,17 @@ use serde::{de::Error as _, Deserialize, Deserializer};
 #[derive(Debug)]
 pub struct Matrix {
     cols: usize,
-    data: Vec<f64>,
+    data: Box<[f64]>,
 }
 
 impl Matrix {
     pub fn new(rows: usize, cols: usize) -> Self {
-        let data = vec![0.; rows * cols];
+        let data = vec![0.; rows * cols].into();
         Self { cols, data }
+    }
+
+    pub fn rows(&self) -> usize {
+        self.data.len() / self.cols()
     }
 
     pub fn cols(&self) -> usize {
@@ -49,7 +53,7 @@ impl<'de> Deserialize<'de> for Matrix {
         if rows_vec.is_empty() {
             return Ok(Matrix {
                 cols: 0,
-                data: Vec::new(),
+                data: Box::new([]),
             });
         }
         let cols = rows_vec[0].len();
@@ -61,7 +65,7 @@ impl<'de> Deserialize<'de> for Matrix {
                 "all rows must have the same number of columns",
             ));
         }
-        let data: Vec<f64> = rows_vec.into_iter().flatten().collect();
+        let data = rows_vec.into_iter().flatten().collect::<Vec<f64>>().into();
         Ok(Matrix { cols, data })
     }
 }


### PR DESCRIPTION
This PR is not to be merged; it is merely an attempt to understand why the Wasm implementation in #629 is 3x slower than the C++ implementation.

```sh
make -C cpp
make -C tools/manual
./gradbench repo run --eval "$ uv run python/gradbench/gradbench/evals/gmm/run.py -d64 -k100 -n1000" --tool "$ cargo run --package gradbench-rust --release"
./gradbench repo run --eval "$ uv run python/gradbench/gradbench/evals/gmm/run.py -d64 -k100 -n1000" --tool "$ python3 python/gradbench/gradbench/cpp.py manual"
```

On my machine, the C++ implementation is about 55 milliseconds per objective evaluation, whereas the Rust implementation is about 78 milliseconds (it was 92 milliseconds before I made it a bit more similar to the C++ implementation in 39b60d443d8e73f94da18e589482b80d17eaf0e5). The Wasm implementation in #629 is about 145 milliseconds.