### PR TITLE
Fix Nix shell

### DIFF
--- a/crates/gradbench/src/util.rs
+++ b/crates/gradbench/src/util.rs
@@ -71,7 +71,7 @@ pub fn nanostring(nanoseconds: u128) -> String {
     }
 }
 
-pub fn lock<T>(mutex: &Mutex<T>) -> MutexGuard<T> {
+pub fn lock<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
     match mutex.lock() {
         Ok(guard) => guard,
         Err(poison_error) => poison_error.into_inner(),
@@ -118,7 +118,7 @@ impl CtrlC {
         Ok(obj)
     }
 
-    pub fn handle(&mut self, f: Box<dyn FnOnce() + Send>) -> CtrlCHandler {
+    pub fn handle(&mut self, f: Box<dyn FnOnce() + Send>) -> CtrlCHandler<'_> {
         let key = self.next_key;
         lock(&self.handlers).insert(key, f);
         self.next_key += 1;

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": null,
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d89fc19e405cb2d55ce7cc114356846a0ee5e956",
-        "sha256": "1i3sj7bapriaanmnlrr6p3khr20j1k59il12fkww78ik2xa81vyx",
+        "rev": "241313f4e8e508cb9b13278c2b0fa25b9ca27163",
+        "sha256": "09d83cyl9dlfkkbspkgkk7bfydj3mvw6r1x98kvc2v8wl2xd8ldy",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/d89fc19e405cb2d55ce7cc114356846a0ee5e956.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/241313f4e8e508cb9b13278c2b0fa25b9ca27163.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/nix/sources.nix
+++ b/nix/sources.nix
@@ -6,9 +6,12 @@ let
   # The fetchers. fetch_<type> fetches specs of type <type>.
   #
 
-  fetch_file = pkgs: name: spec:
-    let name' = sanitizeName name + "-src";
-    in if spec.builtin or true then
+  fetch_file =
+    pkgs: name: spec:
+    let
+      name' = sanitizeName name + "-src";
+    in
+    if spec.builtin or true then
       builtins_fetchurl {
         inherit (spec) url sha256;
         name = name';
@@ -19,9 +22,12 @@ let
         name = name';
       };
 
-  fetch_tarball = pkgs: name: spec:
-    let name' = sanitizeName name + "-src";
-    in if spec.builtin or true then
+  fetch_tarball =
+    pkgs: name: spec:
+    let
+      name' = sanitizeName name + "-src";
+    in
+    if spec.builtin or true then
       builtins_fetchTarball {
         name = name';
         inherit (spec) url sha256;
@@ -32,43 +38,58 @@ let
         inherit (spec) url sha256;
       };
 
-  fetch_git = name: spec:
+  fetch_git =
+    name: spec:
     let
-      ref = spec.ref or (if spec ? branch then
-        "refs/heads/${spec.branch}"
-      else if spec ? tag then
-        "refs/tags/${spec.tag}"
-      else
-        abort
-        "In git source '${name}': Please specify `ref`, `tag` or `branch`!");
+      ref =
+        spec.ref or (
+          if spec ? branch then
+            "refs/heads/${spec.branch}"
+          else if spec ? tag then
+            "refs/tags/${spec.tag}"
+          else
+            abort "In git source '${name}': Please specify `ref`, `tag` or `branch`!"
+        );
       submodules = spec.submodules or false;
-      submoduleArg = let
-        nixSupportsSubmodules =
-          builtins.compareVersions builtins.nixVersion "2.4" >= 0;
-        emptyArgWithWarning = if submodules then
-          builtins.trace (''The niv input "${name}" uses submodules ''
-            + "but your nix's (${builtins.nixVersion}) builtins.fetchGit "
-            + "does not support them") { }
+      submoduleArg =
+        let
+          nixSupportsSubmodules = builtins.compareVersions builtins.nixVersion "2.4" >= 0;
+          emptyArgWithWarning =
+            if submodules then
+              builtins.trace (
+                ''The niv input "${name}" uses submodules ''
+                + "but your nix's (${builtins.nixVersion}) builtins.fetchGit "
+                + "does not support them"
+              ) { }
+            else
+              { };
+        in
+        if nixSupportsSubmodules then
+          {
+            inherit submodules;
+          }
         else
-          { };
-      in if nixSupportsSubmodules then {
-        inherit submodules;
-      } else
-        emptyArgWithWarning;
-    in builtins.fetchGit ({
-      url = spec.repo;
-      inherit (spec) rev;
-      inherit ref;
-    } // submoduleArg);
+          emptyArgWithWarning;
+    in
+    builtins.fetchGit (
+      {
+        url = spec.repo;
+        inherit (spec) rev;
+        inherit ref;
+      }
+      // submoduleArg
+    );
 
   fetch_local = spec: spec.path;
 
-  fetch_builtin-tarball = name:
+  fetch_builtin-tarball =
+    name:
     throw ''
       [${name}] The niv type "builtin-tarball" is deprecated. You should instead use `builtin = true`.
               $ niv modify ${name} -a type=tarball -a builtin=true'';
 
-  fetch_builtin-url = name:
+  fetch_builtin-url =
+    name:
     throw ''
       [${name}] The niv type "builtin-url" will soon be deprecated. You should instead use `builtin = true`.
               $ niv modify ${name} -a type=file -a builtin=true'';
@@ -78,21 +99,23 @@ let
   #
 
   # https://github.com/NixOS/nixpkgs/pull/83241/files#diff-c6f540a4f3bfa4b0e8b6bafd4cd54e8bR695
-  sanitizeName = name:
-    (concatMapStrings (s: if builtins.isList s then "-" else s)
-      (builtins.split "[^[:alnum:]+._?=-]+"
-        ((x: builtins.elemAt (builtins.match "\\.*(.*)" x) 0) name)));
+  sanitizeName =
+    name:
+    (concatMapStrings (s: if builtins.isList s then "-" else s) (
+      builtins.split "[^[:alnum:]+._?=-]+" ((x: builtins.elemAt (builtins.match "\\.*(.*)" x) 0) name)
+    ));
 
   # The set of packages used when specs are fetched using non-builtins.
-  mkPkgs = sources: system:
+  mkPkgs =
+    sources: system:
     let
-      sourcesNixpkgs = import
-        (builtins_fetchTarball { inherit (sources.nixpkgs) url sha256; }) {
-          inherit system;
-        };
+      sourcesNixpkgs = import (builtins_fetchTarball { inherit (sources.nixpkgs) url sha256; }) {
+        inherit system;
+      };
       hasNixpkgsPath = builtins.any (x: x.prefix == "nixpkgs") builtins.nixPath;
       hasThisAsNixpkgsPath = <nixpkgs> == ./.;
-    in if builtins.hasAttr "nixpkgs" sources then
+    in
+    if builtins.hasAttr "nixpkgs" sources then
       sourcesNixpkgs
     else if hasNixpkgsPath && !hasThisAsNixpkgsPath then
       import <nixpkgs> { }
@@ -103,7 +126,8 @@ let
       '';
 
   # The actual fetching function.
-  fetch = pkgs: name: spec:
+  fetch =
+    pkgs: name: spec:
 
     if !builtins.hasAttr "type" spec then
       abort "ERROR: niv spec ${name} does not have a 'type' attribute"
@@ -120,17 +144,17 @@ let
     else if spec.type == "builtin-url" then
       fetch_builtin-url name
     else
-      abort
-      "ERROR: niv spec ${name} has unknown type ${builtins.toJSON spec.type}";
+      abort "ERROR: niv spec ${name} has unknown type ${builtins.toJSON spec.type}";
 
   # If the environment variable NIV_OVERRIDE_${name} is set, then use
   # the path directly as opposed to the fetched source.
-  replace = name: drv:
+  replace =
+    name: drv:
     let
-      saneName = stringAsChars
-        (c: if (builtins.match "[a-zA-Z0-9]" c) == null then "_" else c) name;
+      saneName = stringAsChars (c: if (builtins.match "[a-zA-Z0-9]" c) == null then "_" else c) name;
       ersatz = builtins.getEnv "NIV_OVERRIDE_${saneName}";
-    in if ersatz == "" then
+    in
+    if ersatz == "" then
       drv
     else
     # this turns the string into an actual Nix path (for both absolute and
@@ -143,23 +167,24 @@ let
   # Ports of functions for older nix versions
 
   # a Nix version of mapAttrs if the built-in doesn't exist
-  mapAttrs = builtins.mapAttrs or (f: set:
-    with builtins;
-    listToAttrs (map (attr: {
-      name = attr;
-      value = f attr set.${attr};
-    }) (attrNames set)));
+  mapAttrs =
+    builtins.mapAttrs or (
+      f: set:
+      with builtins;
+      listToAttrs (
+        map (attr: {
+          name = attr;
+          value = f attr set.${attr};
+        }) (attrNames set)
+      )
+    );
 
   # https://github.com/NixOS/nixpkgs/blob/0258808f5744ca980b9a1f24fe0b1e6f0fecee9c/lib/lists.nix#L295
-  range = first: last:
-    if first > last then
-      [ ]
-    else
-      builtins.genList (n: first + n) (last - first + 1);
+  range =
+    first: last: if first > last then [ ] else builtins.genList (n: first + n) (last - first + 1);
 
   # https://github.com/NixOS/nixpkgs/blob/0258808f5744ca980b9a1f24fe0b1e6f0fecee9c/lib/strings.nix#L257
-  stringToCharacters = s:
-    map (p: builtins.substring p 1 s) (range 0 (builtins.stringLength s - 1));
+  stringToCharacters = s: map (p: builtins.substring p 1 s) (range 0 (builtins.stringLength s - 1));
 
   # https://github.com/NixOS/nixpkgs/blob/0258808f5744ca980b9a1f24fe0b1e6f0fecee9c/lib/strings.nix#L269
   stringAsChars = f: s: concatStrings (map f (stringToCharacters s));
@@ -170,41 +195,55 @@ let
   optionalAttrs = cond: as: if cond then as else { };
 
   # fetchTarball version that is compatible between all the versions of Nix
-  builtins_fetchTarball = { url, name ? null, sha256 }@attrs:
-    let inherit (builtins) lessThan nixVersion fetchTarball;
-    in if lessThan nixVersion "1.12" then
-      fetchTarball
-      ({ inherit url; } // (optionalAttrs (name != null) { inherit name; }))
+  builtins_fetchTarball =
+    {
+      url,
+      name ? null,
+      sha256,
+    }@attrs:
+    let
+      inherit (builtins) lessThan nixVersion fetchTarball;
+    in
+    if lessThan nixVersion "1.12" then
+      fetchTarball ({ inherit url; } // (optionalAttrs (name != null) { inherit name; }))
     else
       fetchTarball attrs;
 
   # fetchurl version that is compatible between all the versions of Nix
-  builtins_fetchurl = { url, name ? null, sha256 }@attrs:
-    let inherit (builtins) lessThan nixVersion fetchurl;
-    in if lessThan nixVersion "1.12" then
-      fetchurl
-      ({ inherit url; } // (optionalAttrs (name != null) { inherit name; }))
+  builtins_fetchurl =
+    {
+      url,
+      name ? null,
+      sha256,
+    }@attrs:
+    let
+      inherit (builtins) lessThan nixVersion fetchurl;
+    in
+    if lessThan nixVersion "1.12" then
+      fetchurl ({ inherit url; } // (optionalAttrs (name != null) { inherit name; }))
     else
       fetchurl attrs;
 
   # Create the final "sources" from the config
-  mkSources = config:
-    mapAttrs (name: spec:
+  mkSources =
+    config:
+    mapAttrs (
+      name: spec:
       if builtins.hasAttr "outPath" spec then
-        abort
-        "The values in sources.json should not have an 'outPath' attribute"
+        abort "The values in sources.json should not have an 'outPath' attribute"
       else
-        spec // { outPath = replace name (fetch config.pkgs name spec); })
-    config.sources;
+        spec // { outPath = replace name (fetch config.pkgs name spec); }
+    ) config.sources;
 
   # The "config" used by the fetchers
-  mkConfig = { sourcesFile ?
-      if builtins.pathExists ./sources.json then ./sources.json else null
-    , sources ? if sourcesFile == null then
-      { }
-    else
-      builtins.fromJSON (builtins.readFile sourcesFile)
-    , system ? builtins.currentSystem, pkgs ? mkPkgs sources system }: rec {
+  mkConfig =
+    {
+      sourcesFile ? if builtins.pathExists ./sources.json then ./sources.json else null,
+      sources ? if sourcesFile == null then { } else builtins.fromJSON (builtins.readFile sourcesFile),
+      system ? builtins.currentSystem,
+      pkgs ? mkPkgs sources system,
+    }:
+    rec {
       # The sources, i.e. the attribute set of spec name to spec
       inherit sources;
 
@@ -212,6 +251,8 @@ let
       inherit pkgs;
     };
 
-in mkSources (mkConfig { }) // {
+in
+mkSources (mkConfig { })
+// {
   __functor = _: settings: mkSources (mkConfig settings);
 }

--- a/shell.nix
+++ b/shell.nix
@@ -19,7 +19,8 @@ let
   GRADBENCH_PATH = builtins.getEnv "PWD";
 
   isX86 = builtins.currentSystem == "x86_64-linux";
-in pkgs.stdenv.mkDerivation rec {
+in
+pkgs.stdenv.mkDerivation rec {
   name = "gradbench";
   buildInputs = [
     # Required
@@ -45,7 +46,7 @@ in pkgs.stdenv.mkDerivation rec {
     pkgs.llvmPackages_19.clang
     pkgs.llvmPackages_19.lld
     pkgs.llvmPackages_19.openmp
-    pkgs.nixfmt-classic
+    pkgs.nixfmt
     pkgs.nodejs_24
     pkgs.openblas
     pkgs.pkg-config
@@ -70,15 +71,15 @@ in pkgs.stdenv.mkDerivation rec {
     pkgs.opam
     pkgs.ocamlPackages.dune_3
     pkgs.ocamlPackages.ocaml
-  ] ++
+  ]
+  ++
     # Nixpkgs marks Julia as broken on Apple Silicon
     (if isX86 then [ pkgs.julia_110 ] else [ ]);
 
   # The following are environment variables used by various tools.
   RUST_SRC_PATH = pkgs.rustPlatform.rustLibSrc;
   ENZYME_LIB = "${pkgs.enzyme}/lib";
-  LD_LIBRARY_PATH =
-    "${pkgs.lib.makeLibraryPath buildInputs}:${pkgs.stdenv.cc.cc.lib}/lib";
+  LD_LIBRARY_PATH = "${pkgs.lib.makeLibraryPath buildInputs}:${pkgs.stdenv.cc.cc.lib}/lib";
 
   # The Nix C/C++ compilers disable -march=native on purity reasons, but we
   # don't use them to compile Nix derivations.


### PR DESCRIPTION
It got broken because we build Floretta from source and crates.io started giving 403s in some cases, so we bump to a newer Nixpkgs that knows how to ask crates.io more politely.

This also updates Nixfmt and Clippy, so I did a `./gradbench repo lint --fix` to fix those.