### PR TITLE
Fix CI lint

### DIFF
--- a/crates/gradbench/src/log.rs
+++ b/crates/gradbench/src/log.rs
@@ -37,13 +37,13 @@ impl InOut<anyhow::Result<()>> for Trim {
                         writeln!(out, "{}", serde_json::to_string(&message)?)?;
                         writeln!(out, "{}", serde_json::to_string(&response)?)?;
                     } else {
-                        write!(out, "{}", line)?;
+                        write!(out, "{line}")?;
                     }
                 }
                 _ => {
-                    write!(out, "{}", line)?;
+                    write!(out, "{line}")?;
                     if let Some(response_line) = try_read_line(input)? {
-                        write!(out, "{}", response_line)?;
+                        write!(out, "{response_line}")?;
                     }
                 }
             }

--- a/crates/gradbench/src/stats.rs
+++ b/crates/gradbench/src/stats.rs
@@ -351,13 +351,11 @@ fn svg(output: &Path, summary: Summary) -> anyhow::Result<()> {
     let total_height = tool_text_length + gap + num_evals * (cell_size + gap);
     writeln!(
         file,
-        r#"<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {} {}">"#,
-        total_width, total_height,
+        r#"<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {total_width} {total_height}">"#
     )?;
     writeln!(
         file,
-        r##"  <rect x="0" y="0" width="{}" height="{}" rx="{}" ry="{}" fill="#222" />"##,
-        total_width, total_height, gap, gap,
+        r##"  <rect x="0" y="0" width="{total_width}" height="{total_height}" rx="{gap}" ry="{gap}" fill="#222" />"##
     )?;
     for (i, row) in summary.table.iter().enumerate() {
         let x = eval_text_length;
@@ -400,8 +398,7 @@ fn svg(output: &Path, summary: Summary) -> anyhow::Result<()> {
                 let y = tool_text_length + gap + i as f64 * (cell_size + gap);
                 writeln!(
                     file,
-                    r#"  <rect x="{}" y="{}" width="{}" height="{}" fill="{}" />"#,
-                    x, y, cell_size, cell_size, color,
+                    r#"  <rect x="{x}" y="{y}" width="{cell_size}" height="{cell_size}" fill="{color}" />"#
                 )?;
             }
         }
@@ -418,7 +415,7 @@ pub fn generate(input: PathBuf, output: PathBuf, metadata: StatsMetadata) -> any
     let mut table = Vec::new();
     let map = evals_to_tools(evals)?;
     for (eval, supported) in &map {
-        println!("{}", eval);
+        println!("{eval}");
         let mut row = Vec::new();
         let mut scorer = scorer(eval);
         for (tool, &outcome) in supported {

--- a/nix/floretta.nix
+++ b/nix/floretta.nix
@@ -11,6 +11,5 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-1FwcQB4h60ZO30+yx+ILVephmXj0Z/eV8S2Bv8qVTI0=";
   };
 
-  useFetchCargoVendor = true;
   cargoHash = "sha256-VcgCgCRsMCgHDmSv2Dx4DnyUokZCq+zNUzDudr8L788=";
 }

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": null,
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d89fc19e405cb2d55ce7cc114356846a0ee5e956",
-        "sha256": "1i3sj7bapriaanmnlrr6p3khr20j1k59il12fkww78ik2xa81vyx",
+        "rev": "20075955deac2583bb12f07151c2df830ef346b4",
+        "sha256": "1s3lxb33cwazlx72pygcbcc76bbgbhdil6q9bhqbzbjxj001zk0w",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/d89fc19e405cb2d55ce7cc114356846a0ee5e956.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/20075955deac2583bb12f07151c2df830ef346b4.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }


### PR DESCRIPTION
The Clippy part of the CI lint job failed after merging #634, presumably because the Rust compiler got upgraded. This PR attempts to fix that by updating the Rust compiler version provided by `shell.nix`, then running `cargo clippy --fix`. I also removed `useFetchCargoVendor = true;` from `nix/floretta.nix` because I got a warning saying that's now enabled by default.

I wonder whether it'd be valuable to prevent this problem from occurring in the future by just using Nix in CI to guarantee stable versions of everything.