### PR TITLE
Give horde-ad a weaker but safer variant of -march=native

### DIFF
--- a/tools/horde-ad/cabal.project
+++ b/tools/horde-ad/cabal.project
@@ -2,12 +2,20 @@ packages: gradbench.cabal
 
 -- Of all the options below, nonportable-simd helps across the board,
 -- while ffast-math helps immensely in lse and kmeans, but much less elsewhere.
--- The other options sound like plausible speedups looking at their documentation
--- and apparently don't lower performance at least.
+-- The other options sound like plausible speedups looking at their
+-- documentation and apparently don't lower performance at least.
+
+-- CI seems to sometimes compile on a different CPU than the binary is run on
+-- so this optimisation that contains "-march=native" has to be disabled:
+-- package ox-arrays
+--   flags: +nonportable-simd
+-- but this weaker optimization seems safe enough for github CI:
+if arch(x86_64)
+  package ox-arrays
+    ghc-options: -optc-march=x86-64-v3
+
 package ox-arrays
-  -- CI seems to sometimes compile on a different CPU than the binary is run on
-  -- so this optimisation has to be disabled
-  -- flags: +nonportable-simd
+  -- These seem safe always:
   ghc-options: -optc-ffast-math -optc-fassociative-math -optc-fno-signed-zeros -optc-fno-trapping-math -optc-freciprocal-math
 
 ghc-options: -fexcess-precision


### PR DESCRIPTION
Unfortunately, the removal of `-march=native` was not the cause of the 2-times slowdown of a few horde-ad evals, because the slow and the fast result seem to appear at random, even for different evals within the same CI run and regardless of the compiler flags I set. 

I still think it must be caused by different CPU kinds used by CI for different evals and it may or may not be additionally affected by what CPU the binary was built and optimized for originally (because for Haskell, we build the binary once and use it for all evals; it's hard to do otherwise without repeating the whole long compilation for each eval).

Regardless, the tweak in this PR seems safe and it potentially could improve the performance, even though it probably doesn't or at least there's too much noise to tell.

Please kindly review.