### PR TITLE
Use Nix for CI lint job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,22 +40,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Install Bun
-        uses: oven-sh/setup-bun@v2
-      - name: Install uv
-        uses: astral-sh/setup-uv@v6
-      - name: Install clang-format 19
-        run: sudo apt-get install -y clang-format-19
-      - name: Install nixfmt
-        run: |
-          wget -O /usr/local/bin/nixfmt https://github.com/NixOS/nixfmt/releases/download/v0.6.0/nixfmt-x86_64-linux
-          chmod +x /usr/local/bin/nixfmt
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
       - name: Install CLI from artifact
         uses: ./.github/actions/cli
       - name: Install npm dependencies
-        run: bun install
+        run: nix-shell --command bun install
       - name: Lint
-        run: gradbench repo lint
+        run: nix-shell --command gradbench repo lint
 
   site:
     needs: lint

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,9 +45,9 @@ jobs:
       - name: Install CLI from artifact
         uses: ./.github/actions/cli
       - name: Install npm dependencies
-        run: nix-shell --command bun install
+        run: nix-shell --command "bun install"
       - name: Lint
-        run: nix-shell --command gradbench repo lint
+        run: nix-shell --command "gradbench repo lint"
 
   site:
     needs: lint


### PR DESCRIPTION
This is an alternative to #635 for fixing the CI lint job.

One "advantage" is that now `shell.nix` actually gets tested in CI. The main disadvantage is that now the lint job takes longer: it's about ten minutes instead of two. But it seems like we could potentially eliminate this using caching: https://github.com/cachix/cachix-action

Another disadvantage is that the commands in the lint job now have to use `nix-shell --command` which is annoying; I wonder if there's a way to just automatically do that for all shell commands in a CI job.