### PR TITLE
Lower the heap limit for the Haskell tools to prevent hanging containers and also tweak Haskell and OCaml things for CI

### DIFF
--- a/tools/haskell-ad/gradbench.cabal
+++ b/tools/haskell-ad/gradbench.cabal
@@ -29,4 +29,4 @@ executable gradbench
     default-extensions: OverloadedStrings
     -- Idle GC makes benchmarks less deterministic, hence disabled.
     -- Also make sure to crash after RAM exhausted instead of swapping, etc.
-    ghc-options:      -rtsopts "-with-rtsopts=-A500m -I0 -M30G"
+    ghc-options:      -rtsopts "-with-rtsopts=-A500m -I0 -M14G"

--- a/tools/haskell-ad/src/Main.hs
+++ b/tools/haskell-ad/src/Main.hs
@@ -161,10 +161,18 @@ main = forever loop
             BS.putStrLn . BS.toStrict . JSON.encode . JSON.object $
               ("id", toJSON (msgId msg)) : vs
             hFlush stdout
+          onRunError :: SomeException -> IO a
+          onRunError e = do
+            reply
+              [ ("success", toJSON False),
+                ("error", toJSON $ "tool exception:\n" <> take 1000 (show e))
+              ]
+            throw e
       case msg of
         MsgStart _ _ -> reply [("tool", "haskell-ad")]
         MsgDefine _ mod -> reply [("success", toJSON $ knownModule mod)]
         MsgEvaluate _ mod fun input ->
+          (`catch` onRunError) $
           case L.lookup (mod, fun) modules of
             Nothing ->
               reply

--- a/tools/horde-ad/cabal.project
+++ b/tools/horde-ad/cabal.project
@@ -5,7 +5,9 @@ packages: gradbench.cabal
 -- The other options sound like plausible speedups looking at their documentation
 -- and apparently don't lower performance at least.
 package ox-arrays
-  flags: +nonportable-simd
+  -- CI seems to sometimes compile on a different CPU than the binary is run on
+  -- so this optimisation has to be disabled
+  -- flags: +nonportable-simd
   ghc-options: -optc-ffast-math -optc-fassociative-math -optc-fno-signed-zeros -optc-fno-trapping-math -optc-freciprocal-math
 
 ghc-options: -fexcess-precision

--- a/tools/horde-ad/gradbench.cabal
+++ b/tools/horde-ad/gradbench.cabal
@@ -82,6 +82,4 @@ executable gradbench
   ghc-options:        -rtsopts -threaded
   -- Make GC more predictable in benchmarks (especially through disabling idle GC).
   -- Also make sure to crash after RAM exhausted instead of swapping, etc.
-  ghc-options:        "-with-rtsopts=-A0.75g -I0 -M30G"
-  -- Too big a performance hit:
-  -- ghc-options:        "-with-rtsopts=-H1.5g -A0.75g -I0"
+  ghc-options:        "-with-rtsopts=-A2G -I0 -M14G"

--- a/tools/horde-ad/src/Main.hs
+++ b/tools/horde-ad/src/Main.hs
@@ -167,10 +167,18 @@ main = forever loop
             BS.putStrLn . BS.toStrict . JSON.encode . JSON.object $
               ("id", toJSON (msgId msg)) : vs
             hFlush stdout
+          onRunError :: SomeException -> IO a
+          onRunError e = do
+            reply
+              [ ("success", toJSON False),
+                ("error", toJSON $ "tool exception:\n" <> take 1000 (show e))
+              ]
+            throw e
       case msg of
         MsgStart _ _ -> reply [("tool", "horde-ad")]
         MsgDefine _ mod -> reply [("success", toJSON $ knownModule mod)]
         MsgEvaluate _ mod fun input ->
+          (`catch` onRunError) $
           case L.lookup (mod, fun) modules of
             Nothing ->
               reply

--- a/tools/ocaml/run/main.ml
+++ b/tools/ocaml/run/main.ml
@@ -112,10 +112,16 @@ let () =
           | Msg_Evaluate (_id, mname, fname, input) ->
              match look (mname, fname) modules with
                f ->
-               let (output, timings) = f input in
-               let timings' = `List (List.map timing_of timings)
-               in reply [("success", `Bool true);
-                         ("output",output);
-                         ("timings", timings')])
+               try
+                 let (output, timings) = f input in
+                 let timings' = `List (List.map timing_of timings)
+                 in reply [("success", `Bool true);
+                           ("output", output);
+                           ("timings", timings')]
+               with e ->
+                 let msg = Printexc.to_string e in
+                 reply [("success", `Bool false);
+                        ("error", `String (Printf.sprintf "tool exception:\n%s" msg))];
+                 raise e)
     | None -> exit 0
   done

--- a/tools/ocaml/run/main.ml
+++ b/tools/ocaml/run/main.ml
@@ -110,6 +110,7 @@ let () =
           | Msg_Define (_id, mname) ->
              reply [("success", `Bool (List.exists (fun l -> fst (fst l) = mname) modules))]
           | Msg_Evaluate (_id, mname, fname, input) ->
+            try
              match look (mname, fname) modules with
                f ->
                try
@@ -122,6 +123,9 @@ let () =
                  let msg = Printexc.to_string e in
                  reply [("success", `Bool false);
                         ("error", `String (Printf.sprintf "tool exception:\n%s" msg))];
-                 raise e)
+                 raise e
+            with _ ->
+              reply [("success", `Bool false);
+                     ("error", `String (Printf.sprintf "unknown function: %s" fname))])
     | None -> exit 0
   done


### PR DESCRIPTION
Apparently, the 30G limit sometimes causes a gentle quick OOM but sometimes it hangs hard: https://github.com/gradbench/gradbench/actions/runs/25091053615/job/73544366949, so I'm bisecting until I find a limit where all tests pass but the haskell-ad/kmeans  OOM is quick.