### PR TITLE
Pin Bun to 1.2 in Docker

### DIFF
--- a/tools/floretta/Dockerfile
+++ b/tools/floretta/Dockerfile
@@ -1,4 +1,4 @@
-FROM oven/bun
+FROM oven/bun:1.2
 WORKDIR /gradbench
 
 # `COPY` the minimal set of files to create `node_modules`.

--- a/tools/tensorflow-js/Dockerfile
+++ b/tools/tensorflow-js/Dockerfile
@@ -1,4 +1,4 @@
-FROM oven/bun
+FROM oven/bun:1.2
 WORKDIR /gradbench
 
 # `COPY` the minimal set of files to create `node_modules`.


### PR DESCRIPTION
The nightlies have been failing [for the past couple weeks](https://github.com/gradbench/gradbench/actions/runs/18422959256) with this error:

```
running eval hello
   with tool tensorflow-js
node:internal/modules/package_json_reader:316
  throw new ERR_MODULE_NOT_FOUND(packageName, fileURLToPath(base), null);
        ^

Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@gradbench/common' imported from /gradbench/js/tensorflow/run.ts
    at Object.getPackageJSONURL (node:internal/modules/package_json_reader:316:9)
    at packageResolve (node:internal/modules/esm/resolve:768:81)
    at moduleResolve (node:internal/modules/esm/resolve:858:18)
    at defaultResolve (node:internal/modules/esm/resolve:990:11)
    at #cachedDefaultResolve (node:internal/modules/esm/loader:757:20)
    at ModuleLoader.resolve (node:internal/modules/esm/loader:734:38)
    at ModuleLoader.getModuleJobForImport (node:internal/modules/esm/loader:317:38)
    at #link (node:internal/modules/esm/module_job:208:49) {
  code: 'ERR_MODULE_NOT_FOUND'
}

Node.js v24.10.0
Broken pipe (os error 32)
 outcome error
expected success
```

This PR fixes the error by downgrading from [Bun 1.3](https://bun.com/blog/bun-v1.3) to Bun 1.2.