### PR TITLE
Add ffast-math and similar options to horde-ad compilation and also perform other tweaks to horde-ad and haskell-ad

### DIFF
--- a/tools/haskell-ad/gradbench.cabal
+++ b/tools/haskell-ad/gradbench.cabal
@@ -27,4 +27,5 @@ executable gradbench
     hs-source-dirs:   src
     default-language: GHC2021
     default-extensions: OverloadedStrings
-    ghc-options:      -rtsopts "-with-rtsopts=-A500m"
+    -- Idle GC makes benchmarks less deterministic, hence disabled.
+    ghc-options:      -rtsopts "-with-rtsopts=-A500m -I0"

--- a/tools/haskell-ad/gradbench.cabal
+++ b/tools/haskell-ad/gradbench.cabal
@@ -28,4 +28,5 @@ executable gradbench
     default-language: GHC2021
     default-extensions: OverloadedStrings
     -- Idle GC makes benchmarks less deterministic, hence disabled.
-    ghc-options:      -rtsopts "-with-rtsopts=-A500m -I0"
+    -- Also make sure to crash after RAM exhausted instead of swapping, etc.
+    ghc-options:      -rtsopts "-with-rtsopts=-A500m -I0 -M30G"

--- a/tools/haskell-ad/src/GradBench/Det.hs
+++ b/tools/haskell-ad/src/GradBench/Det.hs
@@ -19,8 +19,8 @@ import Data.List qualified as L
 import Numeric.AD.Double qualified as D
 
 data Input = Input
-  { _inputA :: [Double],
-    _inputEll :: Int
+  { _inputA :: ![Double],
+    _inputEll :: !Int
   }
 
 type PrimalOutput = Double

--- a/tools/haskell-ad/src/GradBench/GMM.hs
+++ b/tools/haskell-ad/src/GradBench/GMM.hs
@@ -17,9 +17,9 @@ vMinus :: (Floating a) => V.Vector a -> V.Vector a -> V.Vector a
 vMinus = V.zipWith (-)
 
 data Matrix a = Matrix
-  { matRows :: Int,
-    matCols :: Int,
-    matVals :: V.Vector a
+  { matRows :: !Int,
+    matCols :: !Int,
+    matVals :: !V.Vector a
   }
 
 matRow :: Matrix a -> Int -> V.Vector a

--- a/tools/haskell-ad/src/GradBench/KMeans.hs
+++ b/tools/haskell-ad/src/GradBench/KMeans.hs
@@ -23,9 +23,9 @@ getPoints d v =
   map (getPoint d v) [0 .. (V.length v `div` d - 1)]
 
 data Input = Input
-  { inputD         :: Int,
-    inputPoints    :: V.Vector Double,
-    inputCentroids :: V.Vector Double
+  { inputD         :: !Int,
+    inputPoints    :: !(V.Vector Double),
+    inputCentroids :: !(V.Vector Double)
   }
 
 instance JSON.FromJSON Input where
@@ -41,7 +41,7 @@ instance JSON.FromJSON Input where
 
 type CostOutput = Double
 
-data DirOutput = DirOutput Int (V.Vector Double)
+data DirOutput = DirOutput !Int !(V.Vector Double)
 
 instance JSON.ToJSON DirOutput where
   toJSON (DirOutput d v) = JSON.toJSON $ getPoints d v

--- a/tools/haskell-ad/src/GradBench/LLSq.hs
+++ b/tools/haskell-ad/src/GradBench/LLSq.hs
@@ -13,8 +13,8 @@ import Data.Vector qualified as V
 import Numeric.AD.Double qualified as D
 
 data Input = Input
-  { _inputX :: V.Vector Double,
-    _inputN :: Int
+  { _inputX :: !(V.Vector Double),
+    _inputN :: !Int
   }
 
 type PrimalOutput = Double

--- a/tools/haskell-ad/src/GradBench/ODE.hs
+++ b/tools/haskell-ad/src/GradBench/ODE.hs
@@ -13,8 +13,8 @@ import Data.Vector qualified as V
 import Numeric.AD.Double qualified as D
 
 data Input = Input
-  { _inputX :: V.Vector Double,
-    _inputS :: Int
+  { _inputX :: !(V.Vector Double),
+    _inputS :: !Int
   }
 
 type PrimalOutput = V.Vector Double

--- a/tools/haskell-ad/src/Main.hs
+++ b/tools/haskell-ad/src/Main.hs
@@ -22,6 +22,7 @@ import System.Clock (Clock (Monotonic), getTime, toNanoSecs)
 import System.Exit
 import System.IO
 import System.IO.Error (isEOFError)
+import System.Mem (performBlockingMajorGC)
 
 import Prelude hiding (mod)
 
@@ -65,6 +66,18 @@ wrap f input =
     JSON.Error e ->
       pure $ Left $ "Invalid input:\n" <> T.pack e
     JSON.Success !v -> do  -- the bang excludes samples processing time from score
+      -- We force GC here to prevent
+      -- 1. counting GC time incurred by data sample batch receiving and processing
+      --    as part of the actual benchmark time
+      -- 2. randomly sometimes counting the time of a GC incurred by the benchmark
+      --    for the previous data batch as part of the benchmark time for
+      --    the current data batch
+      -- The resulting measurement is similar to when a tool is restarted before
+      -- each data sample batch (disregarding the negligible RTS startup time)
+      -- in that after each batch finishes, the heap is cleaned-up up for free.
+      -- The time of each GC performed during benchmarking of a batch is correctly
+      -- attributed to that batch, so this is as expected.
+      performBlockingMajorGC
       (output, timings) <- doRuns [] 1 0 (getRuns input) f v
       pure $ Right (JSON.toJSON output, timings)
 

--- a/tools/haskell-ad/src/Main.hs
+++ b/tools/haskell-ad/src/Main.hs
@@ -64,7 +64,7 @@ wrap f input =
   case JSON.fromJSON input of
     JSON.Error e ->
       pure $ Left $ "Invalid input:\n" <> T.pack e
-    JSON.Success v -> do
+    JSON.Success !v -> do  -- the bang excludes samples processing time from score
       (output, timings) <- doRuns [] 1 0 (getRuns input) f v
       pure $ Right (JSON.toJSON output, timings)
 

--- a/tools/horde-ad/cabal.project
+++ b/tools/horde-ad/cabal.project
@@ -1,7 +1,17 @@
 packages: gradbench.cabal
 
+-- Of all the options below, nonportable-simd helps across the board,
+-- while ffast-math helps immensely in lse and kmeans, but much less elsewhere.
+-- The other options sound like plausible speedups looking at their documentation
+-- and apparently don't lower performance at least.
 package ox-arrays
   flags: +nonportable-simd
+  ghc-options: -optc-ffast-math -optc-fassociative-math -optc-fno-signed-zeros -optc-fno-trapping-math -optc-freciprocal-math
+
+ghc-options: -fexcess-precision
+
+package *
+  ghc-options: -fexcess-precision
 
 index-state:
   hackage.haskell.org 2026-04-15T12:29:52Z

--- a/tools/horde-ad/gradbench.cabal
+++ b/tools/horde-ad/gradbench.cabal
@@ -80,7 +80,7 @@ executable gradbench
 
   -- * Misc.
   ghc-options:        -rtsopts -threaded
-  -- Make GC more predictable in benchmarks.
-  ghc-options:        "-with-rtsopts=-A0.75g"
+  -- Make GC more predictable in benchmarks (especially through disabling idle GC).
+  ghc-options:        "-with-rtsopts=-A0.75g -I0"
   -- Too big a performance hit:
   -- ghc-options:        "-with-rtsopts=-H1.5g -A0.75g -I0"

--- a/tools/horde-ad/gradbench.cabal
+++ b/tools/horde-ad/gradbench.cabal
@@ -81,6 +81,7 @@ executable gradbench
   -- * Misc.
   ghc-options:        -rtsopts -threaded
   -- Make GC more predictable in benchmarks (especially through disabling idle GC).
-  ghc-options:        "-with-rtsopts=-A0.75g -I0"
+  -- Also make sure to crash after RAM exhausted instead of swapping, etc.
+  ghc-options:        "-with-rtsopts=-A0.75g -I0 -M30G"
   -- Too big a performance hit:
   -- ghc-options:        "-with-rtsopts=-H1.5g -A0.75g -I0"

--- a/tools/horde-ad/src/Main.hs
+++ b/tools/horde-ad/src/Main.hs
@@ -24,6 +24,7 @@ import System.Clock (Clock (Monotonic), getTime, toNanoSecs)
 import System.Exit
 import System.IO
 import System.IO.Error (isEOFError)
+import System.Mem (performBlockingMajorGC)
 
 import Prelude hiding (mod)
 
@@ -67,6 +68,18 @@ wrap f input =
     JSON.Error e ->
       pure $ Left $ "Invalid input:\n" <> T.pack e
     JSON.Success !v -> do  -- the bang excludes samples processing time from score
+      -- We force GC here to prevent
+      -- 1. counting GC time incurred by data sample batch receiving and processing
+      --    as part of the actual benchmark time
+      -- 2. randomly sometimes counting the time of a GC incurred by the benchmark
+      --    for the previous data batch as part of the benchmark time for
+      --    the current data batch
+      -- The resulting measurement is similar to when a tool is restarted before
+      -- each data sample batch (disregarding the negligible RTS startup time)
+      -- in that after each batch finishes, the heap is cleaned-up up for free.
+      -- The time of each GC performed during benchmarking of a batch is correctly
+      -- attributed to that batch, so this is as expected.
+      performBlockingMajorGC
       (output, timings) <- doRuns [] 1 0 (getRuns input) f v
       pure $ Right (JSON.toJSON output, timings)
 

--- a/tools/horde-ad/src/Main.hs
+++ b/tools/horde-ad/src/Main.hs
@@ -66,7 +66,7 @@ wrap f input =
   case JSON.fromJSON input of
     JSON.Error e ->
       pure $ Left $ "Invalid input:\n" <> T.pack e
-    JSON.Success v -> do
+    JSON.Success !v -> do  -- the bang excludes samples processing time from score
       (output, timings) <- doRuns [] 1 0 (getRuns input) f v
       pure $ Right (JSON.toJSON output, timings)
 


### PR DESCRIPTION
The `-ffast-math` option speeds up lse with horde-ad by double-digit percent.  The other options don't seem to do much, but in principle, they may. Is using such options legal? If so and CI shows it doesn't break correctness for any of the benchmarks, I'd set it for horde-ad. Would it make sense to write in some documentation that  `-ffast-math` is fair game or is it too obvious for the AD community (as opposed to the rest of the world)?

I will also perform various other hacks and tweaks to horde-ad and haskell-ad in this PR.